### PR TITLE
docs: Add `auth_type`, `private_key_passphrase` to Snowflake config

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ my_warehouse:
   type: snowflake
   account: ${SNOWFLAKE_ACCOUNT}
   user: ${SNOWFLAKE_USER}
+  auth_type: private_key
   private_key_path: ~/.ssh/snowflake_key.p8
+  private_key_passphrase: ${SNOWFLAKE_PRIVATE_KEY_PASSPHRASE}
   warehouse: COMPUTE_WH
   role: ANALYST
   databases:
@@ -127,8 +129,9 @@ my_warehouse:
 Store credentials in `~/.astro/ai/config/.env`:
 
 ```bash
-SNOWFLAKE_ACCOUNT=xyz12345.us-east-1
+SNOWFLAKE_ACCOUNT=xyz12345
 SNOWFLAKE_USER=myuser
+SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=your-passphrase-here  # Only required if using an encrypted private key
 ```
 
 **Supported warehouses:** Snowflake, BigQuery, Databricks, Redshift.


### PR DESCRIPTION
Document the required parameters for Snowflake private key authentication:
- auth_type: private_key
- private_key_passphrase (only required for encrypted private keys)

Also fixed SNOWFLAKE_ACCOUNT example to not include a region suffix.

> [!note]
> We should at some point remove functionality for password auth for Snowflake. This auth type will not be supported and [will be deprecated in August of this year](https://docs.snowflake.com/en/user-guide/security-mfa-rollout#deprecation-timeline). The Data team does not currently support new users on a password auth mechanism either; only private key auth.