### PR TITLE
Use bare `af` in skills instead of spelled-out uvx invocation

### DIFF
--- a/skills/airflow-hitl/SKILL.md
+++ b/skills/airflow-hitl/SKILL.md
@@ -7,7 +7,7 @@ description: Use when the user needs human-in-the-loop workflows in Airflow (app
 
 Pause a DAG until a human responds via the Airflow UI or REST API. HITL operators are deferrable — they release their worker slot while waiting.
 
-> **Requires Airflow 3.1+** (`uvx --from astro-airflow-mcp af config version`).
+> **Requires Airflow 3.1+** (`af config version`).
 >
 > **UI location**: Browse → Required Actions. Respond from the task instance page's Required Actions tab.
 >
@@ -35,15 +35,15 @@ Before writing HITL code, run these to see the live roster and constructor param
 
 ```bash
 # Every HITL-related module in the standard provider
-uvx --from astro-airflow-mcp af registry modules standard \
+af registry modules standard \
   | jq '.modules[] | select(.import_path | test("\\.hitl\\.")) | {name, type, import_path, short_description, docs_url}'
 
 # Constructor signatures: name, type, default, required, description
-uvx --from astro-airflow-mcp af registry parameters standard \
+af registry parameters standard \
   | jq '.classes | to_entries[] | select(.key | test("\\.hitl\\.")) | {fqn: .key, parameters: .value.parameters}'
 
 # Pin to the exact installed provider version
-uvx --from astro-airflow-mcp af config providers \
+af config providers \
   | jq '.providers[] | select(.package_name == "apache-airflow-providers-standard") | .version'
 # then: af registry parameters standard --version <VERSION>
 ```
@@ -117,7 +117,7 @@ HITL operators accept a `notifiers` list. Inside a notifier's `notify(context)` 
 The parameter name and accepted identifier format depend on the active auth manager. Do **not** hardcode — check which one is active and which kwarg the current provider exposes:
 
 ```bash
-uvx --from astro-airflow-mcp af config show | jq '.auth_manager // .core.auth_manager'
+af config show | jq '.auth_manager // .core.auth_manager'
 ```
 
 Then look up the current kwarg in Step 2 (at the time of writing it is `assigned_users`, accepting identifiers in whatever format the active auth manager uses — Astro uses the Astro user ID, FabAuthManager uses email, SimpleAuthManager uses username).
@@ -129,8 +129,8 @@ Then look up the current kwarg in Step 2 (at the time of writing it is `assigned
 For Slack bots, custom apps, or scripts. Discover the live endpoint rather than hardcoding a path:
 
 ```bash
-uvx --from astro-airflow-mcp af api ls --filter hitl           # live endpoint list
-uvx --from astro-airflow-mcp af api spec \
+af api ls --filter hitl           # live endpoint list
+af api spec \
   | jq '.paths | to_entries[] | select(.key | test("hitl"))'   # request/response schemas
 ```
 
@@ -172,7 +172,7 @@ requests.patch(
 The upstream docs URL is surfaced per-module by the registry — do not hardcode:
 
 ```bash
-uvx --from astro-airflow-mcp af registry modules standard \
+af registry modules standard \
   | jq '.modules[] | select(.import_path | test("\\.hitl\\.")) | {name, docs_url}'
 ```
 

--- a/skills/airflow/SKILL.md
+++ b/skills/airflow/SKILL.md
@@ -38,13 +38,7 @@ For more details:
 
 ## Running the CLI
 
-Run all `af` commands using uvx (no installation required):
-
-```bash
-uvx --from astro-airflow-mcp af <command>
-```
-
-Throughout this document, `af` is shorthand for `uvx --from astro-airflow-mcp af`.
+These commands assume `af` is on PATH. Run via `astro otto` to get it automatically, or install standalone with `uv tool install astro-airflow-mcp`.
 
 ## Instance Configuration
 

--- a/skills/airflow/hooks/warm-uvx-cache.sh
+++ b/skills/airflow/hooks/warm-uvx-cache.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
-# Hook: SessionStart - Warm the uvx cache for astro-airflow-mcp
-# This ensures subsequent `uvx --from astro-airflow-mcp af` calls are fast
+# Hook: SessionStart - Warm the af / uvx cache so the first real call is fast.
+#
+# `af` on PATH is typically a thin shell wrapper that exec's
+# `uvx --from 'astro-airflow-mcp==<pin>' af`, so invoking it once warms the
+# uvx cache for whichever pin the wrapper installs. No-op if `af` isn't on
+# PATH (the skill's body tells the user how to install it).
 
-# Run in background so we don't block session startup
-(uvx --from astro-airflow-mcp@latest af --version > /dev/null 2>&1 &)
+(af --version > /dev/null 2>&1 &)
 
 exit 0

--- a/skills/authoring-dags/SKILL.md
+++ b/skills/authoring-dags/SKILL.md
@@ -18,13 +18,7 @@ This skill guides you through creating and validating Airflow DAGs using best pr
 
 ## Running the CLI
 
-Run all `af` commands using uvx (no installation required):
-
-```bash
-uvx --from astro-airflow-mcp af <command>
-```
-
-Throughout this document, `af` is shorthand for `uvx --from astro-airflow-mcp af`.
+These commands assume `af` is on PATH. Run via `astro otto` to get it automatically, or install standalone with `uv tool install astro-airflow-mcp`.
 
 ---
 

--- a/skills/debugging-dags/SKILL.md
+++ b/skills/debugging-dags/SKILL.md
@@ -9,13 +9,7 @@ You are a data engineer debugging a failed Airflow DAG. Follow this systematic a
 
 ## Running the CLI
 
-Run all `af` commands using uvx (no installation required):
-
-```bash
-uvx --from astro-airflow-mcp af <command>
-```
-
-Throughout this document, `af` is shorthand for `uvx --from astro-airflow-mcp af`.
+These commands assume `af` is on PATH. Run via `astro otto` to get it automatically, or install standalone with `uv tool install astro-airflow-mcp`.
 
 ---
 

--- a/skills/testing-dags/SKILL.md
+++ b/skills/testing-dags/SKILL.md
@@ -9,13 +9,7 @@ Use `af` commands to test, debug, and fix DAGs in iterative cycles.
 
 ## Running the CLI
 
-Run all `af` commands using uvx (no installation required):
-
-```bash
-uvx --from astro-airflow-mcp af <command>
-```
-
-Throughout this document, `af` is shorthand for `uvx --from astro-airflow-mcp af`.
+These commands assume `af` is on PATH. Run via `astro otto` to get it automatically, or install standalone with `uv tool install astro-airflow-mcp`.
 
 ---
 


### PR DESCRIPTION
## Summary

Skills currently tell the agent to run `uvx --from astro-airflow-mcp af <command>`, which silently bypasses whatever `af` wrapper the agent platform installs and resolves to whatever astro-airflow-mcp uvx happens to cache. That means a single session can run two different `af` versions depending on which guidance the agent follows. Pinning is also nonexistent: `astro-airflow-mcp` with no `==` constraint is "whatever PyPI gave uvx the first time it cached this spec."

This PR switches every skill to plain `af` and pushes pin responsibility down to whichever wrapper is on PATH:

- `astro otto` installs `~/.astro/otto/bin/af` pinned to its tested release
- Astro CLI installs `~/.astro/bin/af` pinned to its tested release (https://github.com/astronomer/astro-cli/pull/2112)
- standalone users `uv tool install astro-airflow-mcp`

## Changes

- drop the "Running the CLI" boilerplate that hardcoded the uvx form in `airflow`, `debugging-dags`, `testing-dags`, `authoring-dags`. Replaced with a one-line "assumes `af` is on PATH; here's how to install" note
- rewrite the 8 inline `uvx --from astro-airflow-mcp af` invocations in `airflow-hitl/SKILL.md` to bare `af`
- `airflow/hooks/warm-uvx-cache.sh` now warms via `af --version` so it warms whichever pin is actually in use, rather than warming a `@latest` env that nothing reads

## Out of scope

- `README.md`, `CONTRIBUTING.md`, `astro-airflow-mcp/README.md` still spell out the uvx invocation. Those are human-facing setup docs, not agent instructions, so they don't have the two-versions-in-one-session problem. Worth a follow-up but separate concern

## Test plan

- [x] `grep -rn "uvx --from astro-airflow-mcp" skills/` returns zero hits
- [x] every `af` reference in the 5 modified skills still works under `astro otto` (verified that the wrapper installer puts `af` on PATH)