### PR TITLE
Better support for airflow skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,12 +29,6 @@
             ]
           }
         ]
-      },
-      "mcpServers": {
-        "airflow": {
-          "command": "uvx",
-          "args": ["astro-airflow-mcp@0.2.3", "--transport", "stdio", "--airflow-project-dir", "${PWD}"]
-        }
       }
     }
   ]

--- a/skills/airflow/SKILL.md
+++ b/skills/airflow/SKILL.md
@@ -7,6 +7,16 @@ description: Manages Apache Airflow operations including listing, testing, runni
 
 Use `af` commands to query, manage, and troubleshoot Airflow workflows.
 
+## Running the CLI
+
+Run all `af` commands using uvx (no installation required):
+
+```bash
+uvx --from astro-airflow-mcp af <command>
+```
+
+Throughout this document, `af` is shorthand for `uvx --from astro-airflow-mcp af`.
+
 ## Instance Configuration
 
 Manage multiple Airflow instances with persistent configuration:


### PR DESCRIPTION
Small update to instruct agents to use `uvx` for `af`, and dropping map from Claude plugin.