### PR TITLE
Fail explicit config writes when AF_CONFIG is non-regular

### DIFF
--- a/astro-airflow-mcp/src/astro_airflow_mcp/cli/instances.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/cli/instances.py
@@ -9,7 +9,13 @@ from rich.console import Console
 from rich.table import Table
 
 from astro_airflow_mcp.cli.output import output_error
-from astro_airflow_mcp.config import ConfigError, ConfigManager, LayeredConfig, Scope
+from astro_airflow_mcp.config import (
+    ConfigError,
+    ConfigManager,
+    ConfigWriteError,
+    LayeredConfig,
+    Scope,
+)
 from astro_airflow_mcp.discovery import (
     DiscoveredInstance,
     DiscoveryError,
@@ -42,6 +48,10 @@ _SCOPE_FLAG_HELP = {
     "project": "Write to project-shared config (.astro/config.yaml, committed)",
     "local": "Write to project-local config (.astro/config.local.yaml, gitignored)",
 }
+
+
+def _output_config_error(error: Exception) -> None:
+    output_error(str(error), exit_code=2 if isinstance(error, ConfigWriteError) else 1)
 
 
 def _describe_auth(auth: Auth | None, *, verbose: bool = False) -> str:
@@ -101,7 +111,7 @@ def list_instances() -> None:
 
         console.print(table)
     except ConfigError as e:
-        output_error(str(e))
+        _output_config_error(e)
 
 
 @app.command("current")
@@ -122,7 +132,7 @@ def current_instance() -> None:
             console.print(f"URL: {instance.url}")
             console.print(f"Auth: {_describe_auth(instance.auth, verbose=True)}")
     except ConfigError as e:
-        output_error(str(e))
+        _output_config_error(e)
 
 
 @app.command("use")
@@ -186,7 +196,7 @@ def use_instance(
             highlight=False,
         )
     except (ConfigError, ValueError) as e:
-        output_error(str(e))
+        _output_config_error(e)
 
 
 @app.command("add")
@@ -278,7 +288,7 @@ def add_instance(
         if ca_cert:
             console.print(f"CA cert: {ca_cert}")
     except (ConfigError, ValueError) as e:
-        output_error(str(e))
+        _output_config_error(e)
 
 
 @app.command("delete")
@@ -304,7 +314,7 @@ def delete_instance(
         target = LayeredConfig().delete_instance(name, scope=scope)
         console.print(f"Deleted instance [bold]{name}[/bold] ([dim]{target.value}[/dim])")
     except (ConfigError, ValueError) as e:
-        output_error(str(e))
+        _output_config_error(e)
 
 
 @app.command("show")
@@ -338,7 +348,7 @@ def show_instance(
         if instance.ca_cert:
             console.print(f"CA cert: {instance.ca_cert}")
     except ConfigError as e:
-        output_error(str(e))
+        _output_config_error(e)
 
 
 @app.command("reset")
@@ -355,6 +365,7 @@ def reset_instances(
     """
     try:
         manager = ConfigManager()
+        manager.require_writable("af instance reset")
         config = manager.load()
 
         if not config.instances:
@@ -388,7 +399,7 @@ def reset_instances(
         console.print("  URL: http://localhost:8080")
 
     except ConfigError as e:
-        output_error(str(e))
+        _output_config_error(e)
 
 
 def _format_status(status: str | None) -> str:
@@ -577,10 +588,10 @@ def discover_all(
     # project would scan, then fail at write time.
     try:
         layered = LayeredConfig()
-        layered.assert_writable(write_scope)
+        layered.assert_writable(write_scope, command_name="af instance discover")
         existing_names = {inst.name for inst in layered.list_instances()}
     except ConfigError as e:
-        output_error(str(e))
+        _output_config_error(e)
         return
 
     registry = get_default_registry()
@@ -660,10 +671,10 @@ def discover_astro(
     # Validate write scope before hitting the Astro API.
     try:
         layered = LayeredConfig()
-        layered.assert_writable(write_scope)
+        layered.assert_writable(write_scope, command_name="af instance discover astro")
         existing_names = {inst.name for inst in layered.list_instances()}
     except ConfigError as e:
-        output_error(str(e))
+        _output_config_error(e)
         return
 
     registry = get_default_registry()
@@ -738,10 +749,10 @@ def discover_local(
     # Validate write scope before scanning ports.
     try:
         layered = LayeredConfig()
-        layered.assert_writable(write_scope)
+        layered.assert_writable(write_scope, command_name="af instance discover local")
         existing_names = {inst.name for inst in layered.list_instances()}
     except ConfigError as e:
-        output_error(str(e))
+        _output_config_error(e)
         return
 
     registry = get_default_registry()

--- a/astro-airflow-mcp/src/astro_airflow_mcp/cli/main.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/cli/main.py
@@ -19,7 +19,7 @@ from astro_airflow_mcp.cli.context import get_adapter, init_context
 from astro_airflow_mcp.cli.output import output_error, output_json
 from astro_airflow_mcp.cli.telemetry import track_command
 from astro_airflow_mcp.config import legacy_default_path
-from astro_airflow_mcp.config.loader import ConfigManager
+from astro_airflow_mcp.config.loader import ConfigManager, ConfigWriteError
 
 app = typer.Typer(
     name="af",
@@ -114,15 +114,17 @@ def telemetry(
 
         action_lower = action.lower()
         if action_lower == "disable":
+            manager.require_writable("af telemetry disable")
             manager.set_telemetry_disabled(True)
             output_json({"telemetry": "disabled"})
         elif action_lower == "enable":
+            manager.require_writable("af telemetry enable")
             manager.set_telemetry_disabled(False)
             output_json({"telemetry": "enabled"})
         else:
             output_error(f"Unknown action '{action}'. Use 'enable' or 'disable'.")
     except Exception as e:
-        output_error(str(e))
+        output_error(str(e), exit_code=2 if isinstance(e, ConfigWriteError) else 1)
 
 
 @app.command()

--- a/astro-airflow-mcp/src/astro_airflow_mcp/config/__init__.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/config/__init__.py
@@ -4,6 +4,7 @@ from astro_airflow_mcp.config.layered import LayeredConfig
 from astro_airflow_mcp.config.loader import (
     ConfigError,
     ConfigManager,
+    ConfigWriteError,
     ResolvedConfig,
     legacy_default_path,
 )
@@ -15,6 +16,7 @@ __all__ = [
     "Auth",
     "ConfigError",
     "ConfigManager",
+    "ConfigWriteError",
     "Instance",
     "LayeredConfig",
     "ResolvedConfig",

--- a/astro-airflow-mcp/src/astro_airflow_mcp/config/layered.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/config/layered.py
@@ -181,7 +181,13 @@ class LayeredConfig:
 
     # --- write paths ---------------------------------------------------
 
-    def assert_writable(self, scope: Scope) -> None:
+    def assert_writable(
+        self,
+        scope: Scope,
+        *,
+        command_name: str = "configuration command",
+        prefer_local_in_project: bool = False,
+    ) -> None:
         """Raise ``ConfigError`` if ``scope`` can't be written from here.
 
         Used by ``af instance discover`` to fail fast — discovery does
@@ -189,7 +195,10 @@ class LayeredConfig:
         scope mismatch to surface before any of that happens, not at
         write time.
         """
-        self._resolve_write_scope(scope)
+        _, manager = self._resolve_write_scope(
+            scope, prefer_local_in_project=prefer_local_in_project
+        )
+        manager.require_writable(command_name)
 
     def _manager_for(self, scope: Scope) -> ConfigManager | None:
         """Return the manager for an explicit scope, or None if it's
@@ -245,6 +254,7 @@ class LayeredConfig:
         appropriate only for the global file, never project files.
         """
         target_scope, manager = self._resolve_write_scope(scope)
+        manager.require_writable("af instance add")
         config = self._safe_load(manager)
         config.add_instance(
             name,
@@ -275,10 +285,14 @@ class LayeredConfig:
         this within its own file; layered needs to scan siblings.
         """
         if scope == Scope.AUTO:
+            scopes = self._scopes_in_priority_order()
+            if len(scopes) == 1:
+                scopes[0][1].require_writable("af instance delete")
             target_scope: Scope | None = None
-            for found_scope, manager in self._scopes_in_priority_order():
+            for found_scope, manager in scopes:
                 config = self._safe_load(manager)
                 if config.get_instance(name) is not None:
+                    manager.require_writable("af instance delete")
                     config.delete_instance(name)
                     manager.save(config)
                     target_scope = found_scope
@@ -287,6 +301,7 @@ class LayeredConfig:
                 raise ValueError(f"Instance '{name}' does not exist")
         else:
             target_scope, manager = self._resolve_write_scope(scope)
+            manager.require_writable("af instance delete")
             config = self._safe_load(manager)
             config.delete_instance(name)
             manager.save(config)
@@ -316,9 +331,11 @@ class LayeredConfig:
         against the merged view (so ``use`` can switch to an instance
         defined in any sibling scope).
         """
+        self.assert_writable(scope, command_name="af instance use", prefer_local_in_project=True)
         if not self.get_instance(name):
             raise ValueError(f"Instance '{name}' does not exist")
         target_scope, manager = self._resolve_write_scope(scope, prefer_local_in_project=True)
+        manager.require_writable("af instance use")
         # No auto-create on miss; mutate current_instance directly
         # (ConfigManager.use_instance would re-validate against the
         # single file's instances).
@@ -329,4 +346,5 @@ class LayeredConfig:
 
     def set_telemetry_disabled(self, disabled: bool) -> None:
         # Telemetry is always global — never project-scoped.
+        self._global.require_writable("af telemetry")
         self._global.set_telemetry_disabled(disabled)

--- a/astro-airflow-mcp/src/astro_airflow_mcp/config/loader.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/config/loader.py
@@ -34,6 +34,10 @@ class ConfigError(Exception):
     """Error raised for configuration issues."""
 
 
+class ConfigWriteError(ConfigError):
+    """Error raised when an explicit config mutation cannot be persisted."""
+
+
 @dataclass
 class ResolvedConfig:
     """Resolved configuration ready for use."""
@@ -112,6 +116,15 @@ class ConfigManager:
         # O_CREAT raises EPERM. Treat it as "no config": load() returns
         # an empty config, save() is a no-op.
         self._null_path = self.config_path.exists() and not self.config_path.is_file()
+
+    def require_writable(self, command_name: str) -> None:
+        """Raise when an explicit command would be lost to a neutralized config path."""
+        if self._null_path:
+            raise ConfigWriteError(
+                f"{command_name} cannot persist: {self.CONFIG_ENV_VAR} points to "
+                f"a non-regular path ({self.config_path}).\n"
+                f"Unset {self.CONFIG_ENV_VAR} or point it at a writable file."
+            )
 
     def _ensure_dir(self) -> None:
         """Ensure the config directory exists."""

--- a/astro-airflow-mcp/tests/test_cli_config_writes.py
+++ b/astro-airflow-mcp/tests/test_cli_config_writes.py
@@ -1,0 +1,24 @@
+"""CLI coverage for explicit config writes that must not silently no-op."""
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from astro_airflow_mcp.cli.main import app
+
+
+def test_telemetry_write_fails_when_af_config_is_non_regular(tmp_path, monkeypatch):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    neutralized_config = tmp_path / "neutralized-config"
+    neutralized_config.mkdir()
+    monkeypatch.setenv("AF_CONFIG", str(neutralized_config))
+
+    result = CliRunner().invoke(app, ["telemetry", "disable"])
+
+    assert result.exit_code == 2
+    assert "af telemetry disable cannot persist" in result.output
+    assert "AF_CONFIG points to a non-regular path" in result.output
+    assert str(neutralized_config) in result.output
+    assert list(neutralized_config.iterdir()) == []

--- a/astro-airflow-mcp/tests/test_cli_instances.py
+++ b/astro-airflow-mcp/tests/test_cli_instances.py
@@ -137,6 +137,36 @@ class TestDeleteCommand:
         assert "(global)" in result.output
 
 
+class TestNonRegularConfigPath:
+    @pytest.mark.parametrize(
+        ("argv", "command_name"),
+        [
+            (
+                ["add", "prod", "--url", "https://prod.example.com", "--token", "${T}"],
+                "af instance add",
+            ),
+            (["use", "prod"], "af instance use"),
+            (["delete", "prod"], "af instance delete"),
+            (["reset", "--force"], "af instance reset"),
+        ],
+    )
+    def test_mutating_commands_fail_before_silent_noop(
+        self, cli_env, monkeypatch, argv, command_name
+    ):
+        project, runner = cli_env
+        neutralized_config = project / "neutralized-config"
+        neutralized_config.mkdir()
+        monkeypatch.setenv("AF_CONFIG", str(neutralized_config))
+
+        result = runner.invoke(app, argv)
+
+        assert result.exit_code == 2
+        assert f"{command_name} cannot persist" in result.output
+        assert "AF_CONFIG points to a non-regular path" in result.output
+        assert str(neutralized_config) in result.output
+        assert list(neutralized_config.iterdir()) == []
+
+
 class TestShowCommand:
     def test_show_includes_scope_and_path(self, cli_env):
         project, runner = cli_env

--- a/astro-airflow-mcp/tests/test_layered.py
+++ b/astro-airflow-mcp/tests/test_layered.py
@@ -288,6 +288,18 @@ class TestLayeredWrites:
         with pytest.raises(ConfigError, match="no project root"):
             layered.assert_writable(Scope.PROJECT_SHARED)
 
+    def test_assert_writable_rejects_non_regular_af_config(self, tmp_path, monkeypatch):
+        """Explicit write commands should not silently disappear into AF_CONFIG=/dev/null."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        neutralized_config = tmp_path / "neutralized-config"
+        neutralized_config.mkdir()
+        monkeypatch.setenv("AF_CONFIG", str(neutralized_config))
+
+        with pytest.raises(ConfigError, match="af instance add cannot persist"):
+            LayeredConfig().assert_writable(Scope.AUTO, command_name="af instance add")
+
     def test_add_explicit_project_outside_project_raises(self, tmp_path, monkeypatch):
         fake_home = tmp_path / "home"
         fake_home.mkdir()


### PR DESCRIPTION
## Summary
- Adds a `ConfigManager.require_writable()` guard that preserves neutralized-config read/no-op behavior while giving explicit config mutations a clear failure path.
- Wires the guard through `af instance add/use/delete/reset`, instance discovery write preflight, and `af telemetry enable/disable`.
- Adds CLI and layered-config tests for directory-backed `AF_CONFIG` as the platform-neutral stand-in for `/dev/null`.

Fixes #194.

## Verification
- `/Users/ritwij/Library/Python/3.9/bin/uv run pytest tests/test_cli_instances.py tests/test_cli_config_writes.py tests/test_layered.py tests/test_config.py` (137 passed)
- `/Users/ritwij/Library/Python/3.9/bin/uv run pytest tests --ignore=tests/integration` (574 passed)
- `/Users/ritwij/Library/Python/3.9/bin/uv run ruff check src tests/test_cli_instances.py tests/test_cli_config_writes.py tests/test_layered.py`
- `/Users/ritwij/Library/Python/3.9/bin/uv run ruff format --check src tests/test_cli_instances.py tests/test_cli_config_writes.py tests/test_layered.py`

Full `pytest` was also attempted; only `tests/integration/test_api_endpoints.py` failed because no Airflow server was listening on `localhost:8080` in my local environment.