### PR TITLE
Fix airflow-adapter skill frontmatter

### DIFF
--- a/astro-airflow-mcp/.claude/skills/airflow-adapter/SKILL.md
+++ b/astro-airflow-mcp/.claude/skills/airflow-adapter/SKILL.md
@@ -1,8 +1,6 @@
 ---
-description: Airflow adapter pattern for v2/v3 API compatibility
-globs:
-  - src/astro_airflow_mcp/adapters/**
-  - src/astro_airflow_mcp/server.py
+name: airflow-adapter
+description: Airflow adapter pattern for v2/v3 API compatibility. Use when working with adapters, version detection, or adding new API methods that need to work across Airflow 2.x and 3.x.
 ---
 
 # Airflow Adapter Pattern


### PR DESCRIPTION
## Summary

The [Claude skill spec](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) requires `name` and `description` fields in SKILL.md frontmatter. The existing airflow-adapter skill had an unsupported `globs` field and was missing `name`.

**Before:**
```yaml
description: Airflow adapter pattern for v2/v3 API compatibility
globs:
  - src/astro_airflow_mcp/adapters/**
  - src/astro_airflow_mcp/server.py
```

**After:**
```yaml
name: airflow-adapter
description: Airflow adapter pattern for v2/v3 API compatibility. Use when working with adapters, version detection, or adding new API methods that need to work across Airflow 2.x and 3.x.
```