### PR TITLE
fix: correct uvx version pin syntax for astro-airflow-mcp

### DIFF
--- a/claude-code-plugin/.mcp.json
+++ b/claude-code-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "airflow": {
       "command": "uvx",
-      "args": ["astro-airflow-mcp==0.2.2", "--transport", "stdio", "--airflow-project-dir", "${PWD}"]
+      "args": ["astro-airflow-mcp@0.2.2", "--transport", "stdio", "--airflow-project-dir", "${PWD}"]
     },
     "jupyter": {
       "command": "uvx",


### PR DESCRIPTION
## Summary
- Fixes version pin syntax in `.mcp.json` from `==` (pip syntax) to `@` (uvx syntax)
- Changes `astro-airflow-mcp==0.2.2` to `astro-airflow-mcp@0.2.2`

## Test plan
- [x] Verify MCP server starts correctly with `claude --plugin-dir ./claude-code-plugin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)