### PR TITLE
af: catch OSError in _read_yaml so non-file ASTRO_HOME degrades gracefully

### DIFF
--- a/astro-airflow-mcp/src/astro_airflow_mcp/_astro_session.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/_astro_session.py
@@ -47,15 +47,18 @@ def _config_path() -> Path:
 
 
 def _read_yaml(path: Path) -> dict[str, Any]:
-    """Read and parse the astro config. Empty/missing/unreadable → {}.
+    """Read and parse the astro config. Empty/missing/non-file → {}.
 
-    Returns an empty dict on any OSError (missing file, permission denied,
-    ASTRO_HOME pointing at a non-directory like ``/dev/null``, etc) so the
-    caller falls through to "no astro session" rather than the raw OS error.
+    Treats "missing or not-a-regular-file" as "no astro session" (path is
+    absent, ASTRO_HOME points at /dev/null or a directory, etc). Other
+    OSError shapes (PermissionError, IOError) are deliberately not
+    swallowed — those mean a real config exists but isn't readable, and
+    surfacing the error is more useful than a misleading "run astro
+    login" downstream.
     """
     try:
         text = path.read_text()
-    except OSError:
+    except (FileNotFoundError, NotADirectoryError, IsADirectoryError):
         return {}
     try:
         return yaml.safe_load(text) or {}
@@ -67,7 +70,7 @@ def _read_yaml(path: Path) -> dict[str, Any]:
         time.sleep(0.05)
         try:
             return yaml.safe_load(path.read_text()) or {}
-        except (OSError, yaml.YAMLError):
+        except (FileNotFoundError, NotADirectoryError, IsADirectoryError, yaml.YAMLError):
             return {}
 
 

--- a/astro-airflow-mcp/src/astro_airflow_mcp/_astro_session.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/_astro_session.py
@@ -47,10 +47,15 @@ def _config_path() -> Path:
 
 
 def _read_yaml(path: Path) -> dict[str, Any]:
-    """Read and parse the astro config. Empty/missing → {}."""
+    """Read and parse the astro config. Empty/missing/unreadable → {}.
+
+    Returns an empty dict on any OSError (missing file, permission denied,
+    ASTRO_HOME pointing at a non-directory like ``/dev/null``, etc) so the
+    caller falls through to "no astro session" rather than the raw OS error.
+    """
     try:
         text = path.read_text()
-    except FileNotFoundError:
+    except OSError:
         return {}
     try:
         return yaml.safe_load(text) or {}
@@ -62,7 +67,7 @@ def _read_yaml(path: Path) -> dict[str, Any]:
         time.sleep(0.05)
         try:
             return yaml.safe_load(path.read_text()) or {}
-        except (FileNotFoundError, yaml.YAMLError):
+        except (OSError, yaml.YAMLError):
             return {}
 
 

--- a/astro-airflow-mcp/tests/test_astro_pat.py
+++ b/astro-airflow-mcp/tests/test_astro_pat.py
@@ -577,3 +577,13 @@ class TestParsedYamlRobustness:
         resolver = AstroPATResolver(env={})
         with pytest.raises(AstroNotLoggedInError):
             resolver.get_token()
+
+    def test_astro_home_at_dev_null_treated_as_no_session(self, monkeypatch):
+        # ASTRO_HOME=/dev/null is a sentinel some wrappers use to "neutralize"
+        # global astro state. Reading /dev/null/config.yaml raises
+        # NotADirectoryError (an OSError, NOT FileNotFoundError); the
+        # resolver should still surface "no session" cleanly.
+        monkeypatch.setenv("ASTRO_HOME", "/dev/null")
+        resolver = AstroPATResolver(env={})
+        with pytest.raises(AstroNotLoggedInError):
+            resolver.get_token()

--- a/astro-airflow-mcp/tests/test_astro_pat.py
+++ b/astro-airflow-mcp/tests/test_astro_pat.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import os
 import threading
 import time
 from datetime import datetime, timedelta, timezone
-from pathlib import Path  # noqa: TC003 — used as runtime fixture parameter type
+from pathlib import Path
 
 import httpx
 import pytest
@@ -579,11 +580,13 @@ class TestParsedYamlRobustness:
             resolver.get_token()
 
     def test_astro_home_at_dev_null_treated_as_no_session(self, monkeypatch):
-        # ASTRO_HOME=/dev/null is a sentinel some wrappers use to "neutralize"
-        # global astro state. Reading /dev/null/config.yaml raises
-        # NotADirectoryError (an OSError, NOT FileNotFoundError); the
-        # resolver should still surface "no session" cleanly.
-        monkeypatch.setenv("ASTRO_HOME", "/dev/null")
+        # ASTRO_HOME=os.devnull is a sentinel some wrappers use to "neutralize"
+        # global astro state. Reading <devnull>/config.yaml raises
+        # NotADirectoryError (not FileNotFoundError); the resolver should
+        # still surface "no session" cleanly.
+        if not Path(os.devnull).exists() or Path(os.devnull).is_file():
+            pytest.skip("os.devnull is not a non-regular file on this platform")
+        monkeypatch.setenv("ASTRO_HOME", os.devnull)
         resolver = AstroPATResolver(env={})
         with pytest.raises(AstroNotLoggedInError):
             resolver.get_token()


### PR DESCRIPTION
## summary

found while smoke-testing the 0.7.0a1 alpha (#204): `_read_yaml` only caught `FileNotFoundError`, so any other read failure leaked through as an uncaught exception that `detect_version` then masked as "Failed to detect Airflow version"

simplest repro: `ASTRO_HOME=/dev/null af api version` (`/dev/null/config.yaml` raises `NotADirectoryError`, which is an `OSError` but not `FileNotFoundError`). same for permission-denied or broken symlinks

## what changed

- `_read_yaml` now catches `OSError` instead of `FileNotFoundError` (both the initial read and the partial-write retry)
- regression test: `ASTRO_HOME=/dev/null` now surfaces `AstroNotLoggedInError` cleanly

## test plan

- [x] uv run pytest --ignore=tests/integration (490/490)
- [x] uv run prek run --all-files
- [x] manual smoke: `ASTRO_HOME=/dev/null af api version` now reports "No astro context. Run astro login first." instead of "Failed to detect Airflow version"