### PR TITLE
feat: add Astro CLI reverse proxy discovery for local Airflow

### DIFF
--- a/astro-airflow-mcp/src/astro_airflow_mcp/__main__.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/__main__.py
@@ -5,56 +5,52 @@ import logging
 import os
 from pathlib import Path
 
-import yaml
-
+from astro_airflow_mcp.constants import DEFAULT_AIRFLOW_URL
 from astro_airflow_mcp.logging import configure_logging, get_logger
 from astro_airflow_mcp.server import configure, mcp
 
 logger = get_logger("main")
 
-# Default Airflow URL if no config is found
-DEFAULT_AIRFLOW_URL = "http://localhost:8080"
 
+def discover_airflow_url(
+    project_dir: str | None,
+    proxy_routes_path: Path | None = None,
+    proxy_global_config_path: Path | None = None,
+) -> tuple[str, bool] | None:
+    """Discover Airflow URL, checking proxy routes first then .astro/config.yaml.
 
-def discover_airflow_url(project_dir: str | None) -> str | None:
-    """Discover Airflow URL from .astro/config.yaml in the project directory.
-
-    Looks for the Astro CLI config file and extracts the webserver/api-server port.
-    Prefers api-server.port (Airflow 3.x) over webserver.port (Airflow 2.x).
+    Discovery priority:
+    1. Proxy routes.json match by project directory (Astro CLI reverse proxy)
+    2. .astro/config.yaml port (Airflow 3.x api-server.port, then 2.x webserver.port)
 
     Args:
         project_dir: The project directory to search in
+        proxy_routes_path: Path to proxy routes.json (for testing)
+        proxy_global_config_path: Path to global astro config (for testing)
 
     Returns:
-        The discovered Airflow URL (e.g., "http://localhost:8081"), or None if not found
+        Tuple of (url, is_proxy) if found, None otherwise
     """
     if not project_dir:
         return None
 
-    config_path = Path(project_dir) / ".astro" / "config.yaml"
-    if not config_path.exists():
-        return None
+    from astro_airflow_mcp.discovery.local import LocalDiscoveryBackend
 
-    try:
-        with open(config_path) as f:
-            config = yaml.safe_load(f)
+    backend = LocalDiscoveryBackend()
 
-        if not config:
-            return None
+    # Step 1: Check proxy routes for a matching project directory
+    proxy_url = backend.find_proxy_url_for_project(
+        project_dir,
+        routes_path=proxy_routes_path,
+        global_config_path=proxy_global_config_path,
+    )
+    if proxy_url:
+        return (proxy_url, True)
 
-        # Try api-server.port first (Airflow 3.x), then webserver.port (Airflow 2.x)
-        port = None
-        if "api-server" in config and isinstance(config["api-server"], dict):
-            port = config["api-server"].get("port")
-        if port is None and "webserver" in config and isinstance(config["webserver"], dict):
-            port = config["webserver"].get("port")
-
-        if port:
-            return f"http://localhost:{port}"
-
-    except Exception as e:
-        # Log but don't fail - we'll fall back to default
-        logger.debug("Failed to read .astro/config.yaml: %s", e)
+    # Step 2: Check .astro/config.yaml for port
+    port = backend.get_astro_project_port(project_dir=Path(project_dir))
+    if port:
+        return (f"http://localhost:{port}", False)
 
     return None
 
@@ -147,10 +143,11 @@ def main():
     airflow_url = args.airflow_url
     url_source = "explicit"
     if not airflow_url:
-        # Try auto-discovery from .astro/config.yaml
-        airflow_url = discover_airflow_url(args.airflow_project_dir)
-        if airflow_url:
-            url_source = "auto-discovered"
+        # Try auto-discovery: proxy routes → .astro/config.yaml → default
+        result = discover_airflow_url(args.airflow_project_dir)
+        if result:
+            airflow_url, is_proxy = result
+            url_source = "auto-discovered (proxy)" if is_proxy else "auto-discovered"
         else:
             airflow_url = DEFAULT_AIRFLOW_URL
             url_source = "default"

--- a/astro-airflow-mcp/src/astro_airflow_mcp/constants.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/constants.py
@@ -1,5 +1,8 @@
 """Shared constants for CLI and MCP server."""
 
+import os
+from pathlib import Path
+
 # Terminal states for DAG runs (polling stops when reached)
 TERMINAL_DAG_RUN_STATES = {"success", "failed", "upstream_failed"}
 
@@ -15,3 +18,21 @@ DEFAULT_AIRFLOW_URL = "http://localhost:8080"
 
 # Read-only mode environment variable
 READ_ONLY_ENV_VAR = "AF_READ_ONLY"
+
+# Astro CLI reverse proxy defaults
+DEFAULT_PROXY_PORT = 6563
+
+
+def get_astro_home() -> Path:
+    """Return the Astro CLI home directory, respecting ASTRO_HOME env var."""
+    return Path(os.environ.get("ASTRO_HOME", Path.home() / ".astro")).expanduser()
+
+
+def get_proxy_routes_path() -> Path:
+    """Return the path to the proxy routes.json file."""
+    return get_astro_home() / "proxy" / "routes.json"
+
+
+def get_astro_global_config_path() -> Path:
+    """Return the path to the global Astro CLI config.yaml."""
+    return get_astro_home() / "config.yaml"

--- a/astro-airflow-mcp/src/astro_airflow_mcp/discovery/local.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/discovery/local.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import socket
 from pathlib import Path
 from typing import Any
@@ -10,6 +11,11 @@ from typing import Any
 import httpx
 import yaml
 
+from astro_airflow_mcp.constants import (
+    DEFAULT_PROXY_PORT,
+    get_astro_global_config_path,
+    get_proxy_routes_path,
+)
 from astro_airflow_mcp.discovery.base import DiscoveredInstance, DiscoveryError
 
 
@@ -57,7 +63,7 @@ class LocalDiscoveryBackend:
         """Local discovery is always available."""
         return True
 
-    def _get_astro_project_port(self, project_dir: Path | None = None) -> int | None:
+    def get_astro_project_port(self, project_dir: Path | None = None) -> int | None:
         """Check for .astro/config.yaml and extract the configured port.
 
         Looks for:
@@ -96,35 +102,147 @@ class LocalDiscoveryBackend:
         except (OSError, yaml.YAMLError, ValueError, TypeError):
             return None
 
+    def _get_proxy_port(self, global_config_path: Path | None = None) -> int:
+        """Read the proxy port from the global Astro CLI config.
+
+        Args:
+            global_config_path: Path to ~/.astro/config.yaml (for testing)
+
+        Returns:
+            Proxy port number (default: DEFAULT_PROXY_PORT)
+        """
+        if global_config_path is None:
+            global_config_path = get_astro_global_config_path()
+
+        try:
+            with open(global_config_path) as f:
+                config = yaml.safe_load(f)
+            if (
+                config
+                and "proxy" in config
+                and isinstance(config["proxy"], dict)
+                and (port := config["proxy"].get("port")) is not None
+            ):
+                return int(port)
+        except (OSError, yaml.YAMLError, ValueError, TypeError):
+            pass
+
+        return DEFAULT_PROXY_PORT
+
+    def _read_proxy_routes(self, routes_path: Path | None = None) -> list[dict]:
+        """Read proxy routes from ~/.astro/proxy/routes.json.
+
+        Args:
+            routes_path: Path to routes.json (for testing)
+
+        Returns:
+            List of route dicts, or empty list if unavailable
+        """
+        if routes_path is None:
+            routes_path = get_proxy_routes_path()
+
+        try:
+            with open(routes_path) as f:
+                data = json.load(f)
+            if isinstance(data, list):
+                return data
+        except (OSError, json.JSONDecodeError, TypeError):
+            pass
+
+        return []
+
+    def find_proxy_url_for_project(
+        self,
+        project_dir: str,
+        routes_path: Path | None = None,
+        global_config_path: Path | None = None,
+    ) -> str | None:
+        """Find the proxy URL for a specific project directory.
+
+        Args:
+            project_dir: The project directory to match
+            routes_path: Path to routes.json (for testing)
+            global_config_path: Path to global astro config (for testing)
+
+        Returns:
+            Proxy URL if a matching route is found, None otherwise
+        """
+        routes = self._read_proxy_routes(routes_path=routes_path)
+        if not routes:
+            return None
+
+        project_path = str(Path(project_dir).resolve())
+        for route in routes:
+            if not (route_dir := route.get("projectDir")):
+                continue
+            if str(Path(route_dir).resolve()) != project_path:
+                continue
+            if not (hostname := route.get("hostname")):
+                continue
+            proxy_port = self._get_proxy_port(global_config_path=global_config_path)
+            return f"http://{hostname}:{proxy_port}"
+
+        return None
+
     def discover(
         self,
         ports: list[int] | None = None,
         hosts: list[str] | None = None,
         timeout: float | None = None,
+        proxy_routes_path: Path | None = None,
+        proxy_global_config_path: Path | None = None,
         **kwargs: Any,
     ) -> list[DiscoveredInstance]:
-        """Discover local Airflow instances by scanning ports.
+        """Discover local Airflow instances.
 
-        First checks for .astro/config.yaml in the current directory to find
-        the configured port. Falls back to scanning common ports if not found.
+        Checks proxy routes first (for Astro CLI reverse proxy), then falls
+        back to scanning ports for running Airflow instances.
 
         Args:
             ports: Ports to scan (default: check .astro/config.yaml, then common ports)
             hosts: Hosts to scan (default: localhost, 127.0.0.1)
             timeout: Connection timeout in seconds
+            proxy_routes_path: Path to proxy routes.json (for testing)
+            proxy_global_config_path: Path to global astro config (for testing)
             **kwargs: Additional options (ignored)
 
         Returns:
-            List of discovered instances
+            List of discovered instances (proxy routes first, then port-scanned)
         """
         if timeout is None:
             timeout = self.DEFAULT_HTTP_TIMEOUT
 
+        instances: list[DiscoveredInstance] = []
+
+        # Step 1: Check proxy routes (Astro CLI reverse proxy)
+        if proxy_routes := self._read_proxy_routes(routes_path=proxy_routes_path):
+            proxy_port = self._get_proxy_port(global_config_path=proxy_global_config_path)
+            for route in proxy_routes:
+                if not (hostname := route.get("hostname")):
+                    continue
+                proxy_url = f"http://{hostname}:{proxy_port}"
+                instance_name = f"{hostname}:{proxy_port}"
+                instances.append(
+                    DiscoveredInstance(
+                        name=instance_name,
+                        url=proxy_url,
+                        source=self.name,
+                        auth_token=None,
+                        metadata={
+                            "proxy": True,
+                            "project_dir": route.get("projectDir", ""),
+                            "mode": route.get("mode", ""),
+                            "backend_port": route.get("port", ""),
+                        },
+                    )
+                )
+
+        # Step 2: Port scanning
         # Build port list: check .astro/config.yaml first, then fallback to defaults
         if ports:
             scan_ports = ports
         else:
-            astro_port = self._get_astro_project_port()
+            astro_port = self.get_astro_project_port()
             if astro_port:
                 # Prioritize Astro project port, then check other common ports
                 scan_ports = [astro_port] + [p for p in self.DEFAULT_PORTS if p != astro_port]
@@ -133,7 +251,6 @@ class LocalDiscoveryBackend:
 
         scan_hosts = hosts if hosts else self.DEFAULT_HOSTS
 
-        instances: list[DiscoveredInstance] = []
         seen_urls: set[str] = set()
 
         for host in scan_hosts:

--- a/astro-airflow-mcp/tests/test_discovery.py
+++ b/astro-airflow-mcp/tests/test_discovery.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -457,7 +459,7 @@ class TestLocalDiscoveryBackend:
         backend = LocalDiscoveryBackend()
 
         with patch.object(backend, "_is_port_open", return_value=False):
-            instances = backend.discover(ports=[8080])
+            instances = backend.discover(ports=[8080], proxy_routes_path=Path("/nonexistent"))
 
         assert instances == []
 
@@ -473,7 +475,9 @@ class TestLocalDiscoveryBackend:
                 return_value={"detected_from": "/api/v1/health", "api_version": "v1"},
             ),
         ):
-            instances = backend.discover(ports=[8080], hosts=["localhost"])
+            instances = backend.discover(
+                ports=[8080], hosts=["localhost"], proxy_routes_path=Path("/nonexistent")
+            )
 
         assert len(instances) == 1
         assert instances[0].name == "localhost:8080"
@@ -493,7 +497,11 @@ class TestLocalDiscoveryBackend:
                 return_value={"detected_from": "/api/v1/health"},
             ),
         ):
-            instances = backend.discover(ports=[8080], hosts=["localhost", "127.0.0.1"])
+            instances = backend.discover(
+                ports=[8080],
+                hosts=["localhost", "127.0.0.1"],
+                proxy_routes_path=Path("/nonexistent"),
+            )
 
         # Should only return one instance (deduplicated)
         assert len(instances) == 1
@@ -635,56 +643,294 @@ class TestLocalDiscoveryBackend:
         assert result is None
 
     def test_get_astro_project_port_webserver(self, tmp_path):
-        """Test _get_astro_project_port reads webserver.port (Airflow 2)."""
+        """Test get_astro_project_port reads webserver.port (Airflow 2)."""
         astro_dir = tmp_path / ".astro"
         astro_dir.mkdir()
         config_file = astro_dir / "config.yaml"
         config_file.write_text("webserver:\n  port: 8081\n")
 
         backend = LocalDiscoveryBackend()
-        port = backend._get_astro_project_port(tmp_path)
+        port = backend.get_astro_project_port(tmp_path)
 
         assert port == 8081
 
     def test_get_astro_project_port_api_server(self, tmp_path):
-        """Test _get_astro_project_port reads api-server.port (Airflow 3)."""
+        """Test get_astro_project_port reads api-server.port (Airflow 3)."""
         astro_dir = tmp_path / ".astro"
         astro_dir.mkdir()
         config_file = astro_dir / "config.yaml"
         config_file.write_text("api-server:\n  port: 8082\n")
 
         backend = LocalDiscoveryBackend()
-        port = backend._get_astro_project_port(tmp_path)
+        port = backend.get_astro_project_port(tmp_path)
 
         assert port == 8082
 
     def test_get_astro_project_port_prefers_api_server(self, tmp_path):
-        """Test _get_astro_project_port prefers api-server over webserver."""
+        """Test get_astro_project_port prefers api-server over webserver."""
         astro_dir = tmp_path / ".astro"
         astro_dir.mkdir()
         config_file = astro_dir / "config.yaml"
         config_file.write_text("api-server:\n  port: 8082\nwebserver:\n  port: 8081\n")
 
         backend = LocalDiscoveryBackend()
-        port = backend._get_astro_project_port(tmp_path)
+        port = backend.get_astro_project_port(tmp_path)
 
         assert port == 8082
 
     def test_get_astro_project_port_no_config(self, tmp_path):
-        """Test _get_astro_project_port returns None when no config."""
+        """Test get_astro_project_port returns None when no config."""
         backend = LocalDiscoveryBackend()
-        port = backend._get_astro_project_port(tmp_path)
+        port = backend.get_astro_project_port(tmp_path)
 
         assert port is None
 
     def test_get_astro_project_port_no_port_in_config(self, tmp_path):
-        """Test _get_astro_project_port returns None when no port in config."""
+        """Test get_astro_project_port returns None when no port in config."""
         astro_dir = tmp_path / ".astro"
         astro_dir.mkdir()
         config_file = astro_dir / "config.yaml"
         config_file.write_text("project:\n  name: test\n")
 
         backend = LocalDiscoveryBackend()
-        port = backend._get_astro_project_port(tmp_path)
+        port = backend.get_astro_project_port(tmp_path)
 
         assert port is None
+
+
+@pytest.fixture
+def sample_proxy_route():
+    """A sample proxy route entry from routes.json."""
+    return {
+        "hostname": "myproject.sirius.localhost",
+        "port": "8080",
+        "projectDir": "/projects/myproject",
+        "pid": 0,
+        "mode": "docker",
+    }
+
+
+@pytest.fixture
+def proxy_env(tmp_path):
+    """Set up proxy routes.json and global config for testing."""
+    routes_file = tmp_path / "routes.json"
+    global_config = tmp_path / "config.yaml"
+    global_config.write_text("")
+    return routes_file, global_config
+
+
+class TestLocalDiscoveryProxyRoutes:
+    """Tests for proxy route discovery in LocalDiscoveryBackend."""
+
+    def test_get_proxy_port_default(self):
+        """Returns default port when config doesn't exist."""
+        backend = LocalDiscoveryBackend()
+        assert backend._get_proxy_port(global_config_path=Path("/nonexistent")) == 6563
+
+    def test_get_proxy_port_from_config(self, tmp_path):
+        """Reads proxy.port from global config."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("proxy:\n  port: 7000\n")
+
+        backend = LocalDiscoveryBackend()
+        assert backend._get_proxy_port(global_config_path=config_file) == 7000
+
+    def test_read_proxy_routes_no_file(self):
+        """Returns empty list when routes.json doesn't exist."""
+        backend = LocalDiscoveryBackend()
+        assert backend._read_proxy_routes(routes_path=Path("/nonexistent")) == []
+
+    def test_read_proxy_routes_valid(self, tmp_path, sample_proxy_route):
+        """Reads valid routes.json."""
+        routes_file = tmp_path / "routes.json"
+        routes_file.write_text(json.dumps([sample_proxy_route]))
+
+        backend = LocalDiscoveryBackend()
+        routes = backend._read_proxy_routes(routes_path=routes_file)
+        assert len(routes) == 1
+        assert routes[0]["hostname"] == "myproject.sirius.localhost"
+
+    def test_read_proxy_routes_invalid_json(self, tmp_path):
+        """Returns empty list for malformed JSON."""
+        routes_file = tmp_path / "routes.json"
+        routes_file.write_text("not json")
+
+        backend = LocalDiscoveryBackend()
+        assert backend._read_proxy_routes(routes_path=routes_file) == []
+
+    @pytest.mark.parametrize(
+        argnames=("config_yaml", "hostname", "expected_url"),
+        argvalues=[
+            pytest.param(
+                "",
+                "myproject.sirius.localhost",
+                "http://myproject.sirius.localhost:6563",
+                id="default-port",
+            ),
+            pytest.param(
+                "proxy:\n  port: 7000\n",
+                "alpha.sirius.localhost",
+                "http://alpha.sirius.localhost:7000",
+                id="custom-port",
+            ),
+        ],
+    )
+    def test_discover_yields_proxy_routes(
+        self,
+        proxy_env,
+        sample_proxy_route,
+        config_yaml,
+        hostname,
+        expected_url,
+    ):
+        """discover() yields proxy instances with correct URL and metadata."""
+        routes_file, global_config = proxy_env
+        routes_file.write_text(json.dumps([{**sample_proxy_route, "hostname": hostname}]))
+        global_config.write_text(config_yaml)
+
+        backend = LocalDiscoveryBackend()
+        with patch.object(backend, "_is_port_open", return_value=False):
+            instances = backend.discover(
+                ports=[8080],
+                proxy_routes_path=routes_file,
+                proxy_global_config_path=global_config,
+            )
+
+        assert len(instances) == 1
+        assert instances[0].url == expected_url
+        assert instances[0].source == "local"
+        assert instances[0].metadata["proxy"] is True
+
+    def test_discover_no_proxy_falls_through(self):
+        """discover() falls through to port scan when no proxy routes."""
+        backend = LocalDiscoveryBackend()
+
+        with (
+            patch.object(backend, "_is_port_open", return_value=True),
+            patch.object(
+                backend,
+                "_detect_airflow",
+                return_value={"detected_from": "/api/v1/health", "api_version": "v1"},
+            ),
+        ):
+            instances = backend.discover(
+                ports=[8080],
+                hosts=["localhost"],
+                proxy_routes_path=Path("/nonexistent"),
+            )
+
+        assert len(instances) == 1
+        assert instances[0].url == "http://localhost:8080"
+        assert "proxy" not in instances[0].metadata
+
+    def test_discover_proxy_and_port_scan_coexist(self, proxy_env, sample_proxy_route):
+        """Proxy and port-scanned instances are both returned."""
+        routes_file, global_config = proxy_env
+        routes_file.write_text(json.dumps([sample_proxy_route]))
+
+        backend = LocalDiscoveryBackend()
+
+        with (
+            patch.object(backend, "_is_port_open", return_value=True),
+            patch.object(
+                backend,
+                "_detect_airflow",
+                return_value={"detected_from": "/api/v1/health", "api_version": "v1"},
+            ),
+        ):
+            instances = backend.discover(
+                ports=[8080],
+                hosts=["localhost"],
+                proxy_routes_path=routes_file,
+                proxy_global_config_path=global_config,
+            )
+
+        proxy_instances = [i for i in instances if i.metadata.get("proxy")]
+        port_scan_instances = [i for i in instances if not i.metadata.get("proxy")]
+        assert len(proxy_instances) == 1
+        assert len(port_scan_instances) == 1
+
+
+class TestDiscoverAirflowUrl:
+    """Tests for discover_airflow_url() in __main__.py."""
+
+    @pytest.mark.parametrize(
+        argnames=("config_yaml", "hostname", "expected_url"),
+        argvalues=[
+            pytest.param(
+                "",
+                "myproject.sirius.localhost",
+                "http://myproject.sirius.localhost:6563",
+                id="default-port",
+            ),
+            pytest.param(
+                "proxy:\n  port: 7000\n",
+                "alpha.sirius.localhost",
+                "http://alpha.sirius.localhost:7000",
+                id="custom-port",
+            ),
+        ],
+    )
+    def test_proxy_route_match(
+        self,
+        tmp_path,
+        sample_proxy_route,
+        config_yaml,
+        hostname,
+        expected_url,
+    ):
+        """Returns proxy URL with is_proxy=True when route matches project dir."""
+        from astro_airflow_mcp.__main__ import discover_airflow_url
+
+        routes_file = tmp_path / "routes.json"
+        routes_file.write_text(
+            json.dumps(
+                [
+                    {**sample_proxy_route, "hostname": hostname, "projectDir": str(tmp_path)},
+                ]
+            )
+        )
+        global_config = tmp_path / "config.yaml"
+        global_config.write_text(config_yaml)
+
+        result = discover_airflow_url(
+            str(tmp_path),
+            proxy_routes_path=routes_file,
+            proxy_global_config_path=global_config,
+        )
+        assert result == (expected_url, True)
+
+    @pytest.mark.parametrize(
+        argnames=("routes_json", "routes_exist"),
+        argvalues=[
+            pytest.param('[{"hostname": "other", "projectDir": "/other"}]', True, id="no-match"),
+            pytest.param(None, False, id="no-file"),
+        ],
+    )
+    def test_falls_through_to_astro_config(
+        self,
+        tmp_path,
+        routes_json,
+        routes_exist,
+    ):
+        """Falls through to .astro/config.yaml when proxy doesn't match."""
+        from astro_airflow_mcp.__main__ import discover_airflow_url
+
+        astro_dir = tmp_path / ".astro"
+        astro_dir.mkdir()
+        (astro_dir / "config.yaml").write_text("webserver:\n  port: 8081\n")
+
+        if routes_exist:
+            routes_file = tmp_path / "routes.json"
+            routes_file.write_text(routes_json)
+        else:
+            routes_file = Path("/nonexistent/routes.json")
+
+        result = discover_airflow_url(str(tmp_path), proxy_routes_path=routes_file)
+        assert result == ("http://localhost:8081", False)
+
+    def test_no_project_dir_returns_none(self):
+        """Returns None when no project dir is given."""
+        from astro_airflow_mcp.__main__ import discover_airflow_url
+
+        assert discover_airflow_url(None) is None


### PR DESCRIPTION
## Summary
- Adds reverse proxy route discovery to `LocalDiscoveryBackend`, checking `~/.astro/proxy/routes.json` and global config for proxy port before falling back to port scanning
- Introduces helper functions in `constants.py` for resolving `ASTRO_HOME`, proxy routes path, and global config path
- Refactors `discover_airflow_url` in `__main__.py` to return proxy-matched URLs with source indication
- Adds comprehensive tests for proxy discovery, port fallback, and coexistence scenarios

## Test plan
- [x] Unit tests for proxy port reading (default and custom)
- [x] Unit tests for missing/invalid `routes.json` handling
- [x] Tests for proxy + port-scan coexistence
- [x] Tests for `discover_airflow_url` proxy match and fallthrough paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)