### PR TITLE
af CLI: treat empty AIRFLOW_API_URL as explicit no-op

### DIFF
--- a/astro-airflow-mcp/README.md
+++ b/astro-airflow-mcp/README.md
@@ -453,6 +453,13 @@ export AIRFLOW_PASSWORD=admin
 AIRFLOW_API_URL=http://localhost:5500 af dags list
 ```
 
+When `AIRFLOW_API_URL` is unset and no current instance is configured, the CLI falls back to `http://localhost:8080`. To explicitly signal "no Airflow is configured right now" (useful for automation / agent frameworks that don't want to risk querying a stale localhost service), set `AIRFLOW_API_URL=""`. The CLI will exit with a clear error instead of defaulting.
+
+```bash
+AIRFLOW_API_URL="" af dags list
+# Error: AIRFLOW_API_URL is set but empty. No Airflow instance is configured.
+```
+
 All commands output JSON (except `instance` commands which use human-readable tables), making them easy to use with tools like `jq`:
 
 ```bash

--- a/astro-airflow-mcp/src/astro_airflow_mcp/cli/context.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/cli/context.py
@@ -75,27 +75,26 @@ class CLIContext:
         # since the config's auth is for a different instance.
         #
         # An explicitly empty AIRFLOW_API_URL ("" in the environment) is treated
-        # as "no Airflow is configured right now" — do NOT fall back to the
+        # as "no Airflow is configured right now" -- do NOT fall back to the
         # config file or DEFAULT_AIRFLOW_URL. This lets programmatic callers
         # (automation, agent frameworks) propagate "nothing is configured"
         # without risking queries against whatever happens to be listening on
         # localhost:8080.
-        url_env_value = os.environ.get("AIRFLOW_API_URL")
-        url_env_present = "AIRFLOW_API_URL" in os.environ
-        url_from_env = bool(url_env_value)
+        airflow_url_env = os.environ.get("AIRFLOW_API_URL")
+        url_from_env = bool(airflow_url_env)
 
-        if url_env_present and not url_env_value:
-            print(
-                "Error: AIRFLOW_API_URL is set but empty. No Airflow instance "
-                "is configured.\n"
+        if airflow_url_env is not None and not airflow_url_env:
+            message = (
+                "Error: AIRFLOW_API_URL is set but empty. "
+                "No Airflow instance is configured.\n"
                 "To configure one, either:\n"
                 "  - set AIRFLOW_API_URL to a webserver URL, or\n"
-                "  - run `af instance add <name> --url <url>` and "
-                "`af instance use <name>`.\n"
-                "To use the default (http://localhost:8080), unset "
-                "AIRFLOW_API_URL.",
-                file=sys.stderr,
+                "  - run `af instance add <name> --url <url>` "
+                "and `af instance use <name>`.\n"
+                "To use the default (http://localhost:8080), "
+                "unset AIRFLOW_API_URL."
             )
+            print(message, file=sys.stderr)
             sys.exit(2)
 
         if url_from_env:

--- a/astro-airflow-mcp/src/astro_airflow_mcp/cli/context.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/cli/context.py
@@ -73,7 +73,31 @@ class CLIContext:
         # Determine final values with priority: env > config > default
         # If the URL is overridden by env var, don't inherit auth from config
         # since the config's auth is for a different instance.
-        url_from_env = bool(os.environ.get("AIRFLOW_API_URL"))
+        #
+        # An explicitly empty AIRFLOW_API_URL ("" in the environment) is treated
+        # as "no Airflow is configured right now" — do NOT fall back to the
+        # config file or DEFAULT_AIRFLOW_URL. This lets programmatic callers
+        # (automation, agent frameworks) propagate "nothing is configured"
+        # without risking queries against whatever happens to be listening on
+        # localhost:8080.
+        url_env_value = os.environ.get("AIRFLOW_API_URL")
+        url_env_present = "AIRFLOW_API_URL" in os.environ
+        url_from_env = bool(url_env_value)
+
+        if url_env_present and not url_env_value:
+            print(
+                "Error: AIRFLOW_API_URL is set but empty. No Airflow instance "
+                "is configured.\n"
+                "To configure one, either:\n"
+                "  - set AIRFLOW_API_URL to a webserver URL, or\n"
+                "  - run `af instance add <name> --url <url>` and "
+                "`af instance use <name>`.\n"
+                "To use the default (http://localhost:8080), unset "
+                "AIRFLOW_API_URL.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
         if url_from_env:
             final_url = os.environ["AIRFLOW_API_URL"]
         elif config_values and config_values.url:

--- a/astro-airflow-mcp/src/astro_airflow_mcp/cli/main.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/cli/main.py
@@ -68,6 +68,12 @@ def main(
 
     Or configure named instances in ~/.af/config.yaml and switch with:
         af instance use <name>
+
+    Setting AIRFLOW_API_URL to an empty string signals "no Airflow is
+    configured"; the CLI will exit with a clear error instead of falling back
+    to the http://localhost:8080 default. This lets programmatic callers
+    safely propagate "nothing is configured" without risking a query against
+    whatever happens to be listening on localhost:8080.
     """
     # Set config path env var so all ConfigManager instances use it
     if config:

--- a/astro-airflow-mcp/tests/test_config.py
+++ b/astro-airflow-mcp/tests/test_config.py
@@ -978,9 +978,7 @@ class TestCLIContextEmptyURL:
         """When AIRFLOW_API_URL is entirely unset, default fallback still works."""
         ctx = self._make_context()
         with patch.object(ctx, "_load_from_config", return_value=None):
-            env_clear = {
-                k: v for k, v in os.environ.items() if k != "AIRFLOW_API_URL"
-            }
+            env_clear = {k: v for k, v in os.environ.items() if k != "AIRFLOW_API_URL"}
             with patch.dict(os.environ, env_clear, clear=True):
                 ctx.init()
         assert ctx._manager._airflow_url == "http://localhost:8080"
@@ -993,9 +991,7 @@ class TestCLIContextEmptyURL:
             instance_name="test",
         )
         with patch.object(ctx, "_load_from_config", return_value=mock_config):
-            env_clear = {
-                k: v for k, v in os.environ.items() if k != "AIRFLOW_API_URL"
-            }
+            env_clear = {k: v for k, v in os.environ.items() if k != "AIRFLOW_API_URL"}
             with patch.dict(os.environ, env_clear, clear=True):
                 ctx.init()
         assert ctx._manager._airflow_url == "http://configured.example.com"

--- a/astro-airflow-mcp/tests/test_config.py
+++ b/astro-airflow-mcp/tests/test_config.py
@@ -941,3 +941,63 @@ class TestCLIContextSSL:
             with patch.dict(os.environ, env_clear, clear=True):
                 ctx.init()
         assert ctx._manager._verify is True
+
+
+class TestCLIContextEmptyURL:
+    """Tests for explicit 'no Airflow configured' signal via empty AIRFLOW_API_URL."""
+
+    def _make_context(self):
+        from astro_airflow_mcp.cli.context import CLIContext
+
+        ctx = CLIContext.__new__(CLIContext)
+        ctx._manager = __import__(
+            "astro_airflow_mcp.adapter_manager", fromlist=["AdapterManager"]
+        ).AdapterManager()
+        ctx._initialized = False
+        return ctx
+
+    def test_empty_env_var_exits_with_error(self, capsys):
+        """AIRFLOW_API_URL='' should exit, not fall back to config or default."""
+        import pytest
+
+        ctx = self._make_context()
+        mock_config = ResolvedConfig(
+            url="http://configured.example.com",
+            instance_name="test",
+        )
+        with (
+            patch.object(ctx, "_load_from_config", return_value=mock_config),
+            patch.dict(os.environ, {"AIRFLOW_API_URL": ""}, clear=False),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                ctx.init()
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        assert "AIRFLOW_API_URL is set but empty" in captured.err
+        assert "No Airflow instance is configured" in captured.err
+
+    def test_unset_env_var_falls_back_to_default(self):
+        """When AIRFLOW_API_URL is entirely unset, default fallback still works."""
+        ctx = self._make_context()
+        with patch.object(ctx, "_load_from_config", return_value=None):
+            env_clear = {
+                k: v for k, v in os.environ.items() if k != "AIRFLOW_API_URL"
+            }
+            with patch.dict(os.environ, env_clear, clear=True):
+                ctx.init()
+        assert ctx._manager._airflow_url == "http://localhost:8080"
+
+    def test_unset_env_var_uses_config(self):
+        """When AIRFLOW_API_URL is unset but config has a URL, config wins."""
+        ctx = self._make_context()
+        mock_config = ResolvedConfig(
+            url="http://configured.example.com",
+            instance_name="test",
+        )
+        with patch.object(ctx, "_load_from_config", return_value=mock_config):
+            env_clear = {
+                k: v for k, v in os.environ.items() if k != "AIRFLOW_API_URL"
+            }
+            with patch.dict(os.environ, env_clear, clear=True):
+                ctx.init()
+        assert ctx._manager._airflow_url == "http://configured.example.com"

--- a/astro-airflow-mcp/tests/test_config.py
+++ b/astro-airflow-mcp/tests/test_config.py
@@ -958,8 +958,6 @@ class TestCLIContextEmptyURL:
 
     def test_empty_env_var_exits_with_error(self, capsys):
         """AIRFLOW_API_URL='' should exit, not fall back to config or default."""
-        import pytest
-
         ctx = self._make_context()
         mock_config = ResolvedConfig(
             url="http://configured.example.com",
@@ -968,9 +966,9 @@ class TestCLIContextEmptyURL:
         with (
             patch.object(ctx, "_load_from_config", return_value=mock_config),
             patch.dict(os.environ, {"AIRFLOW_API_URL": ""}, clear=False),
+            pytest.raises(SystemExit) as exc_info,
         ):
-            with pytest.raises(SystemExit) as exc_info:
-                ctx.init()
+            ctx.init()
         assert exc_info.value.code == 2
         captured = capsys.readouterr()
         assert "AIRFLOW_API_URL is set but empty" in captured.err


### PR DESCRIPTION
Setting `AIRFLOW_API_URL=""` now exits with a clear error instead of silently falling back to `http://localhost:8080`. This lets programmatic callers (automation, agent frameworks) signal "no Airflow is configured right now" without risking queries against whatever happens to be listening on localhost.

Unset `AIRFLOW_API_URL` still falls back to config → default, so existing behavior is preserved. Documented in `--help` and the README.

Fixes https://github.com/astronomer/agents/issues/188