### PR TITLE
ci: Add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions-minor-patch:
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` so Dependabot opens weekly PRs to bump GitHub Actions versions. Would have surfaced the Node 20 deprecation (PR #195) months ago instead of us catching it from CI warnings.

## Behavior

- **Weekly schedule.** One pass per week per ecosystem.
- **Grouped minor/patch bumps.** All non-major action updates land in a single PR (`actions-minor-patch`) to keep noise low.
- **Majors get their own PR.** Breaking-change reviews stay isolated — useful for cases like `setup-uv@v8` removing major-version tags.
- **Commits prefixed `ci:`** to match the project's commit style.
- **Labels: `dependencies`, `github-actions`** for filtering.

## Why GitHub Actions only (for now)

Scoping narrowly so we can see how the cadence feels before extending to `pip` for `astro-airflow-mcp/` or vendored skill dirs. Easy to add later if this proves useful.

## Tradeoffs

- One extra PR/week even when there's nothing exciting to bump. Mitigated by grouping.
- For pinned actions like `astral-sh/setup-uv@v8.1.0` (intentionally pinned because the project no longer publishes major tags), Dependabot will propose patch bumps — exactly what we want, since that's the only way to track upstream there.