### PR TITLE
Add Postgres application_name support

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ my_postgres:
   user: analyst
   password: ${POSTGRES_PASSWORD}
   database: analytics
+  application_name: claude-code
 
 # BigQuery
 my_bigquery:

--- a/skills/analyzing-data/scripts/connectors.py
+++ b/skills/analyzing-data/scripts/connectors.py
@@ -282,6 +282,7 @@ class PostgresConnector(DatabaseConnector):
     sslmode: str = ""
     databases: list[str] = field(default_factory=list)
     password_env_var: str | None = None
+    application_name: str = ""
 
     @classmethod
     def connector_type(cls) -> str:
@@ -303,6 +304,7 @@ class PostgresConnector(DatabaseConnector):
             sslmode=data.get("sslmode", ""),
             databases=data.get("databases", [database] if database else []),
             password_env_var=pw_env,
+            application_name=data.get("application_name", ""),
         )
 
     def validate(self, name: str) -> None:
@@ -334,6 +336,8 @@ class PostgresConnector(DatabaseConnector):
         lines.append(f"    dbname={self.database!r},")
         if self.sslmode:
             lines.append(f"    sslmode={self.sslmode!r},")
+        if self.application_name:
+            lines.append(f"    application_name={self.application_name!r},")
         lines.append("    autocommit=True,")
         lines.append(")")
         connection_code = "\n".join(lines)
@@ -343,6 +347,10 @@ class PostgresConnector(DatabaseConnector):
             f'print("   Host: {self.host}:{self.port}")',
             f'print("   User: {self.user}")',
             f'print("   Database: {self.database}")',
+        ]
+        if self.application_name:
+            status_lines.append(f'print("   Application: {self.application_name}")')
+        status_lines += [
             'print("\\nAvailable: run_sql(query) -> polars, run_sql_pandas(query) -> pandas")',
         ]
         status_code = "\n".join(status_lines)

--- a/skills/analyzing-data/scripts/tests/test_connectors.py
+++ b/skills/analyzing-data/scripts/tests/test_connectors.py
@@ -237,6 +237,48 @@ class TestPostgresConnector:
         assert "host='localhost'" in prelude
         assert "def run_sql" in prelude
 
+    @pytest.mark.parametrize(
+        "data,expected_name",
+        [
+            (
+                {
+                    "host": "h",
+                    "user": "u",
+                    "database": "d",
+                    "application_name": "claude-code",
+                },
+                "claude-code",
+            ),
+            ({"host": "h", "user": "u", "database": "d"}, ""),
+        ],
+        ids=["with_application_name", "without_application_name"],
+    )
+    def test_from_dict_application_name(self, data, expected_name):
+        conn = PostgresConnector.from_dict(data)
+        assert conn.application_name == expected_name
+
+    def test_to_python_prelude_with_application_name(self):
+        conn = PostgresConnector(
+            host="h",
+            user="u",
+            database="db",
+            databases=["db"],
+            application_name="claude-code",
+        )
+        prelude = conn.to_python_prelude()
+        assert "application_name='claude-code'" in prelude
+
+    def test_to_python_prelude_application_name_in_status(self):
+        conn = PostgresConnector(
+            host="h",
+            user="u",
+            database="db",
+            databases=["db"],
+            application_name="claude-code",
+        )
+        prelude = conn.to_python_prelude()
+        assert "Application:" in prelude
+
 
 class TestBigQueryConnector:
     def test_connector_type(self):
@@ -878,6 +920,14 @@ class TestPreludeCompilation:
                 sslmode="require",
                 databases=[],
             ),
+            PostgresConnector(
+                host="h",
+                user="u",
+                password="p",
+                database="db",
+                databases=[],
+                application_name="claude-code",
+            ),
             BigQueryConnector(project="p", databases=["p"]),
             BigQueryConnector(project="p", location="US", databases=["p"]),
             BigQueryConnector(
@@ -903,6 +953,7 @@ class TestPreludeCompilation:
             "snowflake_query_tag",
             "postgres_basic",
             "postgres_ssl",
+            "postgres_application_name",
             "bigquery_basic",
             "bigquery_location",
             "bigquery_credentials",


### PR DESCRIPTION
## Summary

- Adds `application_name` field to `PostgresConnector`, continuing the cost-attribution story across all connectors (BQ labels #118, Snowflake `query_tag` #119)
- The parameter is passed to `psycopg.connect()` and appears in `pg_stat_activity.application_name`, enabling query attribution per tool/team
- Shown in the status output when set (e.g., `Application: claude-code`)

## Design rationale

- **No validation**: Postgres truncates `application_name` gracefully at `NAMEDATALEN` (usually 64 bytes), so there's no need to enforce a length limit on our side—unlike Snowflake's explicit 2000-char `query_tag` limit.
- **No env-var substitution**: `application_name` isn't a secret, so it's treated as a plain string (same as Snowflake's `query_tag`).
- **Conditional in prelude**: Only emitted when non-empty, keeping the generated connection code clean for users who don't set it.

## Usage

```yaml
# ~/.astro/agents/warehouse.yml
my_postgres:
  type: postgres
  host: localhost
  port: 5432
  user: analyst
  password: ${POSTGRES_PASSWORD}
  database: analytics
  application_name: claude-code
```

Then in `pg_stat_activity`:
```sql
SELECT application_name, query FROM pg_stat_activity WHERE application_name = 'claude-code';
```