### PR TITLE
docs: add shared utility imports breaking change to Airflow 2→3 migration

### DIFF
--- a/skills/migrating-airflow-2-to-3/SKILL.md
+++ b/skills/migrating-airflow-2-to-3/SKILL.md
@@ -25,6 +25,7 @@ This skill helps migrate **Airflow 2.x DAG code** to **Airflow 3.x**, focusing o
      - Cron scheduling semantics: consider `AIRFLOW__SCHEDULER__CREATE_CRON_DATA_INTERVAL=True` if you need Airflow 2-style cron data intervals.
      - `.airflowignore` syntax changed from regexp to glob; set `AIRFLOW__CORE__DAG_IGNORE_FILE_SYNTAX=regexp` if you must keep regexp behavior.
      - OAuth callback URLs add an `/auth/` prefix (e.g. `/auth/oauth-authorized/google`).
+     - **Shared utility imports**: Bare imports like `import common` from `dags/common/` no longer work on Astro. Use fully qualified imports: `import dags.common`.
 3. Plan changes per file and issue type:
    - Fix imports - update operators/hooks/providers - refactor metadata access to using the Airflow client instead of direct access - fix use of outdated context variables - fix scheduling logic.
 4. Implement changes incrementally, re-running Ruff and code searches after each major change.

--- a/skills/migrating-airflow-2-to-3/reference/migration-checklist.md
+++ b/skills/migrating-airflow-2-to-3/reference/migration-checklist.md
@@ -127,15 +127,21 @@ After running Ruff's AIR rules, use this manual search checklist to find remaini
 
 ---
 
-## 10. File paths
+## 10. File paths and shared utility imports
 
 **Search for:**
 - `open("include/`
 - `open("data/`
 - `template_searchpath=`
 - relative paths
+- `import common` or `from common` (bare imports from `dags/common/` or similar)
+- `import utils` or `from utils` (bare imports from `dags/utils/` or similar)
+- `sys.path.append` or `sys.path.insert` (custom path manipulation)
 
-**Fix:** Use `__file__` or `AIRFLOW_HOME` anchoring. Note: triggers cannot be in DAG bundle; must be elsewhere on `sys.path`
+**Fix:**
+- Use `__file__` or `AIRFLOW_HOME` anchoring for file paths
+- Note: triggers cannot be in DAG bundle; must be elsewhere on `sys.path`
+- **Shared utility imports**: Bare imports like `import common` no longer work. Use fully qualified imports: `import dags.common` or `from dags.common.utils import helper_function`
 
 ---
 

--- a/skills/migrating-airflow-2-to-3/reference/migration-patterns.md
+++ b/skills/migrating-airflow-2-to-3/reference/migration-patterns.md
@@ -363,6 +363,28 @@ def read_triggering_assets(**context):
 
 ## DAG Bundles & File Paths
 
+On Astro Runtime, Airflow 3 uses a versioned DAG bundle, so file paths and imports behave differently.
+
+### Shared utility imports
+
+If you import shared utility code from `dags/common/` or similar directories, **bare imports no longer work** in Airflow 3 on Astro. This is because DAG bundles place the bundle root on `sys.path`, but not `<bundle_root>/dags`. Additionally, bare imports are unsafe with DAG bundles due to Python's global import cache conflicting with concurrent bundle versions.
+
+Use fully qualified imports instead:
+
+```python
+# Airflow 2 (no longer works)
+import common
+from common.utils import helper_function
+
+# Airflow 3
+import dags.common
+from dags.common.utils import helper_function
+```
+
+Each bundle has its own `dags` package rooted at its bundle directory, which keeps imports scoped to the correct bundle version.
+
+### File path handling
+
 On Astro Runtime, Airflow 3 uses a versioned DAG bundle, so file paths behave differently:
 
 **For files inside `dags/` folder:**


### PR DESCRIPTION
## Summary

- Adds documentation for the shared utility imports breaking change in Airflow 3 on Astro
- Bare imports like `import common` from `dags/common/` no longer work because DAG bundles place the bundle root on `sys.path`, not `<bundle_root>/dags`
- Documents the fix: use fully qualified imports like `import dags.common`

Customer feedback indicated this gotcha was missing from the migration skill.

Reference: https://www.astronomer.io/docs/astro/airflow3/upgrade-af3#shared-utility-imports
