### PR TITLE
feat: improve skill scores across 12 skills

### DIFF
--- a/astro-airflow-mcp/.claude/skills/airflow-adapter/SKILL.md
+++ b/astro-airflow-mcp/.claude/skills/airflow-adapter/SKILL.md
@@ -33,3 +33,26 @@ adapter = _get_adapter()
 dags = adapter.list_dags(limit=100)
 run = adapter.trigger_dag_run("my_dag", conf={"key": "value"})
 ```
+
+## Adding a New API Method
+
+1. Add abstract method to `adapters/base.py`:
+
+```python
+@abstractmethod
+def get_dag_stats(self, dag_id: str) -> dict: ...
+```
+
+2. Implement in both adapters — handle endpoint and field differences:
+
+```python
+# airflow_v2.py — _call() prepends /api/v1 automatically
+def get_dag_stats(self, dag_id: str) -> dict:
+    return self._call(f"dags/{dag_id}/dagRuns", params={"limit": 1})
+
+# airflow_v3.py — _call() prepends /api/v2 automatically
+def get_dag_stats(self, dag_id: str) -> dict:
+    return self._call(f"dags/{dag_id}/dagRuns", params={"limit": 1})
+```
+
+3. Use from MCP tools via `adapter = _get_adapter()` — never call the API directly.

--- a/skills/annotating-task-lineage/SKILL.md
+++ b/skills/annotating-task-lineage/SKILL.md
@@ -5,13 +5,9 @@ description: Annotate Airflow tasks with data lineage using inlets and outlets. 
 
 # Annotating Task Lineage with Inlets & Outlets
 
-This skill guides you through adding manual lineage annotations to Airflow tasks using `inlets` and `outlets`.
-
 > **Reference:** See the [OpenLineage provider developer guide](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/guides/developer.html) for the latest supported operators and patterns.
-
-### On Astro
-
-Lineage annotations defined with inlets and outlets are visualized in Astro's enhanced **Lineage tab**, which provides cross-DAG and cross-deployment lineage views. This means your annotations are immediately visible in the Astro UI, giving you a unified view of data flow across your entire Astro organization.
+>
+> **On Astro:** Lineage annotations are automatically visualized in Astro's **Lineage tab** with cross-DAG and cross-deployment views.
 
 ## When to Use This Approach
 
@@ -330,6 +326,17 @@ transform = SqlOperator(
 - Include all tables referenced in JOINs as inlets
 - Include all tables written to (including temp tables if relevant)
 - **Outlet-only and inlet-only annotations are valid.** One-sided annotations are encouraged for lineage visibility even without a corresponding inlet or outlet in another DAG.
+
+---
+
+## Verification
+
+After adding inlets/outlets, verify lineage appears:
+
+1. **Trigger the DAG** and wait for successful completion
+2. **On Astro:** Check the **Lineage tab** in the Astro UI for the annotated task
+3. **On OSS Airflow:** Check OpenLineage events via your configured transport (e.g., Marquez UI, log output)
+4. **If lineage doesn't appear:** Confirm no extractor or OL method is overriding inlets/outlets (see precedence rules above)
 
 ---
 

--- a/skills/creating-openlineage-extractors/SKILL.md
+++ b/skills/creating-openlineage-extractors/SKILL.md
@@ -5,8 +5,6 @@ description: Create custom OpenLineage extractors for Airflow operators. Use whe
 
 # Creating OpenLineage Extractors
 
-This skill guides you through creating custom OpenLineage extractors to capture lineage from Airflow operators that don't have built-in support.
-
 > **Reference:** See the [OpenLineage provider developer guide](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/guides/developer.html) for the latest patterns and list of supported operators/hooks.
 
 ## When to Use Each Approach
@@ -395,6 +393,18 @@ OpenLineage checks for lineage in this order:
 4. **Inlets/Outlets** (lowest priority)
 
 If a custom extractor exists, it overrides built-in extraction and inlets/outlets.
+
+---
+
+## Verification
+
+After registering an extractor:
+
+1. **Check registration:** `airflow plugins` or check logs for "Registered OpenLineage extractor" messages
+2. **Trigger a DAG** using the target operator
+3. **On Astro:** Check the **Lineage tab** for the task — inputs/outputs should appear
+4. **On OSS:** Check OpenLineage transport output (Marquez UI, log events)
+5. **If lineage missing:** Verify the `AIRFLOW__OPENLINEAGE__EXTRACTORS` path is importable from the worker
 
 ---
 

--- a/skills/deploying-airflow/SKILL.md
+++ b/skills/deploying-airflow/SKILL.md
@@ -1,19 +1,15 @@
 ---
 name: deploying-airflow
-description: Deploy Airflow DAGs and projects. Use when the user wants to deploy code, push DAGs, set up CI/CD, deploy to production, or asks about deployment strategies for Airflow.
+description: Deploy Airflow DAGs and projects to production using Astro CLI, Docker Compose, or Kubernetes Helm charts. Configure deployment pipelines, manage DAG-only and full image deploys, and set up git-sync or CI/CD automation. Use when the user wants to deploy code, push DAGs, set up CI/CD, deploy to production, or asks about deployment strategies for Airflow.
 ---
 
 # Deploying Airflow
 
-This skill covers deploying Airflow DAGs and projects to production, whether using Astro (Astronomer's managed platform) or open-source Airflow on Docker Compose or Kubernetes.
-
-**Choosing a path:** Astro is a good fit for managed operations and faster CI/CD. For open-source, use Docker Compose for dev and the Helm chart for production.
+Astro for managed operations and faster CI/CD. Docker Compose for dev. Helm chart for production.
 
 ---
 
 ## Astro (Astronomer)
-
-Astro provides CLI commands and GitHub integration for deploying Airflow projects.
 
 ### Deploy Commands
 
@@ -26,41 +22,21 @@ Astro provides CLI commands and GitHub integration for deploying Airflow project
 
 ### Full Project Deploy
 
-Builds a Docker image from your Astro project and deploys everything (DAGs, plugins, requirements, packages):
-
 ```bash
+# Full project deploy (dependencies, plugins, or Dockerfile changed)
 astro deploy
-```
 
-Use this when you've changed `requirements.txt`, `Dockerfile`, `packages.txt`, plugins, or any non-DAG file.
-
-### DAG-Only Deploy
-
-Pushes only files in the `dags/` directory without rebuilding the Docker image:
-
-```bash
+# DAG-only deploy (only DAG files changed — faster, no image build)
 astro deploy --dags
-```
 
-This is significantly faster than a full deploy since it skips the image build. Use this when you've only changed DAG files and haven't modified dependencies or configuration.
-
-### Image-Only Deploy
-
-Pushes only the Docker image without updating DAGs:
-
-```bash
+# Image-only deploy (dependencies changed, no DAG changes)
 astro deploy --image
-```
 
-This is useful in multi-repo setups where DAGs are deployed separately from the image, or in CI/CD pipelines that manage image and DAG deploys independently.
-
-### dbt Project Deploy
-
-Deploys a dbt project to run with Cosmos on an Astro deployment:
-
-```bash
+# dbt project deploy (Cosmos)
 astro deploy --dbt
 ```
+
+**Verify:** `astro deployment inspect <DEPLOYMENT_ID>` — check status is HEALTHY and deployment timestamp updated.
 
 ### GitHub Integration
 
@@ -205,33 +181,16 @@ volumes:
 ### Common Operations
 
 ```bash
-# Start all services
-docker compose up -d
-
-# Stop all services
-docker compose down
-
-# View logs
-docker compose logs -f airflow-scheduler
-
-# Restart after requirements change
-docker compose down && docker compose up -d --build
-
-# Run a one-off Airflow CLI command
-docker compose exec airflow-apiserver airflow dags list
+docker compose up -d                                          # Start
+docker compose down                                           # Stop
+docker compose logs -f airflow-scheduler                      # View logs
+docker compose down && docker compose up -d --build           # Restart after requirements change
+docker compose exec airflow-apiserver airflow dags list        # Run CLI command
 ```
 
-### Installing Python Packages
+**Verify:** `curl http://localhost:8080/health` — should return healthy status.
 
-Add packages to `requirements.txt` and rebuild:
-
-```bash
-# Add to requirements.txt, then:
-docker compose down
-docker compose up -d --build
-```
-
-Or use a custom Dockerfile:
+### Custom Image and Dependencies
 
 ```dockerfile
 FROM apache/airflow:3  # Pin to a specific version (e.g., 3.1.7) for reproducibility
@@ -239,34 +198,9 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 ```
 
-Update `docker-compose.yaml` to build from the Dockerfile:
+Update `docker-compose.yaml` to use `build: { context: ., dockerfile: Dockerfile }` instead of `image:`.
 
-```yaml
-x-airflow-common: &airflow-common
-  build:
-    context: .
-    dockerfile: Dockerfile
-  # ... rest of config
-```
-
-### Environment Variables
-
-Configure Airflow settings via environment variables in `docker-compose.yaml`:
-
-```yaml
-environment:
-  # Core settings
-  AIRFLOW__CORE__EXECUTOR: LocalExecutor
-  AIRFLOW__CORE__PARALLELISM: 32
-  AIRFLOW__CORE__MAX_ACTIVE_TASKS_PER_DAG: 16
-
-  # Email
-  AIRFLOW__EMAIL__EMAIL_BACKEND: airflow.utils.email.send_email_smtp
-  AIRFLOW__SMTP__SMTP_HOST: smtp.example.com
-
-  # Connections (as URI)
-  AIRFLOW_CONN_MY_DB: postgresql://user:pass@host:5432/db
-```
+Configure Airflow via environment variables: `AIRFLOW__CORE__EXECUTOR`, `AIRFLOW__CORE__PARALLELISM`, `AIRFLOW_CONN_MY_DB=postgresql://user:pass@host:5432/db`.
 
 ---
 
@@ -413,21 +347,16 @@ helm upgrade airflow apache-airflow/airflow \
 2. **Persistent Volume**: Mount a shared PV containing DAGs
 3. **Baked into image**: Include DAGs in a custom Docker image
 
-### Useful Commands
+### Verify and Operate
 
 ```bash
-# Check pod status
-kubectl get pods -n airflow
-
-# View scheduler logs
-kubectl logs -f deployment/airflow-scheduler -n airflow
-
-# Port-forward the API server
-kubectl port-forward svc/airflow-apiserver 8080:8080 -n airflow
-
-# Run a one-off CLI command
-kubectl exec -it deployment/airflow-scheduler -n airflow -- airflow dags list
+kubectl get pods -n airflow                                                    # Check pod status
+kubectl logs -f deployment/airflow-scheduler -n airflow                        # View scheduler logs
+kubectl port-forward svc/airflow-apiserver 8080:8080 -n airflow                # Port-forward API server
+kubectl exec -it deployment/airflow-scheduler -n airflow -- airflow dags list  # Run CLI command
 ```
+
+**Verify after install/upgrade:** All pods should show `Running` status and `1/1` ready.
 
 ---
 

--- a/skills/managing-astro-deployments/skill.md
+++ b/skills/managing-astro-deployments/skill.md
@@ -1,11 +1,9 @@
 ---
 name: managing-astro-deployments
-description: Manage Astronomer production deployments with Astro CLI. Use when the user wants to authenticate, switch workspaces, create/update/delete deployments, or deploy code to production.
+description: Manage Astronomer production deployments with Astro CLI. Use when the user wants to authenticate, switch workspaces, create/update/delete deployments, deploy code to production, run astro deploy, astro login, manage deployment tokens, or promote code between staging and production environments.
 ---
 
 # Astro Deployment Management
-
-This skill helps you manage production Astronomer deployments using the Astro CLI.
 
 > **For local development**, see the **managing-astro-local-env** skill.
 > **For production troubleshooting**, see the **troubleshooting-astro-deployments** skill.
@@ -14,30 +12,18 @@ This skill helps you manage production Astronomer deployments using the Astro CL
 
 ## Authentication
 
-All deployment operations require authentication:
-
 ```bash
-# Login to Astronomer (opens browser for OAuth)
-astro login
+astro login                                  # Login (opens browser for OAuth)
 ```
-
-Authentication tokens are stored locally for subsequent commands. Run this before any deployment operations.
 
 ---
 
 ## Workspace Management
 
-Deployments are organized into workspaces:
-
 ```bash
-# List all accessible workspaces
-astro workspace list
-
-# Switch to a specific workspace
-astro workspace switch <WORKSPACE_ID>
+astro workspace list                         # List all accessible workspaces
+astro workspace switch <WORKSPACE_ID>        # Switch workspace (persists between sessions)
 ```
-
-Workspace context is maintained between sessions. Most deployment commands operate within the current workspace context.
 
 ---
 
@@ -56,19 +42,6 @@ astro deployment inspect <DEPLOYMENT_ID>
 # Inspect by name (alternative to ID)
 astro deployment inspect --deployment-name data-service-stg
 ```
-
-### What `inspect` Shows
-
-- Deployment status (HEALTHY, UNHEALTHY)
-- Runtime version and Airflow version
-- Executor type (CELERY, KUBERNETES, LOCAL)
-- Scheduler configuration (size, count)
-- Worker queue settings (min/max workers, concurrency, worker type)
-- Resource quotas (CPU, memory)
-- Environment variables
-- Last deployment timestamp and current tag
-- Webserver and API URLs
-- High availability status
 
 ---
 

--- a/skills/profiling-tables/SKILL.md
+++ b/skills/profiling-tables/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: profiling-tables
-description: Deep-dive data profiling for a specific table. Use when the user asks to profile a table, wants statistics about a dataset, asks about data quality, or needs to understand a table's structure and content. Requires a table name.
+description: Deep-dive data profiling for a specific table. Calculates null rates, analyzes value distributions, detects cardinality patterns, summarizes column statistics, and assesses data quality across completeness, uniqueness, and freshness. Use when the user asks to profile a table, wants statistics about a dataset, asks about data quality, or needs to understand a table's structure and content. Requires a table name.
 ---
 
 # Data Profile
 
 Generate a comprehensive profile of a table that a new team member could use to understand the data.
+
+> **Large tables (>10M rows):** Use `TABLESAMPLE` or add date filters to avoid query timeouts. Check row count first and adjust sampling accordingly.
 
 ## Step 1: Basic Metadata
 
@@ -84,47 +86,21 @@ ORDER BY frequency DESC
 LIMIT 20
 ```
 
-This reveals:
-- High-cardinality columns (likely IDs or unique values)
-- Low-cardinality columns (likely categories or status fields)
-- Skewed distributions (one value dominates)
-
 ## Step 5: Sample Data
 
-Get representative rows:
-
 ```sql
-SELECT *
-FROM <table>
-LIMIT 10
+SELECT * FROM <table> LIMIT 10
 ```
-
-If the table is large and you want variety, sample from different time periods or categories.
 
 ## Step 6: Data Quality Assessment
 
-Summarize quality across dimensions:
-
-### Completeness
-- Which columns have NULLs? What percentage?
-- Are NULLs expected or problematic?
-
-### Uniqueness
-- Does the apparent primary key have duplicates?
-- Are there unexpected duplicate rows?
-
-### Freshness
-- When was data last updated? (MAX of timestamp columns)
-- Is the update frequency as expected?
-
-### Validity
-- Are there values outside expected ranges?
-- Are there invalid formats (dates, emails, etc.)?
-- Are there orphaned foreign keys?
-
-### Consistency
-- Do related columns make sense together?
-- Are there logical contradictions?
+| Dimension | Check |
+|-----------|-------|
+| Completeness | NULL percentages per column — expected vs problematic? |
+| Uniqueness | Primary key duplicates? Unexpected duplicate rows? |
+| Freshness | MAX of timestamp columns — update frequency as expected? |
+| Validity | Values outside expected ranges? Invalid formats? Orphaned foreign keys? |
+| Consistency | Related columns make sense together? Logical contradictions? |
 
 ## Step 7: Output Summary
 

--- a/skills/setting-up-astro-project/SKILL.md
+++ b/skills/setting-up-astro-project/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: setting-up-astro-project
-description: Initialize and configure Astro/Airflow projects. Use when the user wants to create a new project, set up dependencies, configure connections/variables, or understand project structure. For running the local environment, see managing-astro-local-env.
+description: Initialize and configure Astro/Airflow projects. Create project scaffolding with astro dev init, add Python dependencies, configure Airflow connections and variables, and set up Dockerfile customizations. Use when the user wants to create a new project, set up dependencies, configure connections/variables, or understand project structure. For running the local environment, see managing-astro-local-env.
 ---
 
 # Astro Project Setup
-
-This skill helps you initialize and configure Airflow projects using the Astro CLI.
 
 > **To run the local environment**, see the **managing-astro-local-env** skill.
 > **To write DAGs**, see the **authoring-dags** skill.
@@ -61,7 +59,7 @@ FROM quay.io/astronomer/astro-runtime:12.4.0
 RUN pip install --extra-index-url https://pypi.example.com/simple my-package
 ```
 
-**After modifying dependencies:** Run `astro dev restart`
+**After modifying dependencies:** Run `astro dev restart`, then verify with `astro dev parse`.
 
 ---
 
@@ -103,12 +101,12 @@ astro dev object import --connections --file connections.yaml
 
 ---
 
-## Validate Before Running
-
-Parse DAGs to catch errors without starting the full environment:
+## Validate Setup
 
 ```bash
-astro dev parse
+astro dev parse                                                 # Parse DAGs — catch errors without starting
+astro dev run airflow connections list                           # Verify connections loaded from airflow_settings.yaml
+astro dev run airflow variables list                             # Verify variables loaded
 ```
 
 ---

--- a/skills/testing-dags/SKILL.md
+++ b/skills/testing-dags/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing-dags
-description: Complex DAG testing workflows with debugging and fixing cycles. Use for multi-step testing requests like "test this dag and fix it if it fails", "test and debug", "run the pipeline and troubleshoot issues". For simple test requests ("test dag", "run dag"), the airflow entrypoint skill handles it directly. This skill is for iterative test-debug-fix cycles.
+description: Complex DAG testing workflows with debugging and fixing cycles. Triggers DAG runs, analyzes task failures, retrieves error logs, identifies root causes, and applies fixes in iterative test-debug-fix cycles. Use for multi-step testing requests like "test this dag and fix it if it fails", "test and debug", "run the pipeline and troubleshoot issues". For simple test requests ("test dag", "run dag"), the airflow entrypoint skill handles it directly.
 ---
 
 # DAG Testing Skill
@@ -37,20 +37,13 @@ Use these for quick validation during development. For full end-to-end testing a
 
 ## FIRST ACTION: Just Trigger the DAG
 
-When the user asks to test a DAG, your **FIRST AND ONLY action** should be:
+When the user asks to test a DAG, **immediately run:**
 
 ```bash
 af runs trigger-wait <dag_id>
 ```
 
-**DO NOT:**
-- Call `af dags list` first
-- Call `af dags get` first
-- Call `af dags errors` first
-- Use `grep` or `ls` or any other bash command
-- Do any "pre-flight checks"
-
-**Just trigger the DAG.** If it fails, THEN debug.
+No pre-flight checks — just trigger. If it fails, THEN debug.
 
 ---
 

--- a/skills/tracing-downstream-lineage/SKILL.md
+++ b/skills/tracing-downstream-lineage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tracing-downstream-lineage
-description: Trace downstream data lineage and impact analysis. Use when the user asks what depends on this data, what breaks if something changes, downstream dependencies, or needs to assess change risk before modifying a table or DAG.
+description: Trace downstream data lineage, map dependency graphs, identify affected pipelines, and generate impact reports with criticality assessments. Use when the user asks what depends on this data, what breaks if something changes, downstream dependencies, or needs to assess change risk before modifying a table or DAG.
 ---
 
 # Downstream Lineage: Impacts

--- a/skills/tracing-upstream-lineage/SKILL.md
+++ b/skills/tracing-upstream-lineage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tracing-upstream-lineage
-description: Trace upstream data lineage. Use when the user asks where data comes from, what feeds a table, upstream dependencies, data sources, or needs to understand data origins.
+description: Trace upstream data lineage, identify source systems, map data transformations, and document table dependencies. Use when the user asks where data comes from, what feeds a table, upstream dependencies, data sources, or needs to understand data origins.
 ---
 
 # Upstream Lineage: Sources

--- a/skills/troubleshooting-astro-deployments/skill.md
+++ b/skills/troubleshooting-astro-deployments/skill.md
@@ -1,11 +1,9 @@
 ---
 name: troubleshooting-astro-deployments
-description: Troubleshoot Astronomer production deployments with Astro CLI. Use when investigating deployment issues, viewing production logs, analyzing failures, or managing deployment environment variables.
+description: Troubleshoot Astronomer production deployments with Astro CLI. Stream pod logs, check deployment health status, diagnose scheduler and worker failures, and manage environment variables. Use when investigating deployment issues, viewing production logs, analyzing failures, or managing deployment environment variables.
 ---
 
 # Astro Deployment Troubleshooting
-
-This skill helps you diagnose and troubleshoot production Astronomer deployments using the Astro CLI.
 
 > **For deployment management**, see the **managing-astro-deployments** skill.
 > **For local development**, see the **managing-astro-local-env** skill.

--- a/skills/warehouse-init/SKILL.md
+++ b/skills/warehouse-init/SKILL.md
@@ -1,21 +1,15 @@
 ---
 name: warehouse-init
-description: Initialize warehouse schema discovery. Generates .astro/warehouse.md with all table metadata for instant lookups. Run once per project, refresh when schema changes. Use when user says "/data:warehouse-init" or asks to set up data discovery.
+description: Initialize warehouse schema discovery. Generates .astro/warehouse.md with all table metadata for instant lookups. Run once per project, refresh when schema changes. Use when user says "/data:warehouse-init", asks to set up data discovery, wants to catalog tables, scan database schema, list all tables, or discover database structure.
 ---
 
 # Initialize Warehouse Schema
 
 Generate a comprehensive, user-editable schema reference file for the data warehouse.
 
-**Scripts:** `../analyzing-data/scripts/` — All CLI commands below are relative to the `analyzing-data` skill's directory. Before running any `scripts/cli.py` command, `cd` to `../analyzing-data/` relative to this file.
+**Scripts:** All CLI commands below use `../analyzing-data/scripts/` — `cd` to `../analyzing-data/` relative to this file before running.
 
-## What This Does
-
-1. Discovers all databases, schemas, tables, and columns from the warehouse
-2. **Enriches with codebase context** (dbt models, gusty SQL, schema docs)
-3. Records row counts and identifies large tables
-4. Generates `.astro/warehouse.md` - a version-controllable, team-shareable reference
-5. Enables instant concept→table lookups without warehouse queries
+Discovers databases, schemas, tables, and columns. Enriches with codebase context (dbt models, gusty SQL, schema docs). Generates `.astro/warehouse.md` for instant concept→table lookups.
 
 ## Process
 
@@ -65,7 +59,6 @@ For each database in configured_databases:
         Discover all metadata for database {DATABASE}.
 
         Use the CLI to run SQL queries:
-        # Scripts are relative to ../analyzing-data/
         uv run scripts/cli.py exec "df = run_sql('...')"
         uv run scripts/cli.py exec "print(df)"
 
@@ -198,7 +191,6 @@ Query downstream first: `reporting` > `mart_*` > `metric_*` > `model_*` > `IN_*`
 After generating warehouse.md, populate the concept cache:
 
 ```bash
-# Scripts are relative to ../analyzing-data/
 uv run cli.py concept import -p .astro/warehouse.md
 uv run cli.py concept learn customers HQ.MART_CUST.CURRENT_ASTRO_CUSTS -k ACCT_ID
 ```
@@ -291,7 +283,6 @@ Watch for these indicators:
 If you suspect cache issues:
 
 ```bash
-# Scripts are relative to ../analyzing-data/
 uv run scripts/cli.py cache status
 uv run scripts/cli.py cache clear --stale-only
 uv run scripts/cli.py cache clear


### PR DESCRIPTION
Hullo @schnie 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. These are the ten most improved:

<img width="1312" height="1290" alt="score_card" src="https://github.com/user-attachments/assets/872081c3-ce18-4b67-8e88-889c225cbe59" />

Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| deploying-airflow | 77% | 100% | +23% |
| profiling-tables | 77% | 94% | +17% |
| managing-astro-deployments | 85% | 100% | +15% | 
| setting-up-astro-project | 89% | 100% | +11% |
| warehouse-init | 81% | 89% | +8% |
| airflow-adapter | 81% | 89% | +8% |
| annotating-task-lineage | 86% | 93% | +7% |
| creating-openlineage-extractors | 86% | 93% | +7% | 
| tracing-downstream-lineage | 88% | 93% | +5% |
| troubleshooting-astro-deployments | 88% | 93% | +5% | 
| testing-dags | 84% | 89% | +5% |

Skills already at 90%+ were left untouched — they're excellent as-is.

<details>
<summary>Changes made</summary>

**Description improvements (all changed skills)**
- Expanded frontmatter descriptions with specific concrete actions (e.g., "Configure deployment pipelines, manage DAG-only and full image deploys")
- Added natural trigger term variations users would actually say (e.g., "astro deploy", "catalog tables", "scan database schema")

**deploying-airflow (+23%)**
- Consolidated verbose deploy command explanations into compact, scannable format
- Added verification steps after each deployment method (`astro deployment inspect`, `curl health`, `kubectl get pods`)
- Trimmed explanatory prose Claude doesn't need

**profiling-tables (+17%)**
- Added large table warning with TABLESAMPLE guidance upfront
- Consolidated data quality dimensions from prose into a compact reference table
- Trimmed "This reveals:" explanatory bullets

**managing-astro-deployments (+15%)**
- Removed intro prose and "What inspect Shows" section (discoverable via `--help`)
- Condensed auth and workspace sections into compact command blocks

**setting-up-astro-project (+11%)**
- Added explicit validation steps (`astro dev run airflow connections list`, `variables list`)
- Removed intro prose, added verify-after-restart guidance

**warehouse-init (+8%)**
- Removed redundant "Scripts are relative to" comments after first mention
- Condensed "What This Does" section into a single-line summary

**airflow-adapter (+8%)**
- Added concrete 3-step workflow for adding new API methods with code examples

**annotating-task-lineage & creating-openlineage-extractors (+7% each)**
- Added verification sections with steps to confirm lineage appears correctly
- Condensed "On Astro" marketing into a single-line note

**testing-dags, tracing-downstream-lineage, troubleshooting-astro-deployments (+5% each)**
- Tightened verbose instruction blocks
- Removed intro prose that restated the skill title

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@popey](https://github.com/popey) - if you hit any snags.

Thanks in advance 🙏