### PR TITLE
Fix: remove upstream_failed from TERMINAL_DAG_RUN_STATES

### DIFF
--- a/astro-airflow-mcp/src/astro_airflow_mcp/constants.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/constants.py
@@ -1,7 +1,7 @@
 """Shared constants for CLI and MCP server."""
 
 # Terminal states for DAG runs (polling stops when reached)
-TERMINAL_DAG_RUN_STATES = {"success", "failed", "upstream_failed"}
+TERMINAL_DAG_RUN_STATES = {"success", "failed"}
 
 # Task states considered as failures
 FAILED_TASK_STATES = {"failed", "upstream_failed"}

--- a/astro-airflow-mcp/tests/test_utils.py
+++ b/astro-airflow-mcp/tests/test_utils.py
@@ -19,7 +19,7 @@ class TestConstants:
 
     def test_terminal_dag_run_states(self):
         """Test terminal DAG run states are defined correctly."""
-        assert {"success", "failed", "upstream_failed"} == TERMINAL_DAG_RUN_STATES
+        assert {"success", "failed"} == TERMINAL_DAG_RUN_STATES
 
     def test_failed_task_states(self):
         """Test failed task states are defined correctly."""


### PR DESCRIPTION
## Summary

- Removed `upstream_failed` from `TERMINAL_DAG_RUN_STATES` in `constants.py`
- Updated the corresponding assertion in `test_utils.py`

## Why

`upstream_failed` is a **task instance** state, not a DAG run state. DAG runs only ever reach `success` or `failed` as terminal states. Including `upstream_failed` in `TERMINAL_DAG_RUN_STATES` was incorrect — a DAG run would never have that state, so polling logic would never stop on it anyway, but it was misleading and wrong.

`upstream_failed` remains correctly in `FAILED_TASK_STATES`, where it belongs.