### PR TITLE
Fix skill hook paths to resolve to correct directories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,15 +72,13 @@ Everything is defined inline in `.claude-plugin/marketplace.json` following the 
 
 Use `${CLAUDE_PLUGIN_ROOT}` to reference files within the plugin (required because plugins are copied to a cache location when installed).
 
-**Important:** `${CLAUDE_PLUGIN_ROOT}` resolves differently depending on context:
-- In `marketplace.json`: resolves to the **plugin root** (e.g., use `${CLAUDE_PLUGIN_ROOT}/skills/foo/hooks/bar.sh`)
-- In `SKILL.md` frontmatter: resolves to the **skill's directory** (e.g., use `${CLAUDE_PLUGIN_ROOT}/scripts/bar.py` for a script in the same skill)
+**Important:** Hooks in `SKILL.md` frontmatter can use **relative paths** from the skill's directory (e.g., `./scripts/bar.py`). Use `${CLAUDE_PLUGIN_ROOT}` in `marketplace.json` to reference the plugin root.
 
 ## Key Files
 
 - `.claude-plugin/marketplace.json` - Marketplace catalog with inline plugin definition (hooks, mcpServers)
 - `skills/*/SKILL.md` - Individual skills (auto-discovered)
-- `skills/*/hooks/*.sh` - Hook scripts (co-located with skills, referenced via `${CLAUDE_PLUGIN_ROOT}/hooks/...` from SKILL.md or `${CLAUDE_PLUGIN_ROOT}/skills/<name>/hooks/...` from marketplace.json)
+- `skills/*/hooks/*.sh` - Hook scripts (co-located with skills, referenced via relative paths from SKILL.md or `${CLAUDE_PLUGIN_ROOT}/skills/<name>/hooks/...` from marketplace.json)
 
 ## Config Location
 

--- a/skills/analyzing-data/SKILL.md
+++ b/skills/analyzing-data/SKILL.md
@@ -6,12 +6,12 @@ hooks:
     - matcher: "Bash"
       hooks:
         - type: command
-          command: "uv run ${CLAUDE_PLUGIN_ROOT}/scripts/cli.py ensure"
+          command: "uv run ./scripts/cli.py ensure"
           once: true
   Stop:
     - hooks:
         - type: command
-          command: "uv run ${CLAUDE_PLUGIN_ROOT}/scripts/cli.py stop"
+          command: "uv run ./scripts/cli.py stop"
 ---
 
 # Data Analysis

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -6,19 +6,19 @@ hooks:
     - matcher: "Bash"
       hooks:
         - type: command
-          command: "uv run ${CLAUDE_PLUGIN_ROOT}/../analyzing-data/scripts/cli.py ensure"
+          command: "uv run ../analyzing-data/scripts/cli.py ensure"
           once: true
   Stop:
     - hooks:
         - type: command
-          command: "uv run ${CLAUDE_PLUGIN_ROOT}/../analyzing-data/scripts/cli.py stop"
+          command: "uv run ../analyzing-data/scripts/cli.py stop"
 ---
 
 # Initialize Warehouse Schema
 
 Generate a comprehensive, user-editable schema reference file for the data warehouse.
 
-**Scripts:** `$CLAUDE_PLUGIN_ROOT/../analyzing-data/scripts/`
+**Scripts:** `../analyzing-data/scripts/`
 
 ## What This Does
 


### PR DESCRIPTION
## Summary

Fixed skill hook paths that were causing "No such file or directory" errors. The previous paths incorrectly included the full skill directory name twice (e.g., `${CLAUDE_PLUGIN_ROOT}/skills/analyzing-data/skills/analyzing-data/scripts/cli.py`).

## Root Cause

Hooks in SKILL.md frontmatter run with the skill's directory as the working directory, so simple relative paths work correctly without needing `${CLAUDE_PLUGIN_ROOT}`.

## Changes

- **analyzing-data**: Use `./scripts/cli.py` (relative to skill directory)
- **init**: Use `../analyzing-data/scripts/cli.py` (relative path to sibling skill)
- **AGENTS.md / CLAUDE.md**: Document that SKILL.md hooks can use relative paths, while `marketplace.json` should use `${CLAUDE_PLUGIN_ROOT}`

## Test plan

- [ ] Install skills via `npx skills add astronomer/agents` (project scope)
- [ ] Install skills via `npx skills add astronomer/agents` (global scope)
- [ ] Verify `analyzing-data` and `init` skill hooks execute without path errors
- [ ] Test both symlink and copy installation methods

🤖 Generated with [Claude Code](https://claude.ai/code)