### PR TITLE
feat: Add progressive pattern learning for query strategies

### DIFF
--- a/packages/data-warehouse/src/cache.py
+++ b/packages/data-warehouse/src/cache.py
@@ -426,9 +426,224 @@ class TemplateCache:
         }
 
 
+@dataclass
+class QueryPattern:
+    """A learned query pattern/strategy for a type of question.
+
+    Unlike QueryTemplate (which stores SQL with placeholders), QueryPattern
+    captures procedural knowledge: strategies, gotchas, and multi-step approaches.
+    """
+
+    pattern_name: str  # e.g., "operator_usage"
+    question_types: list[str]  # e.g., ["who uses X", "which customers use X"]
+    strategy: list[str]  # Step-by-step approach that worked
+    tables_used: list[str]  # Tables involved
+    gotchas: list[str]  # What to avoid / what failed
+    example_query: str | None = None  # Working SQL example
+    created_at: str = field(default_factory=lambda: datetime.now().isoformat())
+    ttl_days: int = 90  # Auto-expire after N days
+    success_count: int = 1
+    failure_count: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "pattern_name": self.pattern_name,
+            "question_types": self.question_types,
+            "strategy": self.strategy,
+            "tables_used": self.tables_used,
+            "gotchas": self.gotchas,
+            "example_query": self.example_query,
+            "created_at": self.created_at,
+            "ttl_days": self.ttl_days,
+            "success_count": self.success_count,
+            "failure_count": self.failure_count,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "QueryPattern":
+        return cls(
+            pattern_name=data["pattern_name"],
+            question_types=data.get("question_types", []),
+            strategy=data.get("strategy", []),
+            tables_used=data.get("tables_used", []),
+            gotchas=data.get("gotchas", []),
+            example_query=data.get("example_query"),
+            created_at=data.get("created_at", datetime.now().isoformat()),
+            ttl_days=data.get("ttl_days", 90),
+            success_count=data.get("success_count", 1),
+            failure_count=data.get("failure_count", 0),
+        )
+
+    def is_stale(self) -> bool:
+        """Check if pattern is older than its TTL."""
+        created = datetime.fromisoformat(self.created_at)
+        return datetime.now() - created > timedelta(days=self.ttl_days)
+
+    def should_be_purged(self) -> bool:
+        """Check if pattern should be auto-deleted.
+
+        Purge if: stale AND (low usage OR more failures than successes)
+        """
+        if not self.is_stale():
+            return False
+        return self.success_count < 3 or self.failure_count > self.success_count
+
+
+class PatternCache:
+    """Manages learned query patterns (procedural knowledge).
+
+    Patterns capture strategies and gotchas for question types, not SQL templates.
+    """
+
+    def __init__(self, cache_dir: Path | None = None):
+        self.cache_dir = cache_dir or get_cache_dir()
+        self.patterns_file = self.cache_dir / "patterns.json"
+        self._patterns: dict[str, QueryPattern] | None = None
+
+    @property
+    def patterns(self) -> dict[str, QueryPattern]:
+        """Lazy-load patterns cache."""
+        if self._patterns is None:
+            raw = _load_json(self.patterns_file)
+            self._patterns = {k: QueryPattern.from_dict(v) for k, v in raw.items()}
+        return self._patterns
+
+    def save(self) -> None:
+        """Persist cache to disk."""
+        if self._patterns is not None:
+            patterns_dict = {k: v.to_dict() for k, v in self._patterns.items()}
+            _save_json(self.patterns_file, patterns_dict)
+
+    def get_pattern(self, pattern_name: str) -> QueryPattern | None:
+        """Get a pattern by name."""
+        return self.patterns.get(pattern_name.lower().strip())
+
+    def lookup_by_question(self, question: str) -> list[QueryPattern]:
+        """Find patterns that match a question.
+
+        Uses keyword matching against question_types.
+        Returns all matching patterns, sorted by success_count.
+        """
+        question_lower = question.lower()
+        matches = []
+
+        for pattern in self.patterns.values():
+            for question_type in pattern.question_types:
+                # Simple keyword matching - check if question type words appear in question
+                keywords = question_type.lower().replace("x", "").split()
+                if all(kw in question_lower for kw in keywords if len(kw) > 2):
+                    matches.append(pattern)
+                    break
+
+        # Sort by success_count (most successful first)
+        return sorted(matches, key=lambda p: p.success_count, reverse=True)
+
+    def store_pattern(
+        self,
+        pattern_name: str,
+        question_types: list[str],
+        strategy: list[str],
+        tables_used: list[str],
+        gotchas: list[str],
+        example_query: str | None = None,
+        ttl_days: int = 90,
+    ) -> QueryPattern:
+        """Store a new query pattern."""
+        pattern = QueryPattern(
+            pattern_name=pattern_name,
+            question_types=question_types,
+            strategy=strategy,
+            tables_used=tables_used,
+            gotchas=gotchas,
+            example_query=example_query,
+            ttl_days=ttl_days,
+        )
+        self.patterns[pattern_name.lower().strip()] = pattern
+        self.save()
+        logger.info(f"Stored query pattern: {pattern_name}")
+        return pattern
+
+    def record_success(self, pattern_name: str) -> None:
+        """Record a successful use of a pattern."""
+        pattern = self.patterns.get(pattern_name.lower().strip())
+        if pattern:
+            pattern.success_count += 1
+            self.save()
+            logger.info(f"Pattern '{pattern_name}' success count: {pattern.success_count}")
+
+    def record_failure(self, pattern_name: str) -> None:
+        """Record a failed use of a pattern."""
+        pattern = self.patterns.get(pattern_name.lower().strip())
+        if pattern:
+            pattern.failure_count += 1
+            self.save()
+            logger.warning(f"Pattern '{pattern_name}' failure count: {pattern.failure_count}")
+
+    def delete_pattern(self, pattern_name: str) -> bool:
+        """Delete a pattern. Returns True if it existed."""
+        key = pattern_name.lower().strip()
+        if key in self.patterns:
+            del self.patterns[key]
+            self.save()
+            logger.info(f"Deleted pattern: {pattern_name}")
+            return True
+        return False
+
+    def purge_stale(self) -> list[str]:
+        """Remove patterns that should be purged. Returns list of purged names."""
+        purged = []
+        for name, pattern in list(self.patterns.items()):
+            if pattern.should_be_purged():
+                del self.patterns[name]
+                purged.append(name)
+                logger.info(f"Auto-purged stale pattern: {name}")
+
+        if purged:
+            self.save()
+        return purged
+
+    def clear_all(self) -> None:
+        """Clear all patterns."""
+        self._patterns = {}
+        self.save()
+        logger.info("Cleared all query patterns")
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get pattern statistics."""
+        stale_count = sum(1 for p in self.patterns.values() if p.is_stale())
+        return {
+            "patterns_count": len(self.patterns),
+            "stale_count": stale_count,
+            "patterns": [
+                {
+                    "name": p.pattern_name,
+                    "question_types": p.question_types,
+                    "success_count": p.success_count,
+                    "failure_count": p.failure_count,
+                    "is_stale": p.is_stale(),
+                }
+                for p in self.patterns.values()
+            ],
+        }
+
+    def list_patterns(self) -> list[dict]:
+        """List all patterns with summary info."""
+        return [
+            {
+                "name": p.pattern_name,
+                "question_types": p.question_types,
+                "tables_used": p.tables_used,
+                "success_count": p.success_count,
+                "created_at": p.created_at,
+            }
+            for p in self.patterns.values()
+        ]
+
+
 # Global cache instances (lazy-loaded)
 _schema_cache: SchemaCache | None = None
 _template_cache: TemplateCache | None = None
+_pattern_cache: PatternCache | None = None
 
 
 def get_schema_cache() -> SchemaCache:
@@ -449,6 +664,14 @@ def get_template_cache() -> TemplateCache:
     if _template_cache is None:
         _template_cache = TemplateCache()
     return _template_cache
+
+
+def get_pattern_cache() -> PatternCache:
+    """Get the global pattern cache instance."""
+    global _pattern_cache
+    if _pattern_cache is None:
+        _pattern_cache = PatternCache()
+    return _pattern_cache
 
 
 def load_concepts_from_warehouse_md(path: Path | None = None) -> int:


### PR DESCRIPTION
## Summary

- Adds `PatternCache` class and `QueryPattern` dataclass to store procedural knowledge (strategies, gotchas, tables to use)
- Adds 5 new MCP tools for pattern management: `lookup_pattern`, `learn_pattern`, `record_pattern_outcome`, `list_patterns`, `delete_pattern`
- Tool description for `lookup_pattern` starts with "CALL THIS FIRST" to encourage proper usage

## How It Works

1. **After a successful complex query**: User confirms saving the pattern with strategy, tables used, and gotchas
2. **On future similar questions**: `lookup_pattern` finds the saved strategy, allowing Claude to skip discovery and avoid known pitfalls
3. **Pattern lifecycle**: 90-day TTL, success/failure tracking, auto-purge of unhelpful patterns

## Example Pattern (saved for "who uses X operator" questions)

```json
{
  "pattern_name": "operator_usage",
  "question_types": ["who uses operator X", "which customers use X"],
  "strategy": [
    "Use TASK_RUNS table (not DEPLOYMENT_OPERATOR_LOG)",
    "Always use ILIKE '%keyword%' - operators have variants",
    "Add date filter (last 90 days) - table has 6B+ rows"
  ],
  "tables_used": ["HQ.MODEL_ASTRO.TASK_RUNS", "HQ.MODEL_ASTRO.ORGANIZATIONS"],
  "gotchas": ["GROUP BY without date filter will timeout"]
}
```

## Test plan

- Reinstall MCP server: `uv tool install --force packages/data-warehouse`
- Reinstall plugin: `claude plugin uninstall data@astronomer && claude plugin install data@astronomer`
- Test pattern lookup: Ask "who uses S3Operator" and verify `lookup_pattern` is called first

🤖 Generated with [Claude Code](https://claude.com/claude-code)