### PR TITLE
Address Copilot feedback on type safety

### DIFF
--- a/astro-airflow-mcp/src/astro_airflow_mcp/adapters/base.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/adapters/base.py
@@ -107,7 +107,10 @@ class AirflowAdapter(ABC):
         all_params = {k: v for k, v in all_params.items() if v is not None}
 
         with httpx.Client(timeout=30.0, verify=self._verify) as client:
-            response = client.get(url, params=all_params, headers=headers, auth=auth)
+            if auth:
+                response = client.get(url, params=all_params, headers=headers, auth=auth)
+            else:
+                response = client.get(url, params=all_params, headers=headers)
 
             if response.status_code == 404:
                 raise NotFoundError(endpoint)
@@ -139,8 +142,10 @@ class AirflowAdapter(ABC):
         url = f"{self.airflow_url}{self.api_base_path}/{endpoint}"
 
         with httpx.Client(timeout=30.0, verify=self._verify) as client:
-            # httpx accepts auth=None, but ty doesn't recognize it in the union type
-            response = client.post(url, json=json_data, headers=headers, auth=auth)  # type: ignore[arg-type]
+            if auth:
+                response = client.post(url, json=json_data, headers=headers, auth=auth)
+            else:
+                response = client.post(url, json=json_data, headers=headers)
 
             if response.status_code == 404:
                 raise NotFoundError(endpoint)
@@ -172,8 +177,10 @@ class AirflowAdapter(ABC):
         url = f"{self.airflow_url}{self.api_base_path}/{endpoint}"
 
         with httpx.Client(timeout=30.0, verify=self._verify) as client:
-            # httpx accepts auth=None, but ty doesn't recognize it in the union type
-            response = client.patch(url, json=json_data, headers=headers, auth=auth)  # type: ignore[arg-type]
+            if auth:
+                response = client.patch(url, json=json_data, headers=headers, auth=auth)
+            else:
+                response = client.patch(url, json=json_data, headers=headers)
 
             if response.status_code == 404:
                 raise NotFoundError(endpoint)
@@ -202,8 +209,10 @@ class AirflowAdapter(ABC):
         url = f"{self.airflow_url}{self.api_base_path}/{endpoint}"
 
         with httpx.Client(timeout=30.0, verify=self._verify) as client:
-            # httpx accepts auth=None, but ty doesn't recognize it in the union type
-            response = client.delete(url, headers=headers, auth=auth)  # type: ignore[arg-type]
+            if auth:
+                response = client.delete(url, headers=headers, auth=auth)
+            else:
+                response = client.delete(url, headers=headers)
 
             if response.status_code == 404:
                 raise NotFoundError(endpoint)

--- a/astro-airflow-mcp/src/astro_airflow_mcp/config/loader.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/config/loader.py
@@ -64,8 +64,7 @@ class ConfigManager:
 
     def _create_default_config(self) -> AirflowCliConfig:
         """Create default config with localhost:8080 instance."""
-        # ty doesn't recognize Pydantic Field defaults: https://github.com/astral-sh/ty/issues/2130
-        config = AirflowCliConfig()  # type: ignore[call-arg]
+        config = AirflowCliConfig.model_validate({})
         config.add_instance("localhost:8080", "http://localhost:8080", source="local")
         config.use_instance("localhost:8080")
         return config
@@ -90,8 +89,7 @@ class ConfigManager:
                     data = yaml.safe_load(f)
 
                 if data is None:
-                    # ty doesn't recognize Pydantic Field defaults: https://github.com/astral-sh/ty/issues/2130
-                    return AirflowCliConfig()  # type: ignore[call-arg]
+                    return AirflowCliConfig.model_validate({})
 
                 return AirflowCliConfig.model_validate(data)
             except yaml.YAMLError as e:


### PR DESCRIPTION
## Summary

Addresses post-merge feedback from Copilot on #133:

- Replace `AirflowCliConfig()` with `AirflowCliConfig.model_validate({})` to avoid suppressing type errors for Pydantic Field defaults
- Conditionally pass `auth=` parameter to httpx methods only when not None, removing the need for `type: ignore[arg-type]` comments
- Preserve type checking so the type checker can catch auth-type issues

## Design Rationale

**Why model_validate({}) instead of direct instantiation?**
Using `model_validate({})` avoids the ty/Pydantic Field defaults issue while keeping type checking enabled. The `type: ignore[call-arg]` was masking potential constructor argument issues.

**Why conditional auth parameter passing?**
httpx accepts `auth=None`, but ty doesn't recognize it in the union type `tuple[str, str] | None`. By branching and only passing `auth=` when it's not None:
- Type checker can validate auth parameter types when present
- No type: ignore needed, preserving type safety
- Same runtime behavior (httpx handles both cases identically)

## Gotchas

The `cast("int", ...)` in instances.py uses a string type annotation per ruff's TC006 rule. This is intentional for compatibility with `from __future__ import annotations`.