### PR TITLE
fix: add SSL certificate verification bypass for self-signed certs

### DIFF
--- a/astro-airflow-mcp/AGENTS.md
+++ b/astro-airflow-mcp/AGENTS.md
@@ -47,11 +47,11 @@ src/astro_airflow_mcp/
 
 ### HTTP Client
 
-Use `httpx`, not `requests`. All HTTP calls should use `httpx.Client`:
+Use `httpx`, not `requests`. All HTTP calls should use `httpx.Client` and pass `self._verify` for SSL configuration:
 
 ```python
 # Good
-with httpx.Client(timeout=30.0) as client:
+with httpx.Client(timeout=30.0, verify=self._verify) as client:
     response = client.get(url, headers=headers)
 
 # Bad

--- a/astro-airflow-mcp/README.md
+++ b/astro-airflow-mcp/README.md
@@ -147,6 +147,8 @@ By default, the server connects to `http://localhost:8080` (Astro CLI default). 
 | `AIRFLOW_USERNAME` | Username (Airflow 3.x uses OAuth2 token exchange) |
 | `AIRFLOW_PASSWORD` | Password |
 | `AIRFLOW_AUTH_TOKEN` | Bearer token (alternative to username/password) |
+| `AIRFLOW_VERIFY_SSL` | Set to `false` to disable SSL certificate verification |
+| `AIRFLOW_CA_CERT` | Path to custom CA certificate bundle |
 
 Example with auth (Claude Code):
 
@@ -305,6 +307,10 @@ af instance add local --url http://localhost:8080
 af instance add staging --url https://staging.example.com --username admin --password secret
 af instance add prod --url https://prod.example.com --token '${AIRFLOW_PROD_TOKEN}'
 
+# SSL options for self-signed or corporate CA certificates
+af instance add corp --url https://airflow.corp.example.com --no-verify-ssl --username admin --password secret
+af instance add corp --url https://airflow.corp.example.com --ca-cert /path/to/ca-bundle.pem --token '${TOKEN}'
+
 # List and switch instances
 af instance list      # Shows all instances in a table
 af instance use prod  # Switch to prod instance
@@ -365,6 +371,13 @@ instances:
   url: https://prod.example.com
   auth:
     token: ${AIRFLOW_PROD_TOKEN}  # Environment variable interpolation
+- name: corporate
+  url: https://airflow.corp.example.com
+  auth:
+    username: admin
+    password: secret
+  verify-ssl: false               # Disable SSL verification (self-signed certs)
+  # ca-cert: /path/to/ca.pem     # Or provide a custom CA bundle
 current-instance: local
 ```
 
@@ -425,6 +438,8 @@ echo astro-airflow-mcp >> requirements.txt
 | `--host` | `MCP_HOST` | `localhost` | Host to bind to (HTTP mode only) |
 | `--port` | `MCP_PORT` | `8000` | Port to bind to (HTTP mode only) |
 | `--airflow-project-dir` | `AIRFLOW_PROJECT_DIR` | `$PWD` | Astro project directory for auto-discovering Airflow URL |
+| `--no-verify-ssl` | `AIRFLOW_VERIFY_SSL=false` | off | Disable SSL certificate verification |
+| `--ca-cert` | `AIRFLOW_CA_CERT` | `None` | Path to custom CA certificate bundle |
 
 **Airflow Connection (Environment Variables):**
 
@@ -434,6 +449,8 @@ echo astro-airflow-mcp >> requirements.txt
 | `AIRFLOW_AUTH_TOKEN` | `None` | Bearer token for authentication |
 | `AIRFLOW_USERNAME` | `None` | Username for authentication |
 | `AIRFLOW_PASSWORD` | `None` | Password for authentication |
+| `AIRFLOW_VERIFY_SSL` | `true` | Set to `false` to disable SSL verification |
+| `AIRFLOW_CA_CERT` | `None` | Path to custom CA certificate bundle |
 
 **af CLI Options:**
 

--- a/astro-airflow-mcp/src/astro_airflow_mcp/adapter_manager.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/adapter_manager.py
@@ -23,6 +23,7 @@ class AdapterManager:
         self._token_manager: TokenManager | None = None
         self._auth_token: str | None = None
         self._airflow_url: str = DEFAULT_AIRFLOW_URL
+        self._verify: bool | str = True
 
     @property
     def airflow_url(self) -> str:
@@ -35,6 +36,7 @@ class AdapterManager:
         auth_token: str | None = None,
         username: str | None = None,
         password: str | None = None,
+        verify: bool | str = True,
     ) -> None:
         """Configure adapter connection settings.
 
@@ -43,6 +45,8 @@ class AdapterManager:
             auth_token: Direct bearer token for authentication (takes precedence)
             username: Username for token-based authentication
             password: Password for token-based authentication
+            verify: SSL verification setting. True (default) enables verification,
+                    False disables it, or a string path to a CA bundle file.
 
         Note:
             If auth_token is provided, it will be used directly.
@@ -52,6 +56,8 @@ class AdapterManager:
         """
         if url:
             self._airflow_url = url
+
+        self._verify = verify
 
         if auth_token:
             # Direct token takes precedence - no token manager needed
@@ -64,6 +70,7 @@ class AdapterManager:
                 airflow_url=self._airflow_url,
                 username=username,
                 password=password,
+                verify=self._verify,
             )
         else:
             # No auth provided - try credential-less token manager
@@ -72,6 +79,7 @@ class AdapterManager:
                 airflow_url=self._airflow_url,
                 username=None,
                 password=None,
+                verify=self._verify,
             )
 
         # Reset adapter so it will be re-created with new config
@@ -92,6 +100,7 @@ class AdapterManager:
                 airflow_url=self._airflow_url,
                 token_getter=self._get_auth_token,
                 basic_auth_getter=self._get_basic_auth,
+                verify=self._verify,
             )
             logger.info("Created adapter for Airflow %s", self._adapter.version)
         return self._adapter

--- a/astro-airflow-mcp/src/astro_airflow_mcp/adapters/airflow_v3.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/adapters/airflow_v3.py
@@ -24,19 +24,20 @@ class AirflowV3Adapter(AirflowAdapter):
         version: str,
         token_getter: Callable[[], str | None] | None = None,
         basic_auth_getter: Callable[[], tuple[str, str] | None] | None = None,
+        verify: bool | str = True,
     ):
         """Initialize V3 adapter, exchanging basic auth for JWT if needed."""
         # If we have basic auth but no token, exchange for JWT
         if basic_auth_getter and not token_getter:
             creds = basic_auth_getter()
             if creds:
-                jwt_token = self._exchange_for_token(airflow_url, creds[0], creds[1])
+                jwt_token = self._exchange_for_token(airflow_url, creds[0], creds[1], verify=verify)
                 if jwt_token:
                     # Create a token getter that returns the JWT
                     token_getter = self._make_token_getter(jwt_token)
                     basic_auth_getter = None  # Don't use basic auth
 
-        super().__init__(airflow_url, version, token_getter, basic_auth_getter)
+        super().__init__(airflow_url, version, token_getter, basic_auth_getter, verify=verify)
 
     @staticmethod
     def _make_token_getter(token: str) -> Callable[[], str | None]:
@@ -48,13 +49,18 @@ class AirflowV3Adapter(AirflowAdapter):
         return getter
 
     @staticmethod
-    def _exchange_for_token(airflow_url: str, username: str, password: str) -> str | None:
+    def _exchange_for_token(
+        airflow_url: str,
+        username: str,
+        password: str,
+        verify: bool | str = True,
+    ) -> str | None:
         """Exchange username/password for JWT token via OAuth2 flow.
 
         Airflow 3.x uses /auth/token endpoint for OAuth2 password grant.
         """
         try:
-            with httpx.Client(timeout=10.0) as client:
+            with httpx.Client(timeout=10.0, verify=verify) as client:
                 response = client.post(
                     f"{airflow_url}/auth/token",
                     data={"username": username, "password": password},

--- a/astro-airflow-mcp/src/astro_airflow_mcp/auth.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/auth.py
@@ -31,6 +31,7 @@ class TokenManager:
         username: str | None = None,
         password: str | None = None,
         timeout: float = 30.0,
+        verify: bool | str = True,
     ):
         """Initialize the token manager.
 
@@ -39,11 +40,14 @@ class TokenManager:
             username: Optional username for token authentication
             password: Optional password for token authentication
             timeout: HTTP request timeout in seconds (default 30.0)
+            verify: SSL verification setting. True (default) enables verification,
+                    False disables it, or a string path to a CA bundle file.
         """
         self.airflow_url = airflow_url
         self.username = username
         self.password = password
         self._timeout = timeout
+        self._verify: bool | str = verify
         self._token: str | None = None
         self._token_fetched_at: float | None = None
         # Default token lifetime of 30 minutes if not provided by server
@@ -114,7 +118,7 @@ class TokenManager:
         token_url = f"{self.airflow_url}/auth/token"
 
         try:
-            with httpx.Client(timeout=self._timeout) as client:
+            with httpx.Client(timeout=self._timeout, verify=self._verify) as client:
                 if self.username and self.password:
                     # Use credentials to fetch token
                     logger.debug("Fetching token with username/password credentials")

--- a/astro-airflow-mcp/src/astro_airflow_mcp/server.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/server.py
@@ -67,6 +67,7 @@ def configure(
     username: str | None = None,
     password: str | None = None,
     project_dir: str | None = None,
+    verify: bool | str = True,
 ) -> None:
     """Configure global Airflow connection settings.
 
@@ -76,6 +77,8 @@ def configure(
         username: Username for token-based authentication
         password: Password for token-based authentication
         project_dir: Project directory where Claude Code is running
+        verify: SSL verification setting. True (default) enables verification,
+                False disables it, or a string path to a CA bundle file.
 
     Note:
         If auth_token is provided, it will be used directly.
@@ -92,6 +95,7 @@ def configure(
         auth_token=auth_token,
         username=username,
         password=password,
+        verify=verify,
     )
 
 


### PR DESCRIPTION
## Summary

Fixes #125. Users connecting to Airflow instances behind corporate CAs or with self-signed certificates get `SSL: CERTIFICATE_VERIFY_FAILED` errors because all `httpx.Client()` calls used default SSL verification with no way to disable it or provide a custom CA bundle.

This adds a `verify` parameter that threads through the entire HTTP call chain — from config file through to every `httpx.Client()` call.

## Configuration

Three ways to configure, across both CLI and MCP server entry points:

**Config file** (`~/.af/config.yaml`):
```yaml
instances:
  - name: corporate
    url: https://airflow.corp.example.com
    verify-ssl: false          # disable verification
    # or
    ca-cert: /path/to/ca.pem  # custom CA bundle (supports ${ENV_VAR} syntax)
```

**CLI flags** (mutually exclusive):
```bash
af instance add corp --url https://airflow.corp.example.com --no-verify-ssl
af instance add corp --url https://airflow.corp.example.com --ca-cert /path/to/ca.pem
```

**Environment variables**:
```bash
AIRFLOW_VERIFY_SSL=false    # disable verification
AIRFLOW_CA_CERT=/path/ca    # custom CA bundle
```

**MCP server**:
```bash
python -m astro_airflow_mcp --no-verify-ssl --airflow-url https://...
python -m astro_airflow_mcp --ca-cert /path/to/ca.pem --airflow-url https://...
```

Priority: CLI flags > env vars > config file > default (`True`).

## Design rationale

- **`verify: bool | str` union type** matches httpx's native API, avoiding an abstraction layer that would just be unwrapped at every call site.
- **`--no-verify-ssl` and `--ca-cert` are mutually exclusive** — providing a CA bundle implies "verify with this bundle," which contradicts "don't verify." argparse enforces this for the MCP server; the CLI `add` command validates explicitly.
- **`ca_cert` path is validated at config resolve time** — fails early with a clear error instead of surfacing a cryptic OpenSSL error on the first HTTP call.
- **Default SSL values are omitted from YAML** — `verify-ssl: true` and `ca-cert: null` are stripped during save for clean config files. Only non-default values are persisted.
- **`ca_cert` supports `${ENV_VAR}` interpolation** — reuses the existing `interpolate_config_value` mechanism so users can write `ca-cert: ${CA_CERT_PATH}` in config.

## Files changed

**Config layer** (2 files): `config/models.py`, `config/loader.py` — new `verify_ssl` and `ca_cert` fields on Instance/ResolvedConfig

**Adapter layer** (6 files): `adapter_manager.py`, `auth.py`, `adapters/__init__.py`, `adapters/base.py`, `adapters/airflow_v2.py`, `adapters/airflow_v3.py` — `verify` parameter threaded through every constructor and httpx.Client() call

**Entry points** (4 files): `cli/instances.py`, `cli/context.py`, `server.py`, `__main__.py` — CLI flags, env var fallbacks, and MCP server args

**Tests** (2 files): 49 new tests covering model serialization, config round-trips, env var overrides, CLIContext priority logic, and httpx.Client verify pass-through for all HTTP methods (GET/POST/PATCH/DELETE/raw_request) plus V3 token exchange