### PR TITLE
Fix skill hooks to use correct project context

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -29,7 +29,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/skills/analyzing-data/scripts/cli.py stop"
+            "command": "uv run --project ${CLAUDE_PLUGIN_ROOT}/skills/analyzing-data/scripts ${CLAUDE_PLUGIN_ROOT}/skills/analyzing-data/scripts/cli.py stop"
           }
         ]
       }


### PR DESCRIPTION
## Summary
Fixes the `analyzing-data` skill's Stop hook that was failing when run from user project directories with their own `pyproject.toml` files.

## Problem
When hooks run `uv run ${CLAUDE_PLUGIN_ROOT}/skills/analyzing-data/scripts/cli.py stop`, they execute from the user's working directory. This causes `uv` to find the wrong `pyproject.toml`:
- If the user's `pyproject.toml` lacks a `[project]` table: `error: No project table found`
- If it has a `[project]` table: Wrong dependencies and virtual environment are used

## Solution
Use `uv`'s `--project` flag to explicitly specify the correct project directory:
```bash
uv run --project ${CLAUDE_PLUGIN_ROOT}/skills/analyzing-data/scripts ...
```

This ensures the skill's `pyproject.toml` is always used regardless of the user's working directory.

## Testing
Tested with:
1. User project with no `[project]` table (original error case)
2. User project with `[project]` table (wrong context case)
3. Verified correct virtual environment and dependencies are used with `--project` flag

Fixes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)