### PR TITLE
Don't pin Airflow Version on `astro dev init`

### DIFF
--- a/skills/managing-astro-local-env/SKILL.md
+++ b/skills/managing-astro-local-env/SKILL.md
@@ -48,6 +48,8 @@ Docker-free local development. Runs Airflow directly on your machine in a `.venv
 
 **Requirements:** Airflow 3 (runtime 3.x), `uv` on PATH. Not supported on Windows.
 
+> Plain `astro dev init` already pins a runtime 3.x image, so no version flag is needed. See **setting-up-astro-project** for project initialization.
+
 ### Start
 
 ```bash

--- a/skills/setting-up-astro-project/SKILL.md
+++ b/skills/setting-up-astro-project/SKILL.md
@@ -19,6 +19,8 @@ This skill helps you initialize and configure Airflow projects using the Astro C
 astro dev init
 ```
 
+> **Don't pass `--airflow-version` or `--runtime-version` unless the user explicitly asks for a specific pin.** Plain `astro dev init` resolves to the latest Astro Runtime — that's the right default. Specifying a version risks pinning to a stale value from training data. If the user wants to know what was installed, read the generated `Dockerfile` afterward instead of guessing.
+
 Creates this structure:
 ```
 project/


### PR DESCRIPTION
## Summary

Otto on GPT-5.4 (high) was observed pinning Airflow `3.1.0` when a user asked it to *"Configure this project for standalone mode and start local Airflow"* on an empty directory. The expected behavior is to land on the latest Astro Runtime — plain `astro dev init` already does this.

What the model did instead, captured in its reasoning trace from the chat export:

> "I should check the latest supported 3.x version. I might use `astro dev init --airflow-version 3.1.0 --force`."

It then ran exactly that, despite having just read `astro dev init --help` which says **"If not specified, latest is assumed."** End state for the user: `runtime:3.1-2` / Airflow `3.1.0+astro.2` instead of the latest 3.2.x.

This is a knowledge-cutoff hallucination: `3.1.0` is well-represented in training data, the current latest is post-cutoff, and the model substituted memory for the freshly-fetched help text.

## Fix

Two minimal skill edits that block the failure at its source:

1. **`setting-up-astro-project/SKILL.md`** — explicit DON'T directly under the `astro dev init` snippet. Tells the model not to pass `--airflow-version` / `--runtime-version` unless the user explicitly asks for a pin, and points it at the generated `Dockerfile` if it wants to *report* the resolved version rather than guess.
2. **`managing-astro-local-env/SKILL.md`** — one-line reinforcement under the standalone-mode requirements section. The "Airflow 3 (runtime 3.x)" line was enough on its own to nudge the model into picking a 3.x value; the new note clarifies that the default already gives you 3.x.

## Design rationale

- **Why not patch the CLI / runtime instead?** The CLI is correct — `astro dev init` defaults to latest. The bug is purely in the model's decision to add a flag the skill never asked for.
- **Why two skills?** The model loaded both in the failure case. Patching only `setting-up-astro-project` leaves the "runtime 3.x" phrasing in `managing-astro-local-env` as a residual nudge toward picking a version. Both edits are cheap and the risk of duplication is low.
- **Why not a hard CI check?** Skill content is the cheapest layer to fix this. A regression eval that asserts the resulting `Dockerfile` after a setup task would catch future variants of this failure mode and is worth following up on separately, but is out of scope here.

## Gotchas

- This relies on the model following the skill's DON'T. It's not a hard guard, but is consistent with how every other behavioral rule in these skills works.
- `migrating-airflow-2-to-3/SKILL.md` line 16 currently nudges users toward Airflow 3.1 as a migration target. That line is correct in its own context (it's about *upgrade path stability*, not "pick a version") and is left untouched here. Worth bumping to "the latest 3.x" in a separate PR once 3.2 is the broadly-recommended target.