### PR TITLE
af: update --config help text to reference ~/.astro/config.yaml

### DIFF
--- a/astro-airflow-mcp/src/astro_airflow_mcp/cli/main.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/cli/main.py
@@ -45,7 +45,7 @@ def main(
             "--config",
             "-c",
             envvar="AF_CONFIG",
-            help="Path to config file (default: ~/.af/config.yaml)",
+            help="Path to config file (default: ~/.astro/config.yaml)",
         ),
     ] = None,
     _version: Annotated[
@@ -67,7 +67,7 @@ def main(
     - AIRFLOW_PASSWORD: Password for basic auth
     - AIRFLOW_AUTH_TOKEN: Bearer token (takes precedence over basic auth)
 
-    Or configure named instances in ~/.af/config.yaml and switch with:
+    Or configure named instances in ~/.astro/config.yaml and switch with:
         af instance use <name>
 
     Setting AIRFLOW_API_URL to an empty string signals "no Airflow is


### PR DESCRIPTION
## Summary
- The layered-config PR (#207) moved the default global path from `~/.af/config.yaml` to `~/.astro/config.yaml` but two user-facing strings in `cli/main.py` still pointed at the old location.
- This brings `af --help` in line with the README and skill docs.

## Test plan
- [x] `af --help` shows `(default: ~/.astro/config.yaml)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)