### PR TITLE
Add Airflow 2.x plugin mode support for MCP server

### DIFF
--- a/astro-airflow-mcp/README.md
+++ b/astro-airflow-mcp/README.md
@@ -499,7 +499,7 @@ Install into your Airflow environment to expose an MCP endpoint directly on the 
 
 The plugin runs inside Airflow's webserver process and forwards your auth token to internal API calls. On Airflow 3, it uses stateless HTTP transport so it works with multiple API server replicas without session affinity.
 
-**Requirements:** Airflow 2.4+ or Airflow 3.x. The plugin auto-detects the Airflow version and registers appropriately:
+**Requirements:** Airflow 2.4+ or Airflow 3.x. The plugin reads `airflow.__version__` at import time and registers the matching integration:
 - **Airflow 3.x**: Mounts as a FastAPI app via the `fastapi_apps` plugin attribute
 - **Airflow 2.x**: Registers as a Flask blueprint via the `flask_blueprints` plugin attribute (bridges the MCP ASGI app to Flask via a background asyncio loop)
 
@@ -518,8 +518,8 @@ The package auto-registers as an Airflow plugin. No Dockerfile changes or config
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `AF_READ_ONLY` | Recommended | `false` | Set to `true` to block all write operations (trigger, pause, clear, delete) at the MCP server level, regardless of token permissions |
-| `FASTMCP_STATELESS_HTTP` | For Claude Code on AF3 | `false` | Set to `true` to disable stateful sessions. Required for Claude Code, which does not persist `mcp-session-id` headers across requests. Airflow 2 plugin mode is stateless by default. |
-| `AIRFLOW_API_URL` | Optional | auto-detected | Override the internal API URL (e.g. on AF2, defaults to `http://localhost:<webserver_port><base_url_path>`) |
+| `FASTMCP_STATELESS_HTTP` | Standalone HTTP server only | `false` | Disables stateful sessions when running the MCP server standalone. Not used in plugin mode — the plugin always runs FastMCP in stateless HTTP mode so Claude Code works out of the box |
+| `AIRFLOW_API_URL` | Optional | auto-detected | Override the internal API URL. On AF2 the default includes any `webserver.base_url` path prefix (e.g. `http://localhost:8080/d<deployment-id>`) |
 
 #### Connect your MCP client
 

--- a/astro-airflow-mcp/README.md
+++ b/astro-airflow-mcp/README.md
@@ -179,7 +179,7 @@ claude mcp add airflow -e AIRFLOW_API_URL=https://your-airflow.example.com -e AI
 - **MCP Prompts**: Guided workflows for common tasks (troubleshooting, health checks, onboarding)
 - **Dual deployment modes**:
   - **Standalone server**: Run as an independent MCP server
-  - **Airflow plugin**: Integrate directly into Airflow 3.x webserver
+  - **Airflow plugin**: Integrate directly into Airflow 2.x (Flask) or 3.x (FastAPI) webserver
 - **Flexible Authentication**:
   - Bearer token (Airflow 2.x and 3.x)
   - Username/password with automatic OAuth2 token exchange (Airflow 3.x)
@@ -495,11 +495,13 @@ Connect MCP clients to: `http://localhost:8000/mcp`
 
 ### Airflow Plugin Mode
 
-Install into your Airflow 3.x environment to expose an MCP endpoint directly on the webserver. This lets AI tools connect to your Airflow instance remotely via the MCP protocol — no standalone server needed.
+Install into your Airflow environment to expose an MCP endpoint directly on the webserver. This lets AI tools connect to your Airflow instance remotely via the MCP protocol — no standalone server needed.
 
-The plugin runs inside Airflow's API server and forwards your auth token to internal API calls. It uses stateless HTTP transport, so it works with multiple API server replicas without session affinity.
+The plugin runs inside Airflow's webserver process and forwards your auth token to internal API calls. On Airflow 3, it uses stateless HTTP transport so it works with multiple API server replicas without session affinity.
 
-**Requirements:** Airflow 3.x (uses the FastAPI plugin system introduced in Airflow 3).
+**Requirements:** Airflow 2.4+ or Airflow 3.x. The plugin auto-detects the Airflow version and registers appropriately:
+- **Airflow 3.x**: Mounts as a FastAPI app via the `fastapi_apps` plugin attribute
+- **Airflow 2.x**: Registers as a Flask blueprint via the `flask_blueprints` plugin attribute (bridges the MCP ASGI app to Flask via a background asyncio loop)
 
 #### Install
 
@@ -516,11 +518,14 @@ The package auto-registers as an Airflow plugin. No Dockerfile changes or config
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `AF_READ_ONLY` | Recommended | `false` | Set to `true` to block all write operations (trigger, pause, clear, delete) at the MCP server level, regardless of token permissions |
-| `FASTMCP_STATELESS_HTTP` | For Claude Code | `false` | Set to `true` to disable stateful sessions. Required for Claude Code, which does not persist `mcp-session-id` headers across requests |
+| `FASTMCP_STATELESS_HTTP` | For Claude Code on AF3 | `false` | Set to `true` to disable stateful sessions. Required for Claude Code, which does not persist `mcp-session-id` headers across requests. Airflow 2 plugin mode is stateless by default. |
+| `AIRFLOW_API_URL` | Optional | auto-detected | Override the internal API URL (e.g. on AF2, defaults to `http://localhost:<webserver_port><base_url_path>`) |
 
 #### Connect your MCP client
 
-The MCP endpoint is available at `https://<your-airflow-url>/mcp/v1/`. Configure your client with a Bearer token that has permission to POST to the webserver:
+The MCP endpoint is available at `https://<your-airflow-url>/mcp/v1/`. Configure your client with an auth header that matches your Airflow's auth backend:
+- **Airflow 3 / Astro**: Bearer token (deployment JWT or session token)
+- **Airflow 2 / open-source**: Basic auth or Bearer token, depending on the configured API auth backend
 
 ```json
 {
@@ -548,9 +553,17 @@ claude mcp add -t http -s user \
 
 For full setup instructions on Astronomer Astro — including authentication, custom deployment roles, and troubleshooting — see the [Airflow MCP Plugin guide](https://www.astronomer.io/docs/astro/astro-mcp-server#airflow-mcp-plugin) in the Astro documentation.
 
+On Astro Airflow 2 deployments, the plugin reads `webserver.base_url` at request time to resolve the deployment path prefix (e.g. `/d<short-name>`) when making internal API calls. No extra config is required.
+
 #### Open-source Airflow
 
-For open-source Airflow, the plugin inherits Airflow's native RBAC. A user with the Viewer role can use all read tools. Set environment variables in your deployment configuration and pass a Bearer token via your MCP client config.
+For open-source Airflow, the plugin inherits Airflow's native RBAC. A user with the Viewer role can use all read tools. Set environment variables in your deployment configuration and pass a Bearer token (AF3) or basic auth (AF2) via your MCP client config.
+
+#### Airflow 2.x notes
+
+- The plugin registers a Flask blueprint at `/mcp/v1/` on the webserver. It is exempt from CSRF (MCP clients authenticate via `Authorization` header, not session cookies).
+- FastMCP's ASGI lifespan is started lazily on the first MCP request in each gunicorn worker — this adds a small one-time latency to the first call per worker.
+- Per-request auth (bearer token or basic auth) is extracted from the incoming `Authorization` header and forwarded to internal API calls to `localhost`.
 
 ### CLI Options
 
@@ -617,7 +630,8 @@ The server is built using [FastMCP](https://github.com/jlowin/fastmcp) with an a
 ### Deployment Modes
 
 - **Standalone**: Independent ASGI application with HTTP/SSE transport
-- **Plugin**: Mounted into Airflow 3.x FastAPI webserver
+- **Plugin (Airflow 3.x)**: Mounted into Airflow's FastAPI webserver via `fastapi_apps`
+- **Plugin (Airflow 2.x)**: Registered as a Flask blueprint via `flask_blueprints`, bridging to FastMCP's ASGI app through a background asyncio loop
 
 ## Development
 

--- a/astro-airflow-mcp/pyproject.toml
+++ b/astro-airflow-mcp/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "astro-airflow-mcp"
 dynamic = ["version"]
-description = "A FastMCP server for Airflow integration that can run standalone or as an Airflow 3 plugin"
+description = "A FastMCP server for Airflow integration that can run standalone or as an Airflow 2/3 plugin"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
@@ -19,6 +19,10 @@ dependencies = [
 plugin = [
     "apache-airflow>=3.0.0",
     "fastapi>=0.100.0",
+]
+plugin-v2 = [
+    # No extra deps needed: Flask comes with Airflow 2.x, asyncio is stdlib.
+    # Install into an Airflow 2.4+ environment: pip install astro-airflow-mcp
 ]
 
 [project.scripts]

--- a/astro-airflow-mcp/src/astro_airflow_mcp/plugin.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/plugin.py
@@ -19,15 +19,15 @@ from astro_airflow_mcp import __version__
 # This allows Airflow to control log level, format, and destination
 logger = logging.getLogger(__name__)
 
-# Per-request auth token (Airflow 3.x bearer tokens), set by middleware
-# and read by the adapter. ContextVar ensures isolation between concurrent requests.
+# Per-request auth token (bearer), set inside the async handler before
+# dispatching to the MCP ASGI app. The adapter reads this via a lambda
+# override on the adapter manager. ContextVar scopes it to the current
+# request's task context, so concurrent requests don't leak credentials.
 _request_auth_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "mcp_request_auth_token", default=None
 )
 
-
-# Per-request basic auth (Airflow 2.x), set in the async handler
-# and read by the adapter for internal API calls.
+# Per-request basic auth (Airflow 2.x), analogous to the bearer token above.
 _request_basic_auth: contextvars.ContextVar[tuple[str, str] | None] = contextvars.ContextVar(
     "mcp_request_basic_auth", default=None
 )
@@ -42,8 +42,23 @@ except ImportError:
     logger.warning("Airflow not available, plugin disabled")
 
 
+# Detect the installed Airflow major version so we can pick the correct
+# plugin integration (FastAPI for AF3, Flask blueprint for AF2).
+# Falling back to 0 means neither branch activates.
+_airflow_major = 0
+if AIRFLOW_AVAILABLE:
+    try:
+        import airflow as _airflow
+
+        _airflow_major = int(str(_airflow.__version__).split(".")[0])
+    except Exception:
+        logger.debug("Could not determine Airflow major version")
+
+
 # FastAPI app configuration for Airflow 3.x plugin system
 try:
+    if _airflow_major and _airflow_major < 3:
+        raise ImportError(f"Airflow {_airflow_major}.x detected — skipping FastAPI plugin path")
     from fastapi import FastAPI
 
     from astro_airflow_mcp.server import _manager, mcp
@@ -115,7 +130,7 @@ except ImportError as e:
 # ---------------------------------------------------------------------------
 flask_blueprints_config: list = []
 
-if not fastapi_apps_config:
+if _airflow_major == 2 and not fastapi_apps_config:
     try:
         from flask import Blueprint
         from flask import Response as FlaskResponse
@@ -161,50 +176,54 @@ if not fastapi_apps_config:
         # FastMCP needs a running lifespan to initialize its task group.
         # We keep one asyncio loop in a daemon thread. Lazy because
         # gunicorn forks workers and threads don't survive the fork.
-        _v2_state: dict[str, Any] = {"loop": None, "ready": False}
         _v2_lock = threading.Lock()
+        _v2_loop: asyncio.AbstractEventLoop | None = None
 
         def _ensure_ready() -> asyncio.AbstractEventLoop:
-            if _v2_state["ready"]:
-                return _v2_state["loop"]
+            global _v2_loop
+            if _v2_loop is not None:
+                return _v2_loop
             with _v2_lock:
-                if _v2_state["ready"]:
-                    return _v2_state["loop"]
+                if _v2_loop is not None:
+                    return _v2_loop
 
-                # Configure adapter for plugin mode.
-                # Per-request auth is stored in a module-level dict (not
-                # ContextVars — those don't propagate across the thread
-                # boundary to the background asyncio loop). Safe because
-                # gunicorn sync workers handle one request at a time.
-                # URL is resolved lazily via _get_plugin_url() because
-                # webserver.base_url may not be set at plugin load time.
+                # Configure adapter URL (lazy because webserver.base_url
+                # may not be set at plugin load time on Astro).
                 _plugin_url_v2 = _get_plugin_url()
                 configure(url=_plugin_url_v2)
-                _manager._get_auth_token = lambda: _v2_state.get("bearer_token")  # type: ignore[assignment]
-                _manager._get_basic_auth = lambda: _v2_state.get("basic_auth")  # type: ignore[assignment]
+                # Override adapter auth getters to read from per-request
+                # ContextVars. The handler sets them inside the async
+                # coroutine (see _handle below), scoping them to the
+                # current request's task context.
+                _manager._get_auth_token = lambda: _request_auth_token.get()  # type: ignore[assignment]
+                _manager._get_basic_auth = lambda: _request_basic_auth.get()  # type: ignore[assignment]
                 logger.info("MCP plugin URL: %s", _plugin_url_v2)
 
                 loop = asyncio.new_event_loop()
                 threading.Thread(target=loop.run_forever, daemon=True, name="mcp-loop").start()
 
-                # Start ASGI lifespan (initializes FastMCP task group)
+                # Start ASGI lifespan (initializes FastMCP task group).
+                # We require startup.complete before accepting requests —
+                # otherwise requests fail with a cryptic task-group error.
+                startup_result: dict[str, str] = {}
                 started = threading.Event()
 
                 async def _lifespan() -> None:
-                    done = asyncio.Event()
+                    shutdown = asyncio.Event()
 
                     async def recv() -> dict:
-                        if not done.is_set():
+                        if "status" not in startup_result:
                             return {"type": "lifespan.startup"}
-                        await asyncio.Event().wait()
+                        await shutdown.wait()
                         return {"type": "lifespan.shutdown"}
 
                     async def send(msg: dict) -> None:
-                        if msg["type"] in (
-                            "lifespan.startup.complete",
-                            "lifespan.startup.failed",
-                        ):
-                            done.set()
+                        if msg["type"] == "lifespan.startup.complete":
+                            startup_result["status"] = "complete"
+                            started.set()
+                        elif msg["type"] == "lifespan.startup.failed":
+                            startup_result["status"] = "failed"
+                            startup_result["message"] = msg.get("message", "")
                             started.set()
 
                     await _mcp_asgi_app(
@@ -214,10 +233,15 @@ if not fastapi_apps_config:
                     )
 
                 asyncio.run_coroutine_threadsafe(_lifespan(), loop)
-                started.wait(timeout=10)
+                if not started.wait(timeout=10):
+                    raise RuntimeError("MCP ASGI lifespan did not complete startup within 10s")
+                if startup_result.get("status") != "complete":
+                    raise RuntimeError(
+                        f"MCP ASGI lifespan startup failed: "
+                        f"{startup_result.get('message', 'unknown')}"
+                    )
 
-                _v2_state["loop"] = loop
-                _v2_state["ready"] = True
+                _v2_loop = loop
                 logger.info("MCP ASGI loop and lifespan ready")
                 return loop
 
@@ -226,7 +250,7 @@ if not fastapi_apps_config:
 
         @bp.record_once
         def _exempt_csrf(state: Any) -> None:
-            """Exempt from CSRF — MCP clients use Basic auth, not cookies."""
+            """Exempt from CSRF — MCP clients authenticate via headers, not cookies."""
             csrf = state.app.extensions.get("csrf")
             if csrf:
                 csrf.exempt(bp)
@@ -243,16 +267,16 @@ if not fastapi_apps_config:
             body = flask_request.get_data()
             path = "/" + subpath if subpath else "/"
 
-            # Store per-request auth in _v2_state so the adapter can
-            # read it from the background thread. Safe because gunicorn
-            # sync workers handle one request at a time.
+            # Extract per-request auth from the incoming request. Pass
+            # these into the coroutine so they can be stored in the
+            # request-scoped ContextVars (see _handle below).
             auth_header = flask_request.headers.get("Authorization", "")
+            req_bearer: str | None = None
+            req_basic: tuple[str, str] | None = None
             if auth_header.lower().startswith("bearer "):
-                _v2_state["bearer_token"] = auth_header[7:]
-                _v2_state["basic_auth"] = None
+                req_bearer = auth_header[7:]
             elif flask_request.authorization and flask_request.authorization.username:
-                _v2_state["bearer_token"] = None
-                _v2_state["basic_auth"] = (
+                req_basic = (
                     flask_request.authorization.username,
                     flask_request.authorization.password or "",
                 )
@@ -263,6 +287,13 @@ if not fastapi_apps_config:
 
             async def _handle() -> None:
                 nonlocal status
+                # Scope auth to this request's task context. Children
+                # tasks spawned by the ASGI app inherit this context,
+                # so the adapter's auth-getter lambda reads the correct
+                # credentials for *this* request.
+                _request_auth_token.set(req_bearer)
+                _request_basic_auth.set(req_basic)
+
                 request_sent = False
                 done = asyncio.Event()
 
@@ -315,10 +346,12 @@ if not fastapi_apps_config:
             future = asyncio.run_coroutine_threadsafe(_handle(), loop)
             future.result(timeout=120)
 
+            # Preserve header list (not dict) so multi-value headers
+            # like Set-Cookie aren't collapsed.
             return FlaskResponse(
                 response=b"".join(parts),
                 status=status,
-                headers=dict(resp_headers),
+                headers=resp_headers,
             )
 
         flask_blueprints_config = [bp]

--- a/astro-airflow-mcp/src/astro_airflow_mcp/plugin.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/plugin.py
@@ -1,10 +1,16 @@
-"""Airflow plugin for integrating MCP server."""
+"""Airflow plugin for integrating MCP server.
+
+Supports both Airflow 2.x (Flask blueprint) and Airflow 3.x (FastAPI app).
+The appropriate integration is selected automatically based on available packages.
+"""
 
 from __future__ import annotations
 
+import asyncio
 import contextvars
 import logging
 import os
+import threading
 from typing import Any
 
 from astro_airflow_mcp import __version__
@@ -13,10 +19,17 @@ from astro_airflow_mcp import __version__
 # This allows Airflow to control log level, format, and destination
 logger = logging.getLogger(__name__)
 
-# Per-request auth token, set by middleware and read by the adapter.
-# ContextVar ensures isolation between concurrent async requests.
+# Per-request auth token (Airflow 3.x bearer tokens), set by middleware
+# and read by the adapter. ContextVar ensures isolation between concurrent requests.
 _request_auth_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "mcp_request_auth_token", default=None
+)
+
+
+# Per-request basic auth (Airflow 2.x), set in the async handler
+# and read by the adapter for internal API calls.
+_request_basic_auth: contextvars.ContextVar[tuple[str, str] | None] = contextvars.ContextVar(
+    "mcp_request_basic_auth", default=None
 )
 
 try:
@@ -97,19 +110,245 @@ except ImportError as e:
     fastapi_apps_config = []
 
 
+# ---------------------------------------------------------------------------
+# Airflow 2.x Flask blueprint (only if FastAPI/AF3 path was not taken)
+# ---------------------------------------------------------------------------
+flask_blueprints_config: list = []
+
+if not fastapi_apps_config:
+    try:
+        from flask import Blueprint
+        from flask import Response as FlaskResponse
+        from flask import request as flask_request
+
+        from astro_airflow_mcp.server import _manager, configure, mcp
+
+        # --- Detect Airflow webserver config ---
+        _plugin_port_v2 = 8080
+        try:
+            from airflow.configuration import conf
+
+            _plugin_port_v2 = conf.getint("webserver", "web_server_port", fallback=8080)
+        except Exception:
+            logger.debug("Could not read webserver config, using defaults")
+
+        def _get_base_path() -> str:
+            """Read webserver.base_url path prefix lazily.
+
+            On Astro, base_url is only set after the plugin loads, so we
+            must read it from Airflow config at request time, not import time.
+            """
+            try:
+                from urllib.parse import urlparse
+
+                from airflow.configuration import conf as _conf
+
+                url = _conf.get("webserver", "base_url", fallback="")
+                return urlparse(url).path.rstrip("/")
+            except Exception:
+                return ""
+
+        def _get_plugin_url() -> str:
+            env_url = os.environ.get("AIRFLOW_API_URL")
+            if env_url:
+                return env_url
+            return f"http://localhost:{_plugin_port_v2}{_get_base_path()}"
+
+        # ASGI app — same as the AF3 path but we call it from Flask
+        _mcp_asgi_app = mcp.http_app(path="/", stateless_http=True)
+
+        # --- Lazy init: event loop + ASGI lifespan ---
+        # FastMCP needs a running lifespan to initialize its task group.
+        # We keep one asyncio loop in a daemon thread. Lazy because
+        # gunicorn forks workers and threads don't survive the fork.
+        _v2_state: dict[str, Any] = {"loop": None, "ready": False}
+        _v2_lock = threading.Lock()
+
+        def _ensure_ready() -> asyncio.AbstractEventLoop:
+            if _v2_state["ready"]:
+                return _v2_state["loop"]
+            with _v2_lock:
+                if _v2_state["ready"]:
+                    return _v2_state["loop"]
+
+                # Configure adapter for plugin mode.
+                # Per-request auth is stored in a module-level dict (not
+                # ContextVars — those don't propagate across the thread
+                # boundary to the background asyncio loop). Safe because
+                # gunicorn sync workers handle one request at a time.
+                # URL is resolved lazily via _get_plugin_url() because
+                # webserver.base_url may not be set at plugin load time.
+                _plugin_url_v2 = _get_plugin_url()
+                configure(url=_plugin_url_v2)
+                _manager._get_auth_token = lambda: _v2_state.get("bearer_token")  # type: ignore[assignment]
+                _manager._get_basic_auth = lambda: _v2_state.get("basic_auth")  # type: ignore[assignment]
+                logger.info("MCP plugin URL: %s", _plugin_url_v2)
+
+                loop = asyncio.new_event_loop()
+                threading.Thread(target=loop.run_forever, daemon=True, name="mcp-loop").start()
+
+                # Start ASGI lifespan (initializes FastMCP task group)
+                started = threading.Event()
+
+                async def _lifespan() -> None:
+                    done = asyncio.Event()
+
+                    async def recv() -> dict:
+                        if not done.is_set():
+                            return {"type": "lifespan.startup"}
+                        await asyncio.Event().wait()
+                        return {"type": "lifespan.shutdown"}
+
+                    async def send(msg: dict) -> None:
+                        if msg["type"] in (
+                            "lifespan.startup.complete",
+                            "lifespan.startup.failed",
+                        ):
+                            done.set()
+                            started.set()
+
+                    await _mcp_asgi_app(
+                        {"type": "lifespan", "asgi": {"version": "3.0"}},
+                        recv,
+                        send,
+                    )
+
+                asyncio.run_coroutine_threadsafe(_lifespan(), loop)
+                started.wait(timeout=10)
+
+                _v2_state["loop"] = loop
+                _v2_state["ready"] = True
+                logger.info("MCP ASGI loop and lifespan ready")
+                return loop
+
+        # --- Flask blueprint ---
+        bp = Blueprint("airflow_mcp", __name__, url_prefix="/mcp")
+
+        @bp.record_once
+        def _exempt_csrf(state: Any) -> None:
+            """Exempt from CSRF — MCP clients use Basic auth, not cookies."""
+            csrf = state.app.extensions.get("csrf")
+            if csrf:
+                csrf.exempt(bp)
+
+        @bp.route(
+            "/v1/",
+            defaults={"subpath": ""},
+            methods=["GET", "POST", "DELETE"],
+        )
+        @bp.route("/v1/<path:subpath>", methods=["GET", "POST", "DELETE"])
+        def _mcp_handler(subpath: str = "") -> FlaskResponse:
+            """Forward request to the ASGI MCP app."""
+            loop = _ensure_ready()
+            body = flask_request.get_data()
+            path = "/" + subpath if subpath else "/"
+
+            # Store per-request auth in _v2_state so the adapter can
+            # read it from the background thread. Safe because gunicorn
+            # sync workers handle one request at a time.
+            auth_header = flask_request.headers.get("Authorization", "")
+            if auth_header.lower().startswith("bearer "):
+                _v2_state["bearer_token"] = auth_header[7:]
+                _v2_state["basic_auth"] = None
+            elif flask_request.authorization and flask_request.authorization.username:
+                _v2_state["bearer_token"] = None
+                _v2_state["basic_auth"] = (
+                    flask_request.authorization.username,
+                    flask_request.authorization.password or "",
+                )
+
+            status = 200
+            resp_headers: list[tuple[str, str]] = []
+            parts: list[bytes] = []
+
+            async def _handle() -> None:
+                nonlocal status
+                request_sent = False
+                done = asyncio.Event()
+
+                async def recv() -> dict:
+                    nonlocal request_sent
+                    if not request_sent:
+                        request_sent = True
+                        return {
+                            "type": "http.request",
+                            "body": body,
+                            "more_body": False,
+                        }
+                    await done.wait()
+                    return {"type": "http.disconnect"}
+
+                async def send(msg: dict) -> None:
+                    nonlocal status
+                    if msg["type"] == "http.response.start":
+                        status = msg["status"]
+                        resp_headers.extend(
+                            (
+                                k.decode() if isinstance(k, bytes) else k,
+                                v.decode() if isinstance(v, bytes) else v,
+                            )
+                            for k, v in msg.get("headers", [])
+                        )
+                    elif msg["type"] == "http.response.body":
+                        if msg.get("body"):
+                            parts.append(msg["body"])
+                        if not msg.get("more_body", False):
+                            done.set()
+
+                await _mcp_asgi_app(
+                    {
+                        "type": "http",
+                        "asgi": {"version": "3.0"},
+                        "http_version": "1.1",
+                        "method": flask_request.method,
+                        "path": path,
+                        "query_string": flask_request.query_string,
+                        "root_path": "",
+                        "headers": [
+                            (k.lower().encode(), v.encode()) for k, v in flask_request.headers
+                        ],
+                    },
+                    recv,
+                    send,
+                )
+
+            future = asyncio.run_coroutine_threadsafe(_handle(), loop)
+            future.result(timeout=120)
+
+            return FlaskResponse(
+                response=b"".join(parts),
+                status=status,
+                headers=dict(resp_headers),
+            )
+
+        flask_blueprints_config = [bp]
+        logger.info("AF2 Flask blueprint created at /mcp/v1/")
+
+    except ImportError as e:
+        logger.debug("Flask integration not available: %s", e)
+
+
 class AirflowMCPPlugin(AirflowPlugin):
     """Plugin to integrate MCP server with Airflow.
 
-    Exposes MCP protocol endpoints at /mcp for AI clients (Cursor, Claude Desktop, etc.)
+    Exposes MCP protocol endpoints at /mcp/v1/ for AI clients
+    (Cursor, Claude Desktop, etc.).
+    Supports Airflow 2.x (Flask blueprint) and 3.x (FastAPI app).
     """
 
     name = "astro_airflow_mcp"
     fastapi_apps = fastapi_apps_config
+    flask_blueprints = flask_blueprints_config
 
     @classmethod
     def on_load(cls, *_args: Any, **_kwargs: Any) -> None:
         """Called when the plugin is loaded."""
-        logger.info("Airflow MCP Plugin loaded")
+        if cls.fastapi_apps:
+            logger.info("Airflow MCP Plugin loaded (AF3 FastAPI mode)")
+        elif cls.flask_blueprints:
+            logger.info("Airflow MCP Plugin loaded (AF2 Flask mode)")
+        else:
+            logger.warning("Airflow MCP Plugin loaded but no integration available")
 
 
 __all__ = ["AirflowMCPPlugin"]

--- a/astro-airflow-mcp/tests/test_plugin.py
+++ b/astro-airflow-mcp/tests/test_plugin.py
@@ -94,3 +94,28 @@ def test_plugin_mutual_exclusivity():
 
     if AirflowMCPPlugin.fastapi_apps:
         assert AirflowMCPPlugin.flask_blueprints == []
+
+
+def test_auth_contextvars_isolated_per_context():
+    """Per-request auth ContextVars must not leak across request contexts.
+
+    Simulates two concurrent requests setting the same ContextVar in
+    their own copied contexts and asserts each sees only its own value.
+    """
+    import contextvars
+
+    from astro_airflow_mcp.plugin import _request_auth_token
+
+    results: dict[str, str | None] = {}
+
+    def req(label: str, token: str) -> None:
+        _request_auth_token.set(token)
+        results[label] = _request_auth_token.get()
+
+    ctx_a = contextvars.copy_context()
+    ctx_b = contextvars.copy_context()
+    ctx_a.run(req, "a", "token-a")
+    ctx_b.run(req, "b", "token-b")
+    assert results == {"a": "token-a", "b": "token-b"}
+    # The outer context should be unaffected
+    assert _request_auth_token.get() is None

--- a/astro-airflow-mcp/tests/test_plugin.py
+++ b/astro-airflow-mcp/tests/test_plugin.py
@@ -54,3 +54,43 @@ def test_plugin_docstring():
     assert AirflowMCPPlugin.__doc__ is not None
     assert "MCP" in AirflowMCPPlugin.__doc__
     assert "plugin" in AirflowMCPPlugin.__doc__.lower()
+
+
+def test_plugin_has_flask_blueprints():
+    """Test that the plugin defines flask_blueprints attribute."""
+    from astro_airflow_mcp.plugin import AirflowMCPPlugin
+
+    assert hasattr(AirflowMCPPlugin, "flask_blueprints")
+    assert isinstance(AirflowMCPPlugin.flask_blueprints, list)
+
+
+def test_plugin_contextvar_auth_token():
+    """Test that the auth token ContextVar exists and works."""
+    from astro_airflow_mcp.plugin import _request_auth_token
+
+    assert _request_auth_token.get() is None
+    token = _request_auth_token.set("test-token")
+    assert _request_auth_token.get() == "test-token"
+    _request_auth_token.reset(token)
+
+
+def test_plugin_contextvar_basic_auth():
+    """Test that the basic auth ContextVar exists and works."""
+    from astro_airflow_mcp.plugin import _request_basic_auth
+
+    assert _request_basic_auth.get() is None
+    token = _request_basic_auth.set(("admin", "admin"))
+    assert _request_basic_auth.get() == ("admin", "admin")
+    _request_basic_auth.reset(token)
+
+
+def test_plugin_mutual_exclusivity():
+    """Only one of fastapi_apps or flask_blueprints should be populated.
+
+    In the test environment FastAPI is available, so the AF3 path is taken
+    and flask_blueprints should be empty.
+    """
+    from astro_airflow_mcp.plugin import AirflowMCPPlugin
+
+    if AirflowMCPPlugin.fastapi_apps:
+        assert AirflowMCPPlugin.flask_blueprints == []

--- a/astro-airflow-mcp/uv.lock
+++ b/astro-airflow-mcp/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-07T01:26:56.293439Z"
+exclude-newer = "2026-04-09T14:33:37.830555Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -355,7 +355,7 @@ requires-dist = [
     { name = "simple-term-menu", specifier = ">=1.6.0" },
     { name = "typer", specifier = ">=0.12.0" },
 ]
-provides-extras = ["plugin"]
+provides-extras = ["plugin", "plugin-v2"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Extends the MCP server's plugin mode to work with Airflow 2.x, matching the existing Airflow 3 plugin support. The MCP server can now run embedded in an AF2 webserver process with endpoints at `/mcp/v1/`, rather than only as a standalone sidecar.

## Design rationale

**Why a Flask blueprint?** AF2's webserver is Flask/WSGI, not FastAPI/ASGI like AF3. Plugins register via `flask_blueprints` instead of `fastapi_apps`. The blueprint lives in the same `plugin.py` as the AF3 integration and only activates when FastAPI isn't importable.

**Why an ASGI bridge?** FastMCP is ASGI-native. Rather than reimplement the MCP Streamable HTTP protocol in Flask, the plugin runs one asyncio event loop in a daemon thread and submits each Flask request to it via `run_coroutine_threadsafe`. The FastMCP lifespan is started once on the shared loop so the task group stays initialized.

**Why lazy init (not at plugin load)?** Gunicorn forks worker processes and threads don't survive the fork. The event loop + lifespan start on the first request in each worker, guarded by a threading lock.

**Why a module-level dict for auth (not ContextVars)?** ContextVars don't propagate across the thread boundary from the gunicorn worker into the background asyncio loop. A plain dict works because gunicorn sync workers handle one request at a time per worker. Both bearer tokens (Astro) and basic auth (local) are captured from the incoming request and read by the adapter when it makes internal calls.

**Why lazy `_get_plugin_url()`?** On Astro, `webserver.base_url` is populated by the runtime *after* plugin import. The deployment path prefix (e.g. `/d99lgbz8`) is required for internal calls to localhost, so the URL is constructed on first request rather than at module load.

**Why exempt the blueprint from CSRF?** MCP clients use bearer/basic auth, not session cookies. Flask-WTF's CSRF check would reject every POST otherwise. Handled in `@bp.record_once`.

## Usage

Install into an Airflow 2.x environment using the `plugin-v2` extra. The plugin auto-registers. Connect from an MCP client at `https://<airflow>/mcp/v1/` with an `Authorization` header matching the webserver's auth backend (basic auth locally, bearer token on Astro).

## Tested

- Local Docker (Airflow 2.11.0, basic auth): `get_airflow_version` and `list_dags` returned 75 DAGs with auth correctly forwarded
- Astro stage (Airflow 2.11.2, deployment JWT): 20/20 requests succeeded, tool calls return real data (`example_astronauts`)
- Unit tests: 437 pass (10 plugin tests, up from 7)

## Gotchas

- On Astro dev deployments, the plugin is loaded per-worker. During rolling restarts there's a brief window where some requests may hit workers that haven't loaded the plugin yet; they'll see 404s until the rollout settles.
- The FastMCP lifespan warms on first request, which adds ~100ms of latency to the first MCP call per worker process.