### PR TITLE
Add blueprint skill for template-based DAG authoring

### DIFF
--- a/skills/blueprint/SKILL.md
+++ b/skills/blueprint/SKILL.md
@@ -42,7 +42,7 @@ If the user is starting fresh, guide them through setup:
 
 ```bash
 # Add to requirements.txt
-airflow-blueprint>=0.11.0
+airflow-blueprint>=0.1.1
 
 # Or install directly
 pip install airflow-blueprint


### PR DESCRIPTION
## Summary

- Adds new `blueprint` skill for working with the [airflow-blueprint](https://github.com/astronomer/blueprint) package
- Enables platform teams to define reusable Airflow task group templates with Pydantic validation
- Supports composing DAGs from YAML without writing Airflow code

## References

- Blueprint repo: https://github.com/astronomer/blueprint
- Docs PR: https://github.com/astronomer/docs/pull/6339

## Test plan

- [ ] Verify skill loads correctly with `claude plugin install`
- [ ] Test skill triggers on relevant user queries
- [ ] Validate CLI commands work as documented