### PR TITLE
Add Redshift support via SQLAlchemy connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=your-passphrase-here  # Only required if using 
 | `snowflake` | Built-in | Snowflake Data Cloud |
 | `postgres` | Built-in | PostgreSQL |
 | `bigquery` | Built-in | Google BigQuery |
-| `sqlalchemy` | Any SQLAlchemy driver | MySQL, DuckDB, SQLite, and [others](https://docs.sqlalchemy.org/en/20/dialects/) |
+| `sqlalchemy` | Any SQLAlchemy driver | Redshift, MySQL, DuckDB, SQLite, and [others](https://docs.sqlalchemy.org/en/20/dialects/) |
 
 <details>
 <summary>Example configurations</summary>
@@ -276,6 +276,12 @@ my_duckdb:
   type: sqlalchemy
   url: duckdb:///path/to/analytics.duckdb
   databases: [main]
+
+# Redshift (via SQLAlchemy)
+my_redshift:
+  type: sqlalchemy
+  url: redshift+redshift_connector://${REDSHIFT_USER}:${REDSHIFT_PASSWORD}@${REDSHIFT_HOST}:5439/${REDSHIFT_DATABASE}
+  databases: [my_database]
 ```
 
 </details>

--- a/skills/analyzing-data/scripts/lib/connectors/sqlalchemy.py
+++ b/skills/analyzing-data/scripts/lib/connectors/sqlalchemy.py
@@ -59,6 +59,8 @@ class SQLAlchemyConnector(DatabaseConnector):
             packages.append("pyodbc")
         elif "oracle" in url_lower:
             packages.append("oracledb")
+        elif "redshift" in url_lower:
+            packages.append("redshift_connector")
         return packages
 
     def get_env_vars_for_kernel(self) -> dict[str, str]:
@@ -87,6 +89,8 @@ class SQLAlchemyConnector(DatabaseConnector):
             db_type = "SQL Server"
         elif "oracle" in url_lower:
             db_type = "Oracle"
+        elif "redshift" in url_lower:
+            db_type = "Redshift"
         else:
             db_type = "Database"
 

--- a/skills/analyzing-data/scripts/tests/test_connectors.py
+++ b/skills/analyzing-data/scripts/tests/test_connectors.py
@@ -538,6 +538,7 @@ class TestSQLAlchemyPackageDetection:
             ("postgres://u:p@h/d", "psycopg[binary]"),
             ("postgresql://u:p@h/d", "psycopg[binary]"),
             ("duckdb:///data.db", "duckdb"),
+            ("redshift+redshift_connector://u:p@h:5439/d", "redshift_connector"),
         ],
         ids=[
             "mssql",
@@ -547,6 +548,7 @@ class TestSQLAlchemyPackageDetection:
             "postgres",
             "postgresql",
             "duckdb",
+            "redshift",
         ],
     )
     def test_driver_package_detected(self, url, expected_driver):


### PR DESCRIPTION
## Summary

- Add automatic `redshift_connector` package detection when URL contains "redshift"
- Show "Redshift" in connection status messages for better UX
- Document Redshift configuration in README with example

## Usage

Configure in `~/.astro/agents/warehouse.yml`:

```yaml
my_redshift:
  type: sqlalchemy
  url: redshift+redshift_connector://${REDSHIFT_USER}:${REDSHIFT_PASSWORD}@${REDSHIFT_HOST}:5439/${REDSHIFT_DATABASE}
  databases: [my_database]
```

The `redshift_connector` package is auto-installed when the kernel starts.

## Design Notes

Redshift is supported via the generic `sqlalchemy` type rather than a dedicated connector because:
- The SQLAlchemy approach is simple and works well
- Redshift uses standard SQL, so no special query handling is needed
- Users can still use IAM auth by constructing the appropriate SQLAlchemy URL

🤖 Generated with [Claude Code](https://claude.ai/code)