### PR TITLE
  Clarify get_dag_stats requires dag_ids as a list, even for one DAG

### DIFF
--- a/astro-airflow-mcp/src/astro_airflow_mcp/tools/dag.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/tools/dag.py
@@ -160,7 +160,8 @@ def _get_dag_stats_impl(dag_ids: list[str] | None = None) -> str:
     """Internal implementation for getting DAG statistics from Airflow.
 
     Args:
-        dag_ids: Optional list of DAG IDs to get stats for. If None, gets stats for all DAGs.
+        dag_ids: Optional list of DAG IDs to get stats for. Pass a list even for a
+            single DAG, for example ["example_dag"]. If None, gets stats for all DAGs.
 
     Returns:
         JSON string containing DAG run statistics by state
@@ -192,7 +193,9 @@ def get_dag_stats(dag_ids: list[str] | None = None) -> str:
     - And other possible states
 
     Args:
-        dag_ids: Optional list of DAG IDs to filter by. If not provided, returns stats for all DAGs.
+        dag_ids: Optional list of DAG IDs to filter by. Pass a list even for a
+            single DAG, for example ["example_dag"]. If not provided, returns
+            stats for all DAGs.
 
     Returns:
         JSON with DAG run statistics organized by DAG and state


### PR DESCRIPTION
I ran into this (extremely small!) issue in real life with codex using gpt-5.4.  I do like this mcp, I hope this can be a helpful contribution back.

Codex suggested PR description:
----

  Title

  Clarify get_dag_stats requires dag_ids as a list, even for one DAG

  Description

  This updates the get_dag_stats tool docstrings to explicitly say that dag_ids must be passed as a list, even when querying a single DAG.

  Why this is useful:

  - The tool signature already requires list[str] | None, but that’s easy to miss in practice.
  - Single-DAG lookups are a very common case, and it’s natural for MCP clients or agents to try passing "my_dag" instead of ["my_dag"].
  - When that happens, the result is an avoidable validation error rather than a successful call.
  - The docstring is surfaced to MCP clients as tool guidance, so improving it directly helps agents call the tool correctly on the first try.

