### PR TITLE
Fix list_dag_runs (MCP tool + af CLI) returning oldest runs first

### DIFF
--- a/astro-airflow-mcp/src/astro_airflow_mcp/cli/runs.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/cli/runs.py
@@ -29,9 +29,15 @@ def list_dag_runs(
         typer.Option("--offset", "-o", help="Offset for pagination"),
     ] = 0,
     order_by: Annotated[
-        str | None,
-        typer.Option("--order-by", help="Sort field (prefix - for descending, e.g., -start_date)"),
-    ] = None,
+        str,
+        typer.Option(
+            "--order-by",
+            help=(
+                "Sort field; prefix with '-' for descending. Defaults to '-start_date' "
+                "so the most recent runs come first."
+            ),
+        ),
+    ] = "-start_date",
     state: Annotated[
         str | None,
         typer.Option("--state", "-s", help="Filter by state: running, success, failed, queued"),

--- a/astro-airflow-mcp/src/astro_airflow_mcp/tools/dag_run.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/tools/dag_run.py
@@ -33,9 +33,7 @@ def _list_dag_runs_impl(
     """
     try:
         adapter = _get_adapter()
-        data = adapter.list_dag_runs(
-            dag_id=dag_id, limit=limit, offset=offset, order_by=order_by
-        )
+        data = adapter.list_dag_runs(dag_id=dag_id, limit=limit, offset=offset, order_by=order_by)
 
         if "dag_runs" in data:
             return _wrap_list_response(data["dag_runs"], "dag_runs", data)

--- a/astro-airflow-mcp/src/astro_airflow_mcp/tools/dag_run.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/tools/dag_run.py
@@ -33,10 +33,9 @@ def _list_dag_runs_impl(
     """
     try:
         adapter = _get_adapter()
-        extra: dict[str, Any] = {}
-        if order_by is not None:
-            extra["order_by"] = order_by
-        data = adapter.list_dag_runs(dag_id=dag_id, limit=limit, offset=offset, **extra)
+        data = adapter.list_dag_runs(
+            dag_id=dag_id, limit=limit, offset=offset, order_by=order_by
+        )
 
         if "dag_runs" in data:
             return _wrap_list_response(data["dag_runs"], "dag_runs", data)

--- a/astro-airflow-mcp/src/astro_airflow_mcp/tools/dag_run.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/tools/dag_run.py
@@ -17,6 +17,7 @@ def _list_dag_runs_impl(
     dag_id: str | None = None,
     limit: int = DEFAULT_LIMIT,
     offset: int = DEFAULT_OFFSET,
+    order_by: str | None = None,
 ) -> str:
     """Internal implementation for listing DAG runs from Airflow.
 
@@ -24,13 +25,18 @@ def _list_dag_runs_impl(
         dag_id: Optional DAG ID to filter runs for a specific DAG
         limit: Maximum number of DAG runs to return (default: 100)
         offset: Offset for pagination (default: 0)
+        order_by: Sort field; prefix with '-' for descending. ``None`` falls back
+                  to the Airflow API default (``id`` ascending, i.e. oldest first).
 
     Returns:
         JSON string containing the list of DAG runs with their metadata
     """
     try:
         adapter = _get_adapter()
-        data = adapter.list_dag_runs(dag_id=dag_id, limit=limit, offset=offset)
+        extra: dict[str, Any] = {}
+        if order_by is not None:
+            extra["order_by"] = order_by
+        data = adapter.list_dag_runs(dag_id=dag_id, limit=limit, offset=offset, **extra)
 
         if "dag_runs" in data:
             return _wrap_list_response(data["dag_runs"], "dag_runs", data)
@@ -213,7 +219,12 @@ def _trigger_dag_and_wait_impl(
 
 
 @mcp.tool()
-def list_dag_runs(dag_id: str | None = None) -> str:
+def list_dag_runs(
+    dag_id: str | None = None,
+    limit: int = DEFAULT_LIMIT,
+    offset: int = DEFAULT_OFFSET,
+    order_by: str = "-start_date",
+) -> str:
     """Get execution history and status of DAG runs (workflow executions).
 
     Use this tool when the user asks about:
@@ -237,11 +248,23 @@ def list_dag_runs(dag_id: str | None = None) -> str:
     Args:
         dag_id: Optional DAG ID to filter runs for a specific DAG.
                 If not provided, returns runs across all DAGs.
+        limit: Maximum number of DAG runs to return (default: 100).
+        offset: Offset for pagination (default: 0). Use together with `limit`
+                to page through DAGs that have more than `limit` runs.
+        order_by: Sort field; prefix with '-' for descending order.
+                  Defaults to '-start_date' so the most recent runs are
+                  returned first. The Airflow API default would be 'id'
+                  ascending (oldest first), which is rarely what callers want.
 
     Returns:
-        JSON with list of DAG runs, sorted by most recent
+        JSON with list of DAG runs, sorted most-recent-first by default
     """
-    return _list_dag_runs_impl(dag_id=dag_id)
+    return _list_dag_runs_impl(
+        dag_id=dag_id,
+        limit=limit,
+        offset=offset,
+        order_by=order_by,
+    )
 
 
 @mcp.tool()

--- a/astro-airflow-mcp/tests/test_cli_runs.py
+++ b/astro-airflow-mcp/tests/test_cli_runs.py
@@ -1,0 +1,48 @@
+"""Tests for the `af runs` CLI commands."""
+
+from unittest.mock import MagicMock
+
+from typer.testing import CliRunner
+
+from astro_airflow_mcp.cli.main import app
+
+runner = CliRunner()
+
+
+class TestRunsListCommand:
+    """Tests for `af runs list`."""
+
+    def test_defaults_to_newest_first(self, mocker):
+        """Default order_by is '-start_date' so the most recent runs come first."""
+        mock_adapter = MagicMock()
+        mock_adapter.list_dag_runs.return_value = {
+            "dag_runs": [{"dag_run_id": "manual__2024-12-31"}],
+            "total_entries": 1,
+        }
+        mocker.patch("astro_airflow_mcp.cli.runs.get_adapter", return_value=mock_adapter)
+
+        result = runner.invoke(app, ["runs", "list", "-d", "example_dag"])
+
+        assert result.exit_code == 0
+        mock_adapter.list_dag_runs.assert_called_once_with(
+            dag_id="example_dag",
+            limit=100,
+            offset=0,
+            order_by="-start_date",
+        )
+
+    def test_custom_order_by_overrides_default(self, mocker):
+        """Caller can override the default sort (e.g. to get oldest first)."""
+        mock_adapter = MagicMock()
+        mock_adapter.list_dag_runs.return_value = {"dag_runs": [], "total_entries": 0}
+        mocker.patch("astro_airflow_mcp.cli.runs.get_adapter", return_value=mock_adapter)
+
+        result = runner.invoke(app, ["runs", "list", "--order-by", "id"])
+
+        assert result.exit_code == 0
+        mock_adapter.list_dag_runs.assert_called_once_with(
+            dag_id=None,
+            limit=100,
+            offset=0,
+            order_by="id",
+        )

--- a/astro-airflow-mcp/tests/test_consolidated_tools.py
+++ b/astro-airflow-mcp/tests/test_consolidated_tools.py
@@ -119,6 +119,103 @@ class TestDiagnoseDagRun:
         assert "error" in data["run_info"]
 
 
+class TestListDagRunsTool:
+    """Tests for list_dag_runs MCP tool."""
+
+    def test_list_dag_runs_defaults_to_newest_first(self, mocker):
+        """Default order_by is '-start_date' so callers get recent runs, not oldest."""
+        mock_adapter = MagicMock()
+        mock_adapter.list_dag_runs.return_value = {
+            "dag_runs": [{"dag_run_id": "manual__2024-12-31"}],
+            "total_entries": 1,
+        }
+
+        mocker.patch("astro_airflow_mcp.tools.dag_run._get_adapter", return_value=mock_adapter)
+
+        list_fn = get_tool_fn(dag_run_module, "list_dag_runs")
+        list_fn("example_dag")
+
+        mock_adapter.list_dag_runs.assert_called_once_with(
+            dag_id="example_dag",
+            limit=100,
+            offset=0,
+            order_by="-start_date",
+        )
+
+    def test_list_dag_runs_passes_limit_and_offset(self, mocker):
+        """Caller-supplied limit and offset are forwarded to the adapter."""
+        mock_adapter = MagicMock()
+        mock_adapter.list_dag_runs.return_value = {"dag_runs": [], "total_entries": 0}
+
+        mocker.patch("astro_airflow_mcp.tools.dag_run._get_adapter", return_value=mock_adapter)
+
+        list_fn = get_tool_fn(dag_run_module, "list_dag_runs")
+        list_fn("example_dag", limit=25, offset=50)
+
+        mock_adapter.list_dag_runs.assert_called_once_with(
+            dag_id="example_dag",
+            limit=25,
+            offset=50,
+            order_by="-start_date",
+        )
+
+    def test_list_dag_runs_custom_order_by_overrides_default(self, mocker):
+        """Caller can override the default sort (e.g. to get oldest first)."""
+        mock_adapter = MagicMock()
+        mock_adapter.list_dag_runs.return_value = {"dag_runs": [], "total_entries": 0}
+
+        mocker.patch("astro_airflow_mcp.tools.dag_run._get_adapter", return_value=mock_adapter)
+
+        list_fn = get_tool_fn(dag_run_module, "list_dag_runs")
+        list_fn(order_by="id")
+
+        mock_adapter.list_dag_runs.assert_called_once_with(
+            dag_id=None,
+            limit=100,
+            offset=0,
+            order_by="id",
+        )
+
+    def test_list_dag_runs_impl_omits_order_by_when_none(self, mocker):
+        """The internal impl drops order_by when None so the Airflow default applies."""
+        mock_adapter = MagicMock()
+        mock_adapter.list_dag_runs.return_value = {"dag_runs": [], "total_entries": 0}
+
+        mocker.patch("astro_airflow_mcp.tools.dag_run._get_adapter", return_value=mock_adapter)
+
+        dag_run_module._list_dag_runs_impl(dag_id="example_dag", order_by=None)
+
+        mock_adapter.list_dag_runs.assert_called_once_with(
+            dag_id="example_dag",
+            limit=100,
+            offset=0,
+        )
+
+    def test_list_dag_runs_no_dag_runs_key(self, mocker):
+        """Falls back to a descriptive string when the API returns no dag_runs key."""
+        mock_adapter = MagicMock()
+        mock_adapter.list_dag_runs.return_value = {"unexpected": "shape"}
+
+        mocker.patch("astro_airflow_mcp.tools.dag_run._get_adapter", return_value=mock_adapter)
+
+        list_fn = get_tool_fn(dag_run_module, "list_dag_runs")
+        result = list_fn("example_dag")
+
+        assert "No DAG runs found" in result
+
+    def test_list_dag_runs_adapter_error(self, mocker):
+        """Exceptions from the adapter are returned as a string, not raised."""
+        mock_adapter = MagicMock()
+        mock_adapter.list_dag_runs.side_effect = Exception("boom")
+
+        mocker.patch("astro_airflow_mcp.tools.dag_run._get_adapter", return_value=mock_adapter)
+
+        list_fn = get_tool_fn(dag_run_module, "list_dag_runs")
+        result = list_fn("example_dag")
+
+        assert "boom" in result
+
+
 class TestDeleteDagRunTool:
     """Tests for delete_dag_run MCP tool."""
 

--- a/astro-airflow-mcp/tests/test_consolidated_tools.py
+++ b/astro-airflow-mcp/tests/test_consolidated_tools.py
@@ -176,8 +176,8 @@ class TestListDagRunsTool:
             order_by="id",
         )
 
-    def test_list_dag_runs_impl_omits_order_by_when_none(self, mocker):
-        """The internal impl drops order_by when None so the Airflow default applies."""
+    def test_list_dag_runs_impl_passes_order_by_none(self, mocker):
+        """order_by=None reaches the adapter as None; BaseAdapter._call drops Nones."""
         mock_adapter = MagicMock()
         mock_adapter.list_dag_runs.return_value = {"dag_runs": [], "total_entries": 0}
 
@@ -189,6 +189,7 @@ class TestListDagRunsTool:
             dag_id="example_dag",
             limit=100,
             offset=0,
+            order_by=None,
         )
 
     def test_list_dag_runs_no_dag_runs_key(self, mocker):


### PR DESCRIPTION
The `list_dag_runs` MCP tool only accepted `dag_id` and called Airflow's `GET /dags/{dag_id}/dagRuns` with no `order_by`. Airflow's default sort on that endpoint is `id ASC`, so for any DAG with more than 100 runs the tool returned the oldest 100 runs and the recent ones were unreachable through the MCP — directly contradicting the docstring's promise of "sorted by most recent".

The `af runs list` CLI hit the same root cause: `--order-by` defaulted to `None`, so the API again returned oldest-first. Issue #168 reported this from the CLI side.

## Changes

**MCP tool (`list_dag_runs`)**
- Exposes `limit`, `offset`, and `order_by` on the tool surface
- Defaults `order_by="-start_date"` so callers get newest-first

**CLI (`af runs list`)**
- Changes `--order-by` default from `None` to `-start_date`, matching the MCP tool

## Why `-start_date`

`start_date` is the only sort field available on both Airflow 2.x and 3.x DAG-run list endpoints. `run_after` is Airflow 3 only; `logical_date` doesn't exist in v2 (it's `execution_date` there). Picking `-start_date` keeps a single default that works across both adapters.

Callers who want a different order (e.g. `id` ascending to match the old Airflow default, or filter by state) can still pass `--order-by` explicitly on the CLI or `order_by=` on the MCP tool.

Closes #168