### PR TITLE
Fix `cosmos-dbt-core/SKILL.md`

### DIFF
--- a/skills/cosmos-dbt-core/SKILL.md
+++ b/skills/cosmos-dbt-core/SKILL.md
@@ -65,7 +65,7 @@ Pick ONE execution mode:
 | Execution mode | When to use | Speed | Required setup |
 |----------------|-------------|-------|----------------|
 | `WATCHER` | Fastest; single `dbt build` visibility | Fastest | dbt adapter in env OR `dbt_executable_path` or dbt Fusion |
-| `WATCHER_KUBERNETES` | Fastest isolated method; single `dbt build` visibility | Fast | dbt installed in container | 
+| `WATCHER_KUBERNETES` | Fastest isolated method; single `dbt build` visibility | Fast | dbt installed in container |
 | `LOCAL` + `DBT_RUNNER` | dbt + adapter in the same Python installation as Airflow | Fast | dbt 1.5+ in `requirements.txt` |
 | `LOCAL` + `SUBPROCESS` | dbt + adapter available in the Airflow deployment, in an isolated Python installation | Medium | `dbt_executable_path` |
 | `AIRFLOW_ASYNC` | BigQuery + long-running transforms | Fast | Airflow ≥2.8; provider deps |


### PR DESCRIPTION
Fix incorrect statements and improve existing descriptions.

The main issues:
- The containerised approaches do not require `manifest.json`
- The first step should be to set the path to the user's dbt project. Parsing it is a second step.
- Watcher also supports dbt Fusion
- Missing `WATCHER_KUBERNETES`
- Missing a common use case of instantiating Cosmos operators directly