### PR TITLE
fix: Always load config file to fill in missing CLI arguments

### DIFF
--- a/astro-airflow-mcp/src/astro_airflow_mcp/cli/context.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/cli/context.py
@@ -65,12 +65,9 @@ class CLIContext:
         3. Environment variables
         4. Defaults
         """
-        # Try to load from config file if instance specified or no CLI args
-        config_values: ResolvedConfig | None = None
-        if instance_name is not None or (
-            airflow_url is None and username is None and password is None and auth_token is None
-        ):
-            config_values = self._load_from_config(instance_name)
+        # Always try to load config to fill in missing values
+        # Config is used as fallback for any CLI args not provided
+        config_values = self._load_from_config(instance_name)
 
         # Determine final values with priority: CLI > config > env > default
         if airflow_url:


### PR DESCRIPTION
## Summary

Fixes a bug where the `af` CLI would ignore the config file when some (but not all) CLI arguments were provided.

## Problem

When passing `--token` without `--airflow-url`, the CLI ignored the config file entirely and defaulted to `localhost:8080`:

```bash
# ~/.af/config.yaml has astronomer instance configured
af --token "$TOKEN" health
# ERROR: Connects to localhost:8080 instead of config URL!
```

### Root Cause

The config loading condition was too restrictive:

```python
# OLD (buggy): Only load config if ALL CLI args are None
if instance_name is not None or (
    airflow_url is None and username is None and password is None and auth_token is None
):
    config_values = self._load_from_config(instance_name)
```

This meant that providing **any** CLI argument (like `--token`) would skip config loading entirely, even if other values (like URL) were needed from config.

## Solution

Always load config file as a fallback source for missing values:

```python
# NEW: Always load config to fill in missing values
config_values = self._load_from_config(instance_name)
```

The priority order is unchanged:
1. CLI arguments (if provided)
2. Config file values (for missing CLI args)  
3. Environment variables (for still-missing values)
4. Defaults

## Test Plan

- [x] Verified `af --token "$TOKEN" health` now uses URL from config
- [x] Verified `af --airflow-url "https://..." health` now uses token from config
- [x] Verified explicit CLI args still override config values
- [x] Verified behavior unchanged when no config file exists

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)