### PR TITLE
debugging-dags: Add package version change checks to Step 3

### DIFF
--- a/skills/debugging-dags/SKILL.md
+++ b/skills/debugging-dags/SKILL.md
@@ -42,12 +42,45 @@ Once you have identified a failed task:
 Gather additional context to understand WHY this happened:
 
 1. **Recent changes**: Was there a code deploy? Check git history if available
-2. **Data volume**: Did data volume spike? Run a quick count on source tables
-3. **Upstream health**: Did upstream tasks succeed but produce unexpected data?
-4. **Historical pattern**: Is this a recurring failure? Check if same task failed before
-5. **Timing**: Did this fail at an unusual time? (resource contention, maintenance windows)
+2. **Package version changes**: Was a package upgraded — in the image, in a venv-style operator, or at the index? See [Package version changes](#package-version-changes) below.
+3. **Data volume**: Did data volume spike? Run a quick count on source tables
+4. **Upstream health**: Did upstream tasks succeed but produce unexpected data?
+5. **Historical pattern**: Is this a recurring failure? Check if same task failed before
+6. **Timing**: Did this fail at an unusual time? (resource contention, maintenance windows)
 
 Use `af runs get <dag_id> <dag_run_id>` to compare the failed run against recent successful runs.
+
+### Package version changes
+
+A common cause of failures with no git activity is dependency drift — the user's code didn't change, but a package they depend on did. Check in this order:
+
+1. **Worker image diff** (preferred when available). Every Astro deploy = new image tag, so the registry has a "before" and "after". Diff `pip freeze` between current and previous image — that's ground truth for what changed:
+   ```
+   docker run --rm <current_image> pip freeze > /tmp/now.txt
+   docker run --rm <previous_image> pip freeze > /tmp/prev.txt
+   diff /tmp/prev.txt /tmp/now.txt
+   ```
+   `af config providers` lists currently installed provider versions — useful for cross-checking against modules named in the traceback.
+
+2. **Venv-style operators bypass the worker image.** `@task.virtualenv`, `PythonVirtualenvOperator`, `ExternalPythonOperator`, and `KubernetesPodOperator` build their environment per task run, so an image diff won't catch failures inside them. If the failed task is one of these, read its `requirements` / `image` arg directly:
+   - Unbounded specifier (e.g. `pandas>=2.0.0` with no upper bound, or no specifier at all) → a new upstream release is the prime suspect.
+   - `image="foo:latest"` or no tag → the image moved underneath you.
+
+   Fix is to pin: `pandas>=2.0.0,<3.0.0`, a lockfile, or a specific image SHA.
+
+3. **Index lookup** when image diff isn't conclusive (no image history, or a venv-style operator). Identify the configured index first — it may not be PyPI:
+   - Env vars: `UV_INDEX_URL`, `PIP_INDEX_URL`, `PIP_EXTRA_INDEX_URL`
+   - `pyproject.toml` → `[[tool.uv.index]]`
+   - `~/.pip/pip.conf`, `/etc/pip.conf`
+   - `Dockerfile` `--index-url` flags
+
+   Then query for releases of the suspect package since the first failure started. PyPI:
+   ```
+   curl -s https://pypi.org/pypi/<pkg>/json | jq '.releases | to_entries | map({version: .key, uploaded: .value[0].upload_time}) | sort_by(.uploaded) | reverse | .[:5]'
+   ```
+   Private indexes usually expose the same `/pypi/<pkg>/json` shape; fall back to the Simple API (`/simple/<pkg>/`) or ask the user if neither works.
+
+A release timestamp landing between the last green run and the first red run, for a package named in the traceback, is the answer.
 
 ### On Astro
 
@@ -85,6 +118,7 @@ How to prevent this from happening again:
 - Add better error handling?
 - Add alerting for edge cases?
 - Update documentation?
+- Pin dependencies (constraints file, lockfile, or upper-bound specifiers on venv/external/pod operators) to avoid silent upstream drift?
 
 ### Quick Commands
 Provide ready-to-use commands:

--- a/skills/debugging-dags/SKILL.md
+++ b/skills/debugging-dags/SKILL.md
@@ -60,13 +60,14 @@ A common cause of failures with no git activity is dependency drift — the user
    docker run --rm <previous_image> pip freeze > /tmp/prev.txt
    diff /tmp/prev.txt /tmp/now.txt
    ```
-   `af config providers` lists currently installed provider versions — useful for cross-checking against modules named in the traceback.
+   Also compare `docker run --rm <image> python --version` between the two — a Python minor-version bump (3.11 → 3.12, or even a patch) can break wheel compatibility even when `pip freeze` looks identical. `af config providers` lists currently installed provider versions, useful for cross-checking against modules named in the traceback.
 
-2. **Venv-style operators bypass the worker image.** `@task.virtualenv`, `PythonVirtualenvOperator`, `ExternalPythonOperator`, and `KubernetesPodOperator` build their environment per task run, so an image diff won't catch failures inside them. If the failed task is one of these, read its `requirements` / `image` arg directly:
+2. **Venv-style operators bypass the worker image.** `@task.virtualenv`, `PythonVirtualenvOperator`, `ExternalPythonOperator`, and `KubernetesPodOperator` build their environment per task run, so an image diff won't catch failures inside them. If the failed task is one of these, read its `requirements` / `image` / `python_version` / `python` args directly:
    - Unbounded specifier (e.g. `pandas>=2.0.0` with no upper bound, or no specifier at all) → a new upstream release is the prime suspect.
    - `image="foo:latest"` or no tag → the image moved underneath you.
+   - `python_version="3.11"` (on `@task.virtualenv` / `PythonVirtualenvOperator`) or a `python` path (on `ExternalPythonOperator`) resolving to a different interpreter than it used to — a Python minor-version change can break wheel compatibility for unchanged `requirements`. Same vector applies to the worker image itself if the base Python changed there.
 
-   Fix is to pin: `pandas>=2.0.0,<3.0.0`, a lockfile, or a specific image SHA.
+   Fix is to pin: `pandas>=2.0.0,<3.0.0`, a lockfile, a specific image SHA, or a fully-qualified Python version (`python_version="3.11.7"` instead of `"3.11"`).
 
 3. **Index lookup** when image diff isn't conclusive (no image history, or a venv-style operator). Identify the configured index first — it may not be PyPI:
    - Env vars: `UV_INDEX_URL`, `PIP_INDEX_URL`, `PIP_EXTRA_INDEX_URL`


### PR DESCRIPTION
## Summary

Step 3 (Check Context) only mentioned code deploys as a recent-change signal, which misses a really common failure mode: the user's code didn't change but a package they depend on did. Two flavours of that — the worker image was rebuilt and pulled in a new transitive, or a venv-style operator resolved its `requirements` against a moving index at task runtime.

This PR adds instructions for catching both.

## What changed

A new "Package version changes" subsection under Step 3, with three checks the agent should walk through in order.

The first is a worker image diff. When image history exists (every Astro deploy is a new image), `docker run --rm <image> pip freeze` on current vs previous and a `diff` between them is ground truth — anything that changed shows up directly. This is the cleanest signal and the agent should reach for it first.

Image diff is blind to `@task.virtualenv`, `PythonVirtualenvOperator`, `ExternalPythonOperator`, and `KubernetesPodOperator` though, because those build their env per task run, outside the worker image. So the second check is: if the failed task is one of those operators, read its `requirements` (or `image`) arg directly. An unbounded specifier like `pandas>=2.0.0` or an `image="foo:latest"` is the prime suspect, and the fix is to pin.

Third check is an index lookup, for cases where image diff isn't conclusive — usually because there's no image history or it's a venv-style operator. The agent has to detect the configured index first (it may not be PyPI — customers run Artifactory, devpi, etc.) by checking `UV_INDEX_URL` / `PIP_INDEX_URL` / `pyproject.toml` / `pip.conf` / Dockerfile flags, then query that index for releases of the suspect package in the failure window. PyPI's `/pypi/<pkg>/json` shape is widely supported by private indexes, with the Simple API as a fallback.

I also added one bullet to Step 4's Prevention list about pinning deps so this doesn't happen silently in the first place.

## Why this shape

I went back and forth on whether to assume PyPI. Most users *are* on PyPI but enough customers aren't that hardcoding it would produce confidently wrong answers in the cases where it matters most. So the skill asks the agent to detect the index, with the Simple API and "ask the user" as fallbacks.

Kept this PR purely reactive (debugging-time). The obvious follow-up is proactive linting at authoring time — Otto noticing `pandas>=2.0.0` and suggesting `<3.0.0` before it ever ships — but that belongs in `authoring-dags`, not here.

## Credit

Surfaced by Elad Kalif 