### PR TITLE
af: skip preamble lines when parsing astro CLI table output

### DIFF
--- a/astro-airflow-mcp/src/astro_airflow_mcp/discovery/astro_cli.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/discovery/astro_cli.py
@@ -192,11 +192,25 @@ class AstroCli:
         if len(lines) < 2:
             return []
 
-        header_line = lines[0]
-        boundaries = self._find_column_boundaries(header_line)
+        # Skip non-table preamble lines before the real header. astro CLI
+        # prepends informational lines to stdout in some configurations
+        # (eg ``Using an Astro API Token`` when ``ASTRO_API_TOKEN`` is
+        # set), which would otherwise be misread as the header. A real
+        # multi-column header boundary-detects to >=2 columns; preamble
+        # lines have only single-space gaps and yield 1.
+        header_idx: int | None = None
+        boundaries: list[int] = []
+        for idx, line in enumerate(lines):
+            candidate = self._find_column_boundaries(line)
+            if len(candidate) >= 2:
+                header_idx = idx
+                boundaries = candidate
+                break
 
-        if not boundaries:
+        if header_idx is None or not boundaries:
             return []
+
+        header_line = lines[header_idx]
 
         # Extract header names using boundaries
         headers: list[tuple[str, int]] = []
@@ -211,7 +225,7 @@ class AstroCli:
 
         # Parse data rows using same boundaries
         results = []
-        for line in lines[1:]:
+        for line in lines[header_idx + 1 :]:
             if not line.strip():
                 continue
 

--- a/astro-airflow-mcp/tests/test_astro_cli.py
+++ b/astro-airflow-mcp/tests/test_astro_cli.py
@@ -240,6 +240,33 @@ class TestTableParsing:
         assert result[0]["status"] == ""
         assert result[1]["status"] == "HEALTHY"
 
+    def test_parse_table_output_skips_api_token_preamble(self, mock_cli):
+        """Astro CLI prints ``Using an Astro API Token`` ahead of the
+        table when ``ASTRO_API_TOKEN`` is set. The parser must skip it
+        rather than treating it as the header row (it has only
+        single-space gaps and would collapse the table to one column).
+        """
+        output = """Using an Astro API Token
+ NAME     NAMESPACE                    DEPLOYMENT ID
+ test     physical-refraction-2416     cml0a458406f401jkva87iahu"""
+
+        result = mock_cli._parse_table_output(output)
+        assert len(result) == 1
+        assert result[0]["name"] == "test"
+        assert result[0]["namespace"] == "physical-refraction-2416"
+        assert result[0]["deployment_id"] == "cml0a458406f401jkva87iahu"
+
+    def test_parse_table_output_preamble_only_no_table(self, mock_cli):
+        """When astro CLI prints a preamble but no table (eg auth notice
+        followed by ``no Deployments found in workspace X``), the parser
+        should return ``[]`` rather than misparsing the no-results line.
+        """
+        output = """Using an Astro API Token
+no Deployments found in workspace my-workspace"""
+
+        result = mock_cli._parse_table_output(output)
+        assert result == []
+
 
 class TestAstroCliContext:
     """Tests for context management.


### PR DESCRIPTION
## Summary
- When `ASTRO_API_TOKEN` is set in the env, astro CLI prepends `Using an Astro API Token` to stdout (see `astro-cli` `cmd/cloud/setup.go:362`). The af table parser was treating that line as the header row, collapsing the deployment table to a single column called `using_an_astro_api_token`, so every row was dropped silently and `af instance discover` reported `No instances discovered` with no error.
- Walk `lines` from the top and pick the first line that boundary-detects to 2+ columns as the real header. A real multi-column header always has 2-space gaps and yields 2+ boundaries; preamble lines have only single-space gaps and yield 1.
- Fix is generic: handles any future single-line preamble astro CLI may add (warnings, deprecation notices, etc.) without needing to enumerate them.
- `astro deployment list --json` would also fix this, but it was only added in astro CLI v1.42.0 (#2063), so falling back across older versions still requires this parser to be robust.

## Test plan
- [x] New unit test covers the `Using an Astro API Token` preamble case
- [x] New unit test covers preamble + no-results (`no Deployments found in workspace X`) - returns `[]` cleanly
- [x] Existing 33 table-parsing tests still pass
- [x] Full `tests/test_astro_cli.py` + `tests/test_discovery.py` green (76/76)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>