### PR TITLE
af CLI: Don't crash when AF_CONFIG points to a non-regular file

### DIFF
--- a/astro-airflow-mcp/src/astro_airflow_mcp/config/loader.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/config/loader.py
@@ -58,6 +58,14 @@ class ConfigManager:
             self.config_path = self.DEFAULT_CONFIG_DIR / self.DEFAULT_CONFIG_FILE
         self.lock_path = self.config_path.with_suffix(".lock")
 
+        # AF_CONFIG=/dev/null (or any non-regular file: directory, fifo,
+        # socket, device node) is sometimes used by wrappers as a
+        # "neutralize global config" sentinel. We can't read, write, or
+        # FileLock such a path — on macOS, opening /dev/null.lock with
+        # O_CREAT raises EPERM. Treat it as "no config": load() returns
+        # an empty config, save() is a no-op.
+        self._null_path = self.config_path.exists() and not self.config_path.is_file()
+
     def _ensure_dir(self) -> None:
         """Ensure the config directory exists."""
         self.config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -78,6 +86,9 @@ class ConfigManager:
         Raises:
             ConfigError: If config file is invalid
         """
+        if self._null_path:
+            return AirflowCliConfig.model_validate({})
+
         if not self.config_path.exists():
             config = self._create_default_config()
             self.save(config)
@@ -103,6 +114,9 @@ class ConfigManager:
         Args:
             config: Configuration to save
         """
+        if self._null_path:
+            return
+
         self._ensure_dir()
 
         with FileLock(self.lock_path):

--- a/astro-airflow-mcp/tests/test_config.py
+++ b/astro-airflow-mcp/tests/test_config.py
@@ -1,6 +1,7 @@
 """Tests for af CLI config module."""
 
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -496,6 +497,66 @@ class TestConfigManager:
 
         manager.use_instance("staging")
         assert manager.get_current_instance() == "staging"
+
+
+class TestConfigManagerNullPath:
+    """Tests for ConfigManager when AF_CONFIG points to a non-regular file.
+
+    Wrappers like `astro otto` set AF_CONFIG=/dev/null as a "neutralize
+    global config" sentinel. /dev/null is a character device, so FileLock
+    can't create /dev/null.lock (EPERM on macOS). ConfigManager should
+    detect this and treat the path as "no config".
+    """
+
+    def test_load_with_dev_null_via_env(self, monkeypatch):
+        """AF_CONFIG=/dev/null does not crash and yields an empty config."""
+        if not Path(os.devnull).exists() or Path(os.devnull).is_file():
+            pytest.skip("os.devnull is not a non-regular file on this platform")
+
+        monkeypatch.setenv("AF_CONFIG", os.devnull)
+        manager = ConfigManager()
+
+        config = manager.load()
+        assert config.instances == []
+        assert config.current_instance is None
+
+        # Lock file must not be created next to /dev/null.
+        assert not Path(os.devnull + ".lock").exists()
+
+    def test_load_with_directory_path(self, tmp_path):
+        """A directory passed as config_path is treated as 'no config'.
+
+        Platform-agnostic stand-in for /dev/null: a directory satisfies the
+        same `exists() and not is_file()` predicate that triggers the
+        null-path branch.
+        """
+        manager = ConfigManager(config_path=tmp_path)
+
+        config = manager.load()
+        assert config.instances == []
+        assert config.current_instance is None
+
+        # No lock file adjacent to the directory.
+        assert not tmp_path.with_suffix(".lock").exists()
+
+    def test_save_is_noop_for_null_path(self, tmp_path):
+        """save() silently no-ops when config_path is non-regular."""
+        manager = ConfigManager(config_path=tmp_path)
+
+        config = AirflowCliConfig(
+            instances=[Instance(name="x", url="http://x", auth=Auth(token="t"))],
+            current_instance="x",
+        )
+        # Must not raise and must not create a lock or dump YAML into the dir.
+        manager.save(config)
+
+        assert not tmp_path.with_suffix(".lock").exists()
+        assert list(tmp_path.iterdir()) == []
+
+    def test_resolve_instance_returns_none_for_null_path(self, tmp_path):
+        """resolve_instance() returns None when config is neutralized."""
+        manager = ConfigManager(config_path=tmp_path)
+        assert manager.resolve_instance() is None
 
 
 class TestResolvedConfig:


### PR DESCRIPTION
## Summary

Wrappers like `astro otto` set `AF_CONFIG=/dev/null` as a "neutralize the user's global `~/.af/config.yaml`" sentinel — they don't want the agent to silently inherit a stale `current-instance` pointer. The intent is reasonable, but `/dev/null` is a character device, so when `ConfigManager.load()` tries `FileLock(/dev/null.lock)`, macOS rejects the `O_CREAT` with EPERM:

```
PermissionError: [Errno 1] Operation not permitted: '/dev/null.lock'
```

This fires for every `af` subcommand — `af health`, `af config version`, `af dags errors`, etc. — and breaks every Otto skill that shells out to `af`.

This change makes `ConfigManager` defensive against non-regular `AF_CONFIG` paths regardless of who set them.

## Behavior

In `__init__`, compute `_null_path = config_path.exists() and not config_path.is_file()`. This catches `/dev/null`, directories, fifos, sockets, and other device nodes — anything where the standard read/lock/write flow can't apply.

When `_null_path` is true:
- `load()` returns an empty `AirflowCliConfig` without touching the path or attempting a `FileLock`.
- `save()` is a no-op.

`CLIContext.init()` already prioritizes env vars (`AIRFLOW_API_URL`, `AIRFLOW_USERNAME`, etc.) over config values, falling back to `DEFAULT_AIRFLOW_URL`. With an empty config, the priority chain still resolves correctly — same as if no config file existed.

## Why this approach

Three options were considered:

1. **Skip the lock in `load()`/`save()` based on file type** (this PR). Single point of detection in `__init__`, two short-circuits. Future callers automatically get the right behavior.
2. **Catch `PermissionError` in `_load_from_config`**. Hides the real exception class, fragile to other EPERM sources, doesn't help `save()` paths.
3. **Fall back to `~/.af/config.yaml` when `AF_CONFIG` is unusable**. Defeats the original "neutralize global config" intent — exactly what the wrapper was trying to avoid.

Option 1 keeps the wrapper's semantics ("ignore global config") while removing the crash.

## Gotchas

- `af instance add` / `delete` / `use` against an `AF_CONFIG=/dev/null` ConfigManager will appear to succeed but persist nothing. This matches the wrapper's intent (don't write to `~/.af`) and is unreachable in practice — these commands aren't run by the agent. Documenting here for completeness.
- A directory used as `config_path` (`af -c /some/dir`) now silently behaves as "no config" instead of raising. Same defensible "we got told a non-regular path, treat it as null" semantics. If we ever want to surface a clearer error for accidental misuse, we can add it later — but it's not the bug this PR addresses.
