### PR TITLE
fix: MCP tool output displays with proper formatting in Claude Code

### DIFF
--- a/packages/data-jupyter/src/server.py
+++ b/packages/data-jupyter/src/server.py
@@ -343,7 +343,7 @@ async def kernel_status() -> dict[str, Any]:
 # =============================================================================
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 async def run_sql(
     query: str,
     limit: int = 100,
@@ -413,7 +413,7 @@ async def run_sql(
     return result.output if result.output else "(no output)"
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 async def list_schemas(
     database: str | None = None,
     session_id: str | None = None,
@@ -470,7 +470,7 @@ async def list_schemas(
     return result.output if result.output else "(no output)"
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 async def list_tables(
     database: str,
     schema: str,
@@ -522,7 +522,7 @@ async def list_tables(
     return result.output if result.output else "(no output)"
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 async def get_tables_info(
     database: str,
     schema: str,


### PR DESCRIPTION
Changes MCP tool output from JSON with escaped newlines to clean markdown tables that render properly in Claude Code.

Root cause: FastMCP auto-generates structuredContent for tools returning primitive types (-> str), wrapping results as {"result": "..."}. Claude Code v2.0.21+ prioritizes structuredContent over TextContent, displaying escaped newlines (\n) literally instead of as actual line breaks.

Fix: Add structured_output=False to SQL tools (run_sql, list_schemas, list_tables, get_tables_info) to force FastMCP to return only TextContent, which Claude Code renders properly.


  Before/After Comparison
```
  **BEFORE (JSON with escaped newlines)**:
  {"result":"## Schemas in HQ\n\n| Schema | Tables |\n|--------|-------:|\n| COMMONS | 12 |\n| FORENSICS | 39 |\n..."}
```

<img width="1708" height="108" alt="image" src="https://github.com/user-attachments/assets/d3f4591d-afe9-400e-961c-0ece5b46a7f6" />


  **AFTER **:
```
❯ list_schemas
  ⎿  ## Schemas

     | Database | Schema | Tables |
     |----------|--------|-------:|
     | HQ | COMMONS | 12 |
     | HQ | FORENSICS | 39 |
     | HQ | IN_ASTRO_DB_PROD | 83 |
     | HQ | IN_PLM | 1 |
     | HQ | MAPS | 6 |
     | HQ | MART_CUST | 11 |
     | HQ | MART_DEVREL | 3 |
     | HQ | MART_FINANCE | 12 |
     | HQ | MART_GTM | 4 |
     | HQ | METRICS_ASTRO | 14 |
     | HQ | METRICS_CUST | 1 |
     | HQ | METRICS_ECOSYSTEM | 4 |
     | HQ | METRICS_EDU | 1 |
     | HQ | METRICS_FINANCE | 17 |
     | HQ | METRICS_GSD | 1 |
     | HQ | MODEL_ASTRO | 62 |
     | HQ | MODEL_CONTRACTS | 5 |
     | HQ | MODEL_CRM | 21 |
     | HQ | MODEL_ECOSYSTEM | 6 |
     | HQ | MODEL_EDU | 4 |
     | HQ | MODEL_FINANCE | 45 |
     | HQ | MODEL_GSD | 3 |
     | HQ | MODEL_NEBULA | 0 |
     | HQ | MODEL_OBSERVE | 10 |
     | HQ | MODEL_SNOWFLAKE | 15 |
     | HQ | MODEL_SUPPORT | 7 |
     | HQ | MODEL_WEB | 5 |
     | HQ | MODEL_WEBINAR | 3 |
     | HQ | REPORTING | 19 |
     | PRODUCT | SHARED | 0 |

     **Total**: 30 schemas across 2 databases
```

<img width="605" height="676" alt="image" src="https://github.com/user-attachments/assets/76cbca60-25be-432b-8822-ca4e4d9c71d6" />


