### PR TITLE
analyzing-data: Make register_connector preserve subclass type

### DIFF
--- a/skills/analyzing-data/scripts/connectors.py
+++ b/skills/analyzing-data/scripts/connectors.py
@@ -4,7 +4,7 @@ import os
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, TypeVar
 
 
 # --- Base class ---
@@ -63,7 +63,10 @@ def substitute_env_vars(value: Any) -> tuple[Any, str | None]:
 _CONNECTOR_REGISTRY: dict[str, type[DatabaseConnector]] = {}
 
 
-def register_connector(cls: type[DatabaseConnector]) -> type[DatabaseConnector]:
+T = TypeVar("T", bound="DatabaseConnector")
+
+
+def register_connector(cls: type[T]) -> type[T]:
     _CONNECTOR_REGISTRY[cls.connector_type()] = cls
     return cls
 


### PR DESCRIPTION
CI's type-check job has been failing on every PR with 202 `ty` diagnostics across `connectors.py` and the test suite — even on diffs that don't touch any Python. (Found it on #218, which is markdown-only.) Turns out it all collapses to one annotation.

`register_connector` was typed as `type[DatabaseConnector] -> type[DatabaseConnector]`, so after `@register_connector`, ty sees each decorated subclass as the abstract base instead of itself. That cascades hard: 4 `invalid-type-form` errors on every `from_dict` return annotation (the symbols on the right resolve to a variable, not a class), 173 `unknown-argument` errors in tests calling `SnowflakeConnector(account=...)` / `PostgresConnector(host=...)` / etc. because the abstract base has none of those dataclass fields, and 25 more `unresolved-attribute` errors of the same flavour.

Fix is a TypeVar bounded by `DatabaseConnector` so the decorator preserves the specific subclass:

```python
T = TypeVar("T", bound="DatabaseConnector")

def register_connector(cls: type[T]) -> type[T]:
    _CONNECTOR_REGISTRY[cls.connector_type()] = cls
    return cls
```

No runtime change — same identity decorator, just typed properly. `uvx ty check` goes from 202 diagnostics to 0, and the 194 unit tests still pass.

One thing worth flagging while we're here: CI runs `uvx ty check` with no pin, so the next stricter ty release will silently break things again. The version that produced the last green CI on main (2026-05-08) was looser than what `uvx` now resolves to. This is literally the failure mode #218 is documenting, which is funny. I'd suggest pinning `ty` in `.github/workflows/ci.yml` as a follow-up, but kept this PR to just the fix.