### PR TITLE
Add Snowflake query_tag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ my_warehouse:
   private_key_passphrase: ${SNOWFLAKE_PRIVATE_KEY_PASSPHRASE}
   warehouse: COMPUTE_WH
   role: ANALYST
+  query_tag: claude-code
   databases:
     - ANALYTICS
     - RAW

--- a/skills/analyzing-data/scripts/tests/test_connectors.py
+++ b/skills/analyzing-data/scripts/tests/test_connectors.py
@@ -116,6 +116,76 @@ class TestSnowflakeConnector:
         assert "account='test-account'" in prelude
         assert "def run_sql" in prelude
 
+    @pytest.mark.parametrize(
+        "data,expected_tag",
+        [
+            (
+                {
+                    "account": "a",
+                    "user": "u",
+                    "password": "p",
+                    "query_tag": "team=data-eng",
+                },
+                "team=data-eng",
+            ),
+            ({"account": "a", "user": "u", "password": "p"}, ""),
+        ],
+        ids=["with_query_tag", "without_query_tag"],
+    )
+    def test_from_dict_query_tag(self, data, expected_tag):
+        conn = SnowflakeConnector.from_dict(data)
+        assert conn.query_tag == expected_tag
+
+    @pytest.mark.parametrize(
+        "query_tag",
+        [
+            "team=data-eng",
+            "x" * 2000,
+            "",
+        ],
+        ids=["typical_tag", "max_length", "empty"],
+    )
+    def test_validate_valid_query_tag(self, query_tag):
+        conn = SnowflakeConnector(
+            account="a", user="u", password="p", databases=[], query_tag=query_tag
+        )
+        conn.validate("test")  # Should not raise
+
+    def test_validate_invalid_query_tag(self):
+        conn = SnowflakeConnector(
+            account="a",
+            user="u",
+            password="p",
+            databases=[],
+            query_tag="x" * 2001,
+        )
+        with pytest.raises(ValueError, match="2000 character limit"):
+            conn.validate("test")
+
+    def test_to_python_prelude_with_query_tag(self):
+        conn = SnowflakeConnector(
+            account="a",
+            user="u",
+            password="p",
+            databases=["DB"],
+            query_tag="team=data-eng",
+        )
+        prelude = conn.to_python_prelude()
+        assert "session_parameters" in prelude
+        assert "QUERY_TAG" in prelude
+        assert "team=data-eng" in prelude
+
+    def test_to_python_prelude_query_tag_in_status(self):
+        conn = SnowflakeConnector(
+            account="a",
+            user="u",
+            password="p",
+            databases=["DB"],
+            query_tag="team=data-eng",
+        )
+        prelude = conn.to_python_prelude()
+        assert "Query Tag:" in prelude
+
 
 class TestPostgresConnector:
     def test_connector_type(self):
@@ -701,6 +771,13 @@ class TestPreludeCompilation:
                 private_key_path="/k.pem",
                 databases=[],
             ),
+            SnowflakeConnector(
+                account="a",
+                user="u",
+                password="p",
+                query_tag="team=data-eng",
+                databases=[],
+            ),
             PostgresConnector(
                 host="h", port=5432, user="u", database="db", databases=["db"]
             ),
@@ -723,6 +800,7 @@ class TestPreludeCompilation:
         ids=[
             "snowflake_password",
             "snowflake_private_key",
+            "snowflake_query_tag",
             "postgres_basic",
             "postgres_ssl",
             "bigquery_basic",


### PR DESCRIPTION
## Summary

Adds `query_tag` support to `SnowflakeConnector`, the Snowflake equivalent of BigQuery's job labels (#118). Snowflake's [`QUERY_TAG`](https://docs.snowflake.com/en/sql-reference/parameters#query-tag) is a session-level parameter (free-form string, max 2000 chars) that appears in `QUERY_HISTORY` views and the Snowflake web UI, enabling query cost attribution per tool/team/environment.

## Design

Unlike BQ labels (key-value map), `query_tag` is a single string — teams often put JSON in it. The implementation:

- Passes `query_tag` via `session_parameters={'QUERY_TAG': ...}` in the `snowflake.connector.connect()` call, so it applies to all queries in the session
- Validates the 2000-char Snowflake limit at config load time
- No env-var substitution — this is not a secret, just a cost attribution tag

## Usage

```yaml
my_warehouse:
  type: snowflake
  account: ${SNOWFLAKE_ACCOUNT}
  user: ${SNOWFLAKE_USER}
  password: ${SNOWFLAKE_PASSWORD}
  warehouse: COMPUTE_WH
  query_tag: claude-code
  databases:
    - ANALYTICS
```

The tag then shows up in `SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY.QUERY_TAG` for cost attribution queries.

Closes #117