### PR TITLE
ci: Bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/astro-airflow-mcp-ci.yml
+++ b/.github/workflows/astro-airflow-mcp-ci.yml
@@ -25,17 +25,17 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Full history for hatch-vcs to read version from tags
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
 
@@ -49,12 +49,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Full history for hatch-vcs to read version from tags
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Build and test Docker image
       working-directory: astro-airflow-mcp

--- a/.github/workflows/astro-airflow-mcp-integration.yml
+++ b/.github/workflows/astro-airflow-mcp-integration.yml
@@ -35,15 +35,15 @@ jobs:
             health-endpoint: "/api/v2/monitor/health"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
 

--- a/.github/workflows/astro-airflow-mcp-publish.yml
+++ b/.github/workflows/astro-airflow-mcp-publish.yml
@@ -21,19 +21,19 @@ jobs:
         working-directory: astro-airflow-mcp
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: 0  # Full history for hatch-vcs to read version from tags
           fetch-tags: true  # Explicitly fetch tags for version detection
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 
@@ -53,7 +53,7 @@ jobs:
           SETUPTOOLS_SCM_PRETEND_VERSION: ${{ steps.version.outputs.version }}
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-packages
           path: astro-airflow-mcp/dist/*
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist-packages
           path: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     name: Pre-commit checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Run prek
         run: uvx prek run --all-files
@@ -26,10 +26,10 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Run unit tests
         working-directory: skills/analyzing-data/scripts
@@ -54,10 +54,10 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Run integration tests
         working-directory: skills/analyzing-data/scripts
@@ -73,10 +73,10 @@ jobs:
     name: Type checking
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Run ty type checker
         working-directory: skills/analyzing-data/scripts


### PR DESCRIPTION
## Summary

GitHub deprecated Node.js 20 actions in [Sep 2025](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Runners default to Node 24 starting 2026-06-02 and Node 20 is removed entirely on 2026-09-16. Every CI run currently logs a deprecation warning for `actions/checkout@v4`, `actions/setup-python@v5`, `actions/upload-artifact@v4`, and `astral-sh/setup-uv@v5`.

## Changes

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | `v4` | `v6` |
| `actions/setup-python` | `v5` | `v6` |
| `actions/upload-artifact` | `v4` | `v7` |
| `actions/download-artifact` | `v4` | `v8` |
| `docker/setup-buildx-action` | `v3` | `v4` |
| `astral-sh/setup-uv` | `v5` | `v8.1.0` |

## Why `setup-uv` pinned to an exact version

`astral-sh/setup-uv` [stopped publishing major/minor tags in v8.0.0](https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0) to harden against supply-chain attacks (the same class as the [tj-actions compromise](https://unit42.paloaltonetworks.com/github-actions-supply-chain-attack/)). They explicitly recommend pinning to immutable tags like `v8.1.0` or a git SHA. Tradeoff: future patches require a manual bump, but the security posture is stricter and matches the project's own guidance.

## Behavior changes worth flagging

- `actions/checkout@v6` stores credentials under `$RUNNER_TEMP` instead of git config. No effect here — `astro-airflow-mcp-publish.yml` uses `persist-credentials: false`; everything else uses defaults that don't read those creds back.
- `actions/download-artifact@v8` errors on hash mismatch by default (was warn). Same job creates and consumes the artifact in our publish workflow, so a mismatch would itself be a real bug we'd want to fail on.
- `docker/setup-buildx-action@v4` removes deprecated inputs/outputs. Our usage passes no inputs.
- All bumps require Actions Runner ≥ v2.327.1, which GitHub-hosted runners already satisfy.