### PR TITLE
Add required `version` attribute to Cursor plugin hook config

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -23,6 +23,7 @@
   ],
   "logo": "https://www.astronomer.io/logo/astronomer-dark.svg",
   "hooks": {
+    "version": 1,
     "hooks": {
       "beforeSubmitPrompt": [
         {


### PR DESCRIPTION
Cursor's hooks schema requires a `version` field of type `integer` (currently only `1` is supported) at the top level of the hooks configuration object. Without it, Cursor fails to load the plugin hooks and surfaces a "Config version must be a number" error in Settings → Hooks.

### Changes
- Added `"version": 1` to the `hooks` object in `.cursor-plugin/plugin.json`

### Root Cause
Cursor validates hooks configs against a schema where `version` is a required integer field ([see Cursor hooks
docs](https://cursor.com/docs/agent/hooks#examples)). The `.cursor-plugin/plugin.json` hooks object was missing this field entirely, causing Cursor to reject the configuration on load.