### PR TITLE
Pin af CLI to version 0.3.0

### DIFF
--- a/skills/airflow/SKILL.md
+++ b/skills/airflow/SKILL.md
@@ -12,10 +12,11 @@ Use `af` commands to query, manage, and troubleshoot Airflow workflows.
 Run all `af` commands using uvx (no installation required):
 
 ```bash
-uvx --from astro-airflow-mcp af <command>
+# UPDATE VERSION HERE WHEN RELEASING
+uvx --from astro-airflow-mcp==0.3.0 af <command>
 ```
 
-Throughout this document, `af` is shorthand for `uvx --from astro-airflow-mcp af`.
+Throughout this document, `af` is shorthand for the command above.
 
 ## Instance Configuration
 


### PR DESCRIPTION
## Summary
- Pin `astro-airflow-mcp` to version 0.3.0 in the airflow skill to avoid uvx serving stale cached versions
- Consolidate version to a single location with a comment for easy updates on future releases

## Test plan
- [x] Verify skill loads correctly with `/data:airflow`
- [x] Test `af` commands use the pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)