### PR TITLE
remove dbt-agent-skills submodule and vendored skill links

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/dbt-agent-skills"]
-	path = vendor/dbt-agent-skills
-	url = https://github.com/dbt-labs/dbt-agent-skills.git

--- a/README.md
+++ b/README.md
@@ -196,21 +196,6 @@ The `astronomer-data` plugin bundles an MCP server and skills into a single inst
 | [cosmos-dbt-core](./skills/cosmos-dbt-core/) | Run dbt Core projects as Airflow DAGs using [Astronomer Cosmos](https://github.com/astronomer/astronomer-cosmos) |
 | [cosmos-dbt-fusion](./skills/cosmos-dbt-fusion/) | Run dbt Fusion projects with Cosmos (Snowflake/Databricks only) |
 
-**dbt skills by [dbt Labs](https://github.com/dbt-labs/dbt-agent-skills)** — analytics engineering, semantic layer, and dbt platform operations:
-
-| Skill | Description |
-|-------|-------------|
-| [using-dbt-for-analytics-engineering](./skills/using-dbt-for-analytics-engineering/) | Build and modify dbt models, write SQL transformations, create tests, and validate results |
-| [running-dbt-commands](./skills/running-dbt-commands/) | Format and execute dbt CLI commands with the correct executable and parameters |
-| [building-dbt-semantic-layer](./skills/building-dbt-semantic-layer/) | Create semantic models, metrics, dimensions, entities, and measures with MetricFlow |
-| [adding-dbt-unit-test](./skills/adding-dbt-unit-test/) | Create unit test YAML definitions that mock inputs and validate expected outputs |
-| [answering-natural-language-questions-with-dbt](./skills/answering-natural-language-questions-with-dbt/) | Query the data warehouse using dbt's Semantic Layer to answer business questions |
-| [troubleshooting-dbt-job-errors](./skills/troubleshooting-dbt-job-errors/) | Diagnose dbt Cloud job failures by analyzing run logs and the Admin API |
-| [configuring-dbt-mcp-server](./skills/configuring-dbt-mcp-server/) | Set up and troubleshoot the dbt MCP server for AI tools |
-| [fetching-dbt-docs](./skills/fetching-dbt-docs/) | Retrieve dbt documentation pages in LLM-friendly markdown format |
-| [migrating-dbt-core-to-fusion](./skills/migrating-dbt-core-to-fusion/) | Migrate a dbt project from dbt Core to the Fusion engine |
-| [migrating-dbt-project-across-platforms](./skills/migrating-dbt-project-across-platforms/) | Migrate a dbt project between data platforms (e.g., Snowflake to Databricks) |
-
 #### Migration
 
 | Skill | Description |
@@ -445,12 +430,9 @@ See [CLAUDE.md](./CLAUDE.md) for plugin development guidelines.
 ### Local Development Setup
 
 ```bash
-# Clone the repo (includes submodules for vendored skills)
-git clone --recurse-submodules https://github.com/astronomer/agents.git
+# Clone the repo
+git clone https://github.com/astronomer/agents.git
 cd agents
-
-# If already cloned without submodules:
-# git submodule update --init
 
 # Test with local plugin
 claude --plugin-dir .

--- a/skills/adding-dbt-unit-test
+++ b/skills/adding-dbt-unit-test
@@ -1,1 +1,0 @@
-../vendor/dbt-agent-skills/skills/dbt/skills/adding-dbt-unit-test

--- a/skills/answering-natural-language-questions-with-dbt
+++ b/skills/answering-natural-language-questions-with-dbt
@@ -1,1 +1,0 @@
-../vendor/dbt-agent-skills/skills/dbt/skills/answering-natural-language-questions-with-dbt

--- a/skills/building-dbt-semantic-layer
+++ b/skills/building-dbt-semantic-layer
@@ -1,1 +1,0 @@
-../vendor/dbt-agent-skills/skills/dbt/skills/building-dbt-semantic-layer

--- a/skills/configuring-dbt-mcp-server
+++ b/skills/configuring-dbt-mcp-server
@@ -1,1 +1,0 @@
-../vendor/dbt-agent-skills/skills/dbt/skills/configuring-dbt-mcp-server

--- a/skills/fetching-dbt-docs
+++ b/skills/fetching-dbt-docs
@@ -1,1 +1,0 @@
-../vendor/dbt-agent-skills/skills/dbt/skills/fetching-dbt-docs

--- a/skills/migrating-dbt-core-to-fusion
+++ b/skills/migrating-dbt-core-to-fusion
@@ -1,1 +1,0 @@
-../vendor/dbt-agent-skills/skills/dbt-migration/skills/migrating-dbt-core-to-fusion

--- a/skills/migrating-dbt-project-across-platforms
+++ b/skills/migrating-dbt-project-across-platforms
@@ -1,1 +1,0 @@
-../vendor/dbt-agent-skills/skills/dbt-migration/skills/migrating-dbt-project-across-platforms

--- a/skills/running-dbt-commands
+++ b/skills/running-dbt-commands
@@ -1,1 +1,0 @@
-../vendor/dbt-agent-skills/skills/dbt/skills/running-dbt-commands

--- a/skills/troubleshooting-dbt-job-errors
+++ b/skills/troubleshooting-dbt-job-errors
@@ -1,1 +1,0 @@
-../vendor/dbt-agent-skills/skills/dbt/skills/troubleshooting-dbt-job-errors

--- a/skills/using-dbt-for-analytics-engineering
+++ b/skills/using-dbt-for-analytics-engineering
@@ -1,1 +1,0 @@
-../vendor/dbt-agent-skills/skills/dbt/skills/using-dbt-for-analytics-engineering


### PR DESCRIPTION
## Summary

The dbt skills sourced from [dbt-labs/dbt-agent-skills](https://github.com/dbt-labs/dbt-agent-skills) will be made available through a different mechanism, so this PR drops the vendored copy:

- removes the `vendor/dbt-agent-skills` submodule (and `.gitmodules`)
- removes the 10 symlinks in `skills/` that pointed into it (`adding-dbt-unit-test`, `answering-natural-language-questions-with-dbt`, `building-dbt-semantic-layer`, `configuring-dbt-mcp-server`, `fetching-dbt-docs`, `migrating-dbt-core-to-fusion`, `migrating-dbt-project-across-platforms`, `running-dbt-commands`, `troubleshooting-dbt-job-errors`, `using-dbt-for-analytics-engineering`)
- updates the README — drops the "dbt skills by dbt Labs" subsection and the `--recurse-submodules` clone instruction

`skills/cosmos-dbt-core` and `skills/cosmos-dbt-fusion` stay — they're maintained in this repo, not vendored.

## Test plan

- [ ] `git clone` (without `--recurse-submodules`) and confirm the plugin installs cleanly
- [ ] `claude --plugin-dir .` and verify the cosmos-dbt-* skills still load
- [ ] confirm none of the removed dbt skills appear in the available-skills list