### PR TITLE
feat(astro-airflow-mcp): expose limit/offset on list_variables MCP tool

### DIFF
--- a/astro-airflow-mcp/src/astro_airflow_mcp/tools/admin.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/tools/admin.py
@@ -273,7 +273,10 @@ def get_variable(variable_key: str) -> str:
 
 
 @mcp.tool()
-def list_variables() -> str:
+def list_variables(
+    limit: int = DEFAULT_LIMIT,
+    offset: int = DEFAULT_OFFSET,
+) -> str:
     """Get all Airflow variables (key-value configuration pairs).
 
     Use this tool when the user asks about:
@@ -295,10 +298,18 @@ def list_variables() -> str:
     IMPORTANT: Sensitive variables (like passwords, API keys) may have their
     values masked in the response for security reasons.
 
+    Pagination: the response includes ``total_variables`` and ``returned_count``.
+    If ``total_variables > returned_count``, call again with
+    ``offset=offset + returned_count`` to fetch the next page.
+
+    Args:
+        limit: Maximum number of variables to return (default: 100)
+        offset: Offset for pagination (default: 0)
+
     Returns:
-        JSON with list of all variables and their values
+        JSON with list of variables, total count, and returned count
     """
-    return _list_variables_impl()
+    return _list_variables_impl(limit=limit, offset=offset)
 
 
 @mcp.tool()


### PR DESCRIPTION
## Summary

The `list_variables` MCP tool in `astro-airflow-mcp` currently exposes no arguments and always calls `_list_variables_impl()` with the default limit of 100. The underlying `_list_variables_impl(limit, offset)` already accepts pagination parameters and so do several other list-style tools in this package — `list_variables` is just missing the pass-through.

When an Airflow deployment has more than 100 variables, the tool silently returns only the first 100. The wrapped response includes `total_variables` and `returned_count` so the truncation is detectable by the caller, but the tool itself offers no way to fetch the remaining entries — callers fall back to per-key `get_variable` lookups.

## Changes

- `astro-airflow-mcp/src/astro_airflow_mcp/tools/admin.py` — expose `limit` and `offset` parameters on the `list_variables` MCP tool, document pagination semantics in the docstring.

No behavior change for existing callers: defaults (`DEFAULT_LIMIT=100`, `DEFAULT_OFFSET=0`) match the previous hard-coded values.

## Motivation

Hit this while testing a downstream skill that pulls Airflow Variables from a dev deployment. The dev environment has ~73 variables (under the cap today), but the same call against staging returned `total_variables=129, returned_count=100` — silent loss of 29 entries with no way to recover them through this tool. The fix uses the same `(limit, offset)` pattern already established by `_list_connections_impl`, `_list_pools_impl`, etc. in this file.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/integration` — 568 passed
- [x] `uv run ruff check src/` — clean
- [x] `uv run ruff format --check src/` — clean
- [ ] Integration tests against a real Airflow instance (relies on CI)

## Notes for reviewers

The same gap exists on several other arg-less `@mcp.tool()` definitions in this file that call through to `_*_impl` helpers which already accept `limit`/`offset` (e.g. `list_connections`, `list_pools`, `list_plugins`, `list_providers`). Happy to extend this PR to cover them, or follow up — whichever you prefer.