### PR TITLE
fix: Warn when config loading fails instead of silent fallback

### DIFF
--- a/astro-airflow-mcp/src/astro_airflow_mcp/cli/context.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/cli/context.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from typing import TYPE_CHECKING
 
 from astro_airflow_mcp.adapter_manager import AdapterManager
@@ -46,7 +47,13 @@ class CLIContext:
 
             manager = ConfigManager()
             return manager.resolve_instance(instance_name)
-        except (ConfigError, FileNotFoundError):
+        except FileNotFoundError:
+            # No config file - this is normal for first-time users
+            return None
+        except ConfigError as e:
+            # Config exists but has errors - warn the user
+            print(f"Warning: Failed to load config: {e}", file=sys.stderr)
+            print("Falling back to default settings (localhost:8080)", file=sys.stderr)
             return None
 
     def configure(

--- a/skills/airflow/SKILL.md
+++ b/skills/airflow/SKILL.md
@@ -22,6 +22,10 @@ Throughout this document, `af` is shorthand for `uvx --from astro-airflow-mcp@la
 Manage multiple Airflow instances with persistent configuration:
 
 ```bash
+# Add a new instance
+af instance add prod --url https://airflow.example.com --token "$API_TOKEN"
+af instance add staging --url https://staging.example.com --username admin --password admin
+
 # List and switch instances
 af instance list      # Shows all instances in a table
 af instance use prod  # Switch to prod instance
@@ -32,17 +36,28 @@ af instance delete old-instance
 af --instance staging dags list
 ```
 
-Config file: `~/.af/config.yaml` (override with `--config` or `AIRFLOW_CLI_CONFIG`)
+Config file: `~/.af/config.yaml` (override with `--config` or `AF_CONFIG` env var)
 
-Or use environment variables:
+Tokens in config can reference environment variables using `${VAR}` syntax:
+```yaml
+instances:
+- name: prod
+  url: https://airflow.example.com
+  auth:
+    token: ${AIRFLOW_API_TOKEN}
+```
+
+Or use environment variables directly (no config file needed):
 
 ```bash
 export AIRFLOW_API_URL=http://localhost:8080
+export AIRFLOW_AUTH_TOKEN=your-token-here
+# Or username/password:
 export AIRFLOW_USERNAME=admin
 export AIRFLOW_PASSWORD=admin
 ```
 
-Or CLI flags: `af --airflow-url http://localhost:8080 --username admin --password admin <command>`
+Or CLI flags: `af --airflow-url http://localhost:8080 --token "$TOKEN" <command>`
 
 ## Quick Reference
 


### PR DESCRIPTION
## Summary

- Print warning to stderr when config loading fails (e.g., missing env var)
- Update skill docs with missing setup commands and correct env var names

## Problem

When config file exists but has errors (like `${AIRFLOW_API_TOKEN}` when the env var isn't set), the CLI silently falls back to localhost:8080. Users see a connection error to localhost without understanding why their config wasn't used.

## Solution

Print a warning to stderr before falling back:
```
Warning: Failed to load config: Environment variable 'AIRFLOW_API_TOKEN' is not set
Falling back to default settings (localhost:8080)
```

## Skill Doc Fixes

- Added `af instance add` command (was missing entirely!)
- Fixed env var name: `AIRFLOW_CLI_CONFIG` → `AF_CONFIG`
- Documented `${VAR}` syntax for tokens in config
- Documented `--token` CLI flag
- Added example YAML config with env var interpolation

## Test Plan

- [x] Verified warning appears when env var is missing
- [x] Verified no warning when config file doesn't exist (first-time user)
- [x] Verified normal operation when config loads successfully

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)