### PR TITLE
fix: remove doctoc TOCs from skill reference files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,5 +25,5 @@ repos:
         args:
           - "--maxlevel"
           - "3"
-        # Exclude files with YAML frontmatter (doctoc doesn't handle it well)
-        exclude: "(SKILL\\.md|/commands/.*\\.md)$"
+        # Exclude skills directory and command files
+        exclude: "(skills/|/commands/.*\\.md)$"

--- a/skills/analyzing-data/reference/common-patterns.md
+++ b/skills/analyzing-data/reference/common-patterns.md
@@ -1,16 +1,3 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
-
-- [Common Analysis Patterns](#common-analysis-patterns)
-  - [Trend Over Time](#trend-over-time)
-  - [Comparison (Period over Period)](#comparison-period-over-period)
-  - [Top N Analysis](#top-n-analysis)
-  - [Distribution / Histogram](#distribution--histogram)
-  - [Cohort Analysis](#cohort-analysis)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 # Common Analysis Patterns
 
 SQL templates for frequent analysis types.

--- a/skills/analyzing-data/reference/discovery-warehouse.md
+++ b/skills/analyzing-data/reference/discovery-warehouse.md
@@ -1,21 +1,3 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
-
-- [Warehouse Discovery](#warehouse-discovery)
-  - [Value Discovery (Explore Before Filtering)](#value-discovery-explore-before-filtering)
-  - [Fast Table Validation](#fast-table-validation)
-    - [Use Row Counts as a Signal](#use-row-counts-as-a-signal)
-  - [Handling Large Tables (100M+ rows)](#handling-large-tables-100m-rows)
-    - [Pattern: Find examples first, aggregate later](#pattern-find-examples-first-aggregate-later)
-  - [Table Exploration Process](#table-exploration-process)
-    - [Step 1: Search for Relevant Tables](#step-1-search-for-relevant-tables)
-    - [Step 2: Categorize by Data Layer](#step-2-categorize-by-data-layer)
-    - [Step 3: Get Schema Details](#step-3-get-schema-details)
-    - [Step 4: Check Data Freshness](#step-4-check-data-freshness)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 # Warehouse Discovery
 
 Patterns for discovering and querying data in the warehouse.

--- a/skills/authoring-dags/reference/best-practices.md
+++ b/skills/authoring-dags/reference/best-practices.md
@@ -1,27 +1,3 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
-
-- [DAG Authoring Best Practices](#dag-authoring-best-practices)
-  - [Import Compatibility](#import-compatibility)
-  - [Table of Contents](#table-of-contents)
-  - [Use TaskFlow API](#use-taskflow-api)
-  - [Never Hard-Code Credentials](#never-hard-code-credentials)
-  - [Use Provider Operators](#use-provider-operators)
-  - [Ensure Idempotency](#ensure-idempotency)
-  - [Use Data Intervals](#use-data-intervals)
-  - [Organize with Task Groups](#organize-with-task-groups)
-  - [Use Setup/Teardown](#use-setupteardown)
-  - [Include Data Quality Checks](#include-data-quality-checks)
-  - [Anti-Patterns](#anti-patterns)
-    - [DON'T: Access Metadata DB Directly](#dont-access-metadata-db-directly)
-    - [DON'T: Use Deprecated Imports](#dont-use-deprecated-imports)
-    - [DON'T: Use SubDAGs](#dont-use-subdags)
-    - [DON'T: Use Deprecated Context Keys](#dont-use-deprecated-context-keys)
-    - [DON'T: Hard-Code File Paths](#dont-hard-code-file-paths)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 # DAG Authoring Best Practices
 
 ## Import Compatibility

--- a/skills/migrating-airflow-2-to-3/reference/migration-checklist.md
+++ b/skills/migrating-airflow-2-to-3/reference/migration-checklist.md
@@ -1,23 +1,3 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
-
-- [Migration Checklist](#migration-checklist)
-  - [1. Direct metadata DB access](#1-direct-metadata-db-access)
-  - [2. Legacy imports](#2-legacy-imports)
-  - [3. Removed/renamed DAG arguments](#3-removedrenamed-dag-arguments)
-  - [4. Deprecated context keys](#4-deprecated-context-keys)
-  - [5. XCom pickling](#5-xcom-pickling)
-  - [6. Datasets to Assets](#6-datasets-to-assets)
-  - [7. Removed operators](#7-removed-operators)
-  - [8. Email changes](#8-email-changes)
-  - [9. REST API v1](#9-rest-api-v1)
-  - [10. File paths](#10-file-paths)
-  - [11. FAB-based plugins](#11-fab-based-plugins)
-  - [12. Callback and behavior changes](#12-callback-and-behavior-changes)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 # Migration Checklist
 
 After running Ruff's AIR rules, use this manual search checklist to find remaining issues.

--- a/skills/migrating-airflow-2-to-3/reference/migration-patterns.md
+++ b/skills/migrating-airflow-2-to-3/reference/migration-patterns.md
@@ -1,31 +1,3 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
-
-- [Migration Patterns Reference](#migration-patterns-reference)
-  - [Table of Contents](#table-of-contents)
-  - [Removed Modules & Import Reorganizations](#removed-modules--import-reorganizations)
-    - [`airflow.contrib.*` removed](#airflowcontrib-removed)
-    - [Core operators moved to provider packages](#core-operators-moved-to-provider-packages)
-    - [Hook and sensor imports moved to providers](#hook-and-sensor-imports-moved-to-providers)
-    - [`EmailOperator` moved to SMTP provider](#emailoperator-moved-to-smtp-provider)
-  - [Task SDK & Param Usage](#task-sdk--param-usage)
-    - [Key Task SDK imports](#key-task-sdk-imports)
-    - [Import mappings from legacy to Task SDK](#import-mappings-from-legacy-to-task-sdk)
-  - [SubDAGs, SLAs, and Removed Features](#subdags-slas-and-removed-features)
-    - [SubDAGs removed](#subdags-removed)
-    - [SLAs removed](#slas-removed)
-    - [Other removed or renamed code features](#other-removed-or-renamed-code-features)
-  - [Scheduling & Context Changes](#scheduling--context-changes)
-    - [Default scheduling behavior](#default-scheduling-behavior)
-    - [Removed context keys and replacements](#removed-context-keys-and-replacements)
-    - [`days_ago` removed](#days_ago-removed)
-  - [XCom Pickling Removal](#xcom-pickling-removal)
-  - [Datasets to Assets](#datasets-to-assets)
-  - [DAG Bundles & File Paths](#dag-bundles--file-paths)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 # Migration Patterns Reference
 
 Detailed code examples for Airflow 2 to 3 migration.


### PR DESCRIPTION
## Summary

- Removed auto-generated doctoc TOCs from 5 reference markdown files under `skills/`
- Updated the doctoc pre-commit exclude pattern to cover the entire `skills/` directory

## Why

The doctoc pre-commit hook's exclude pattern (`SKILL\.md`) only covered `SKILL.md` files directly but missed the reference `.md` files nested deeper in the skills directory tree (e.g., `skills/analyzing-data/reference/common-patterns.md`). These TOCs are noise — they're consumed by Claude as context, not rendered in a browser, so the TOC just wastes tokens.

The `files: ^README\.md$` pattern on the hook *should* already prevent doctoc from touching non-README files, but the broader exclude is a safety net and the stale TOCs needed removal regardless.

## Files affected

- `.pre-commit-config.yaml` — exclude pattern: `SKILL\.md` → `skills/`
- 5 reference docs under `skills/` — removed doctoc TOC blocks (~105 lines deleted)