### PR TITLE
Improve authoring-dags skill based on early user feedback

### DIFF
--- a/skills/annotating-task-lineage/SKILL.md
+++ b/skills/annotating-task-lineage/SKILL.md
@@ -325,6 +325,7 @@ transform = SqlOperator(
 - Update inlets/outlets when SQL queries change
 - Include all tables referenced in JOINs as inlets
 - Include all tables written to (including temp tables if relevant)
+- **Outlet-only and inlet-only annotations are valid.** One-sided annotations are encouraged for lineage visibility even without a corresponding inlet or outlet in another DAG.
 
 ---
 

--- a/skills/authoring-dags/SKILL.md
+++ b/skills/authoring-dags/SKILL.md
@@ -230,18 +230,9 @@ If issues found:
 
 ## Best Practices & Anti-Patterns
 
-For detailed code examples and patterns, see **[reference/best-practices.md](reference/best-practices.md)**.
+For code patterns and anti-patterns, see **[reference/best-practices.md](reference/best-practices.md)**.
 
-Key topics covered:
-- TaskFlow API usage
-- Credentials management (connections, variables)
-- Provider operators
-- Idempotency patterns
-- Data intervals
-- Task groups
-- Setup/Teardown patterns
-- Data quality checks
-- Anti-patterns to avoid
+**Read this reference when writing new DAGs or reviewing existing ones.** It covers what patterns are correct (including Airflow 3-specific behavior) and what to avoid.
 
 ---
 


### PR DESCRIPTION
## Summary

Addresses feedback from an early adopter using the authoring-dags skill with Junie/PyCharm. The skill was producing some false positives and missing common patterns.

Changes to `skills/authoring-dags/reference/best-practices.md`:

- **Airflow 3 context injection**: Document that `data_interval_end: pendulum.DateTime` (no `= None`) is valid in AF3 Task SDK — the skill was flagging this as a missing argument
- **Claim-check pattern**: Name and describe the pattern explicitly so the skill recognizes it when already applied in existing code, not just when recommending it
- **XCom size context**: Add guidance to consider actual data volume from code context before flagging XCom concerns (e.g. a 12-row DataFrame is fine)
- **Sensor modes**: Expand from just `deferrable=True` to cover `reschedule` vs `poke` mode — this was actually a strength the user called out, now it's documented
- **Error handling/callbacks**: New section covering failure callbacks and trigger rules (gap vs the patterns users expect)
- **Outlets without inlets**: Clarify these are valid for lineage — the skill was adding outlets in one DAG then complaining about outlet-only assets in another

Also adds a matching note to `skills/annotating-task-lineage/SKILL.md` so the lineage skills stay consistent on the outlets-without-inlets point.

## Test plan

- [ ] Verify skill loads correctly with `claude --plugin-dir .`
- [ ] Run doctoc to confirm TOC is up to date (already ran)
- [ ] Review best-practices.md reads coherently end-to-end