### PR TITLE
fix: Use @latest suffix for uvx af CLI to prevent stale version issues

### DIFF
--- a/astro-airflow-mcp/README.md
+++ b/astro-airflow-mcp/README.md
@@ -249,7 +249,7 @@ This package also includes `af`, a command-line tool for interacting with Airflo
 uv tool install astro-airflow-mcp
 
 # Or use uvx to run without installing
-uvx --from astro-airflow-mcp af --help
+uvx --from astro-airflow-mcp@latest af --help
 ```
 
 ### Quick Reference

--- a/skills/airflow/SKILL.md
+++ b/skills/airflow/SKILL.md
@@ -12,10 +12,10 @@ Use `af` commands to query, manage, and troubleshoot Airflow workflows.
 Run all `af` commands using uvx (no installation required):
 
 ```bash
-uvx --from astro-airflow-mcp af <command>
+uvx --from astro-airflow-mcp@latest af <command>
 ```
 
-Throughout this document, `af` is shorthand for `uvx --from astro-airflow-mcp af`.
+Throughout this document, `af` is shorthand for `uvx --from astro-airflow-mcp@latest af`.
 
 ## Instance Configuration
 


### PR DESCRIPTION
## Summary

- Use `@latest` suffix when running `af` CLI via uvx to ensure users always get the latest version
- Fixes issue where users with older versions of `astro-airflow-mcp` installed via `uv tool install` would see "executable not found" errors

## Problem

When users have previously installed an older version of `astro-airflow-mcp` via `uv tool install`, uvx reuses that installed version by default—even if a newer version is available on PyPI. This causes the `af` CLI to be "not found" if the installed version predates when the CLI was added (v0.3.0).

### Root Cause

uv maintains **two separate storage locations** for tools:

| Type | Location | Behavior |
|------|----------|----------|
| Ephemeral (uvx cache) | `~/.cache/uv/` | Cleared with `uv cache clean` |
| Installed (`uv tool install`) | `~/.local/share/uv/tools/` | Persists until explicitly uninstalled |

Once a tool is installed with `uv tool install`, `uvx` uses that installed version by default. Running `uv cache clean` has no effect because it only clears the ephemeral cache, not the tools directory.

## Solution

The `@latest` suffix forces uvx to fetch the latest version from PyPI, bypassing any locally installed tool versions.

## Testing

Verified that with v0.2.3 installed:

| Command | Result |
|---------|--------|
| `uvx --from astro-airflow-mcp af` | **Fails** - uses installed 0.2.3 |
| `uvx --from astro-airflow-mcp@latest af` | **Works** - fetches 0.3.0 |
| `uvx --upgrade --from astro-airflow-mcp af` | **Fails** - warns "Tools cannot be upgraded via uvx" |
| `uvx --isolated --from astro-airflow-mcp af` | **Works** - ignores installed version |

## References

- [uv Tools Documentation](https://docs.astral.sh/uv/concepts/tools/)
- [Issue #5797: uvx doesn't upgrade when existing tool is installed](https://github.com/astral-sh/uv/issues/5797)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)