### PR TITLE
Switch astro-dwh-mcp to dynamic versioning from git tags

### DIFF
--- a/.github/workflows/astro-dwh-mcp-publish.yml
+++ b/.github/workflows/astro-dwh-mcp-publish.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 0  # Full history for hatch-vcs to read version from tags
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/astro-airflow-mcp/pyproject.toml
+++ b/astro-airflow-mcp/pyproject.toml
@@ -31,7 +31,7 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 source = "vcs"
 fallback-version = "0.0.0+dev"
-raw-options = { root = "..", tag_regex = "^astro-airflow-mcp-(?P<version>.*)$" }
+raw-options = { root = "..", tag_regex = "^astro-airflow-mcp-(?P<version>.*)$", git_describe_command = ["git", "describe", "--tags", "--match", "astro-airflow-mcp-*"] }
 
 [tool.hatchling.build.targets.wheel]
 packages = ["src/astro_airflow_mcp"]

--- a/astro-dwh-mcp/pyproject.toml
+++ b/astro-dwh-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "astro-dwh-mcp"
-version = "0.1.0"
+dynamic = ["version"]
 description = "MCP server for data warehouse operations (SQL, schema exploration)"
 requires-python = ">=3.11"
 dependencies = [
@@ -23,8 +23,13 @@ dev = [
 astro-dwh-mcp = "src.server:main"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
+fallback-version = "0.0.0+dev"
+raw-options = { root = "..", tag_regex = "^astro-dwh-mcp-(?P<version>.*)$", git_describe_command = ["git", "describe", "--tags", "--match", "astro-dwh-mcp-*"] }
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]


### PR DESCRIPTION
## Summary

- Switch `astro-dwh-mcp` from static version (`version = "0.1.0"`) to dynamic versioning via `hatch-vcs`
- Add `git_describe_command` with `--match` filter to both packages (required in monorepo to find correct package tags)
- Add `fetch-depth: 0` to dwh publish workflow for full git history

## Why

Both packages now use consistent versioning:
- Version is determined automatically from git tags at build time
- Tag format: `astro-dwh-mcp-X.Y.Z` or `astro-airflow-mcp-X.Y.Z`
- No need to manually keep `pyproject.toml` version in sync with tags

## Release workflow (same for both packages)

1. Create git tag: `git tag astro-dwh-mcp-0.2.0`
2. Push tag: `git push origin astro-dwh-mcp-0.2.0`
3. Create GitHub release from that tag
4. Workflow publishes to PyPI with correct version

## Test plan

- [x] `uv build` in `astro-dwh-mcp/` produces versioned wheel (e.g., `0.1.1.dev4+g016d482`)
- [x] `uv build` in `astro-airflow-mcp/` still works
- [ ] Create test release to verify publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)