### PR TITLE
feat: Return structured tool errors and add MCP safety annotations

### DIFF
--- a/astro-airflow-mcp/src/astro_airflow_mcp/tool_annotations.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/tool_annotations.py
@@ -1,0 +1,62 @@
+"""MCP tool safety annotations (read-only / destructive hints).
+
+These map onto the MCP ``ToolAnnotations`` spec so a client can decide, *before*
+invoking a tool, whether it is safe to auto-approve (reads) or must be gated
+behind user confirmation (writes / destructive operations). This complements the
+server-side ``AF_READ_ONLY`` guard, which only refuses a write *after* the model
+has already decided to call it.
+
+Defaults are cautious: a tool is only advertised as safe when it explicitly opts
+in via :func:`read_only`. Writes default to destructive + non-idempotent and are
+narrowed by the caller when a weaker hint is accurate (e.g. ``pause_dag`` is a
+non-destructive, idempotent write).
+
+``openWorldHint`` is True for every tool here: they all talk to an external
+Airflow instance whose state is outside this process.
+"""
+
+from __future__ import annotations
+
+from mcp.types import ToolAnnotations
+
+
+def read_only(title: str | None = None) -> ToolAnnotations:
+    """Annotations for a tool that only reads Airflow state.
+
+    Safe for clients to auto-approve. Reads are idempotent by definition.
+    """
+    return ToolAnnotations(
+        title=title,
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+
+
+def write(
+    title: str | None = None,
+    *,
+    destructive: bool = True,
+    idempotent: bool = False,
+) -> ToolAnnotations:
+    """Annotations for a tool that modifies Airflow state.
+
+    Defaults are deliberately cautious (destructive, non-idempotent). Callers
+    narrow them for safer writes:
+
+    - ``write(destructive=False, idempotent=True)`` — pause/unpause (reversible,
+      re-applying reaches the same state).
+    - ``write(destructive=False)`` — trigger (creates a new run; not destructive,
+      but each call has an additional effect so it is not idempotent).
+    - ``write(destructive=True, idempotent=True)`` — clear (discards run/task
+      state, but re-clearing reaches the same end state).
+    - ``write()`` — delete (destructive and not safely repeatable).
+    """
+    return ToolAnnotations(
+        title=title,
+        readOnlyHint=False,
+        destructiveHint=destructive,
+        idempotentHint=idempotent,
+        openWorldHint=True,
+    )

--- a/astro-airflow-mcp/src/astro_airflow_mcp/tool_errors.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/tool_errors.py
@@ -1,0 +1,155 @@
+"""Structured, agent-friendly error responses for MCP tools.
+
+MCP tools in this server return JSON strings. On failure we return a JSON
+object instead of a bare ``str(exc)`` so the calling agent can tell *why* a
+call failed and decide what to do next:
+
+    {
+      "error": "<message>",        # always contains str(exc)
+      "error_type": "NotFoundError",
+      "hint": "<what to do next>", # actionable guidance for the agent
+      "retryable": true,          # True  -> a corrected retry may succeed
+                                  # False -> auth/infra/hard block; don't spin
+      "dag_id": "...",            # any identifying args echoed back
+    }
+
+The distinction that matters for an agent: a *wrong dag_id* (fix the argument
+and retry) looks identical to *Airflow is unreachable* (stop and surface to the
+user) when both are collapsed to a bare string. ``retryable`` + ``hint``
+disambiguate them; the echoed identifiers give the model the context it needs
+to correct itself.
+
+``str(exc)`` is always kept inside ``error`` so callers (and tests) that scanned
+the old bare-string responses for substrings keep working.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+
+from astro_airflow_mcp.adapters.base import NotFoundError, ReadOnlyError
+
+try:  # Auth errors live in the astro session module; treat as optional.
+    from astro_airflow_mcp._astro_session import AstroPATError
+except Exception:  # pragma: no cover - defensive, _astro_session is import-light
+    AstroPATError = None  # type: ignore[assignment, misc]
+
+
+def _classify_status(exc: httpx.HTTPStatusError) -> tuple[bool, str]:
+    """Map an HTTP status code to (retryable, hint)."""
+    status = exc.response.status_code
+    if status in (400, 422):
+        return True, (
+            f"Airflow rejected the request as invalid (HTTP {status}). Check the "
+            "argument values and formats, then retry with corrected arguments."
+        )
+    if status in (401, 403):
+        return False, (
+            f"Not authorized (HTTP {status}). The token may be missing, expired, or "
+            "lack permission for this operation. Re-authenticate and restart the "
+            "MCP server, then try again."
+        )
+    if status == 404:
+        return True, (
+            "Not found (HTTP 404). Verify the identifiers are correct — a list_* "
+            "tool (list_dags / list_dag_runs / list_tasks) can confirm valid values."
+        )
+    if status == 409:
+        return False, (
+            "Conflict (HTTP 409). The resource is in a state that does not allow "
+            "this operation (e.g. it already exists or is currently running). "
+            "Retrying the same call is unlikely to help."
+        )
+    if status == 429:
+        return True, "Rate limited (HTTP 429). Wait briefly before retrying."
+    if 500 <= status < 600:
+        return False, (
+            f"Airflow returned a server error (HTTP {status}). This is an "
+            "instance-side problem; retrying the same call is unlikely to help."
+        )
+    return False, f"Airflow returned an unexpected HTTP {status}."
+
+
+def _classify(exc: Exception) -> tuple[bool, str]:
+    """Return ``(retryable, hint)`` inferred from the exception type."""
+    if isinstance(exc, ReadOnlyError):
+        return False, (
+            "The server is running in read-only mode (AF_READ_ONLY=true), so this "
+            "write was blocked. Do not retry; ask the operator to disable read-only "
+            "mode if the change is intended."
+        )
+    if isinstance(exc, NotFoundError):
+        return True, (
+            "The resource was not found. Check the spelling/values of the "
+            "identifiers (dag_id, dag_run_id, task_id) — a list_* tool can confirm "
+            "valid values."
+        )
+    if AstroPATError is not None and isinstance(exc, AstroPATError):
+        return False, (
+            "Authentication with Astro failed. Re-authenticate (run `astro login`) "
+            "and restart the MCP server, then try again."
+        )
+    if isinstance(exc, httpx.HTTPStatusError):
+        return _classify_status(exc)
+    if isinstance(exc, httpx.TimeoutException):
+        return False, (
+            "Airflow did not respond in time. The instance may be slow or "
+            "unreachable; verify it is up and reachable before retrying."
+        )
+    if isinstance(exc, httpx.TransportError):
+        # ConnectError, ReadError, etc. all subclass TransportError.
+        return False, (
+            "Could not reach Airflow. Check that the instance is running and that "
+            "the configured URL and network are correct."
+        )
+    return False, (
+        "The Airflow API call failed unexpectedly. Inspect the error message; this "
+        "is more likely a server-side or configuration issue than a bad argument."
+    )
+
+
+def error_payload(
+    exc: Exception,
+    *,
+    retryable: bool | None = None,
+    hint: str | None = None,
+    **context: Any,
+) -> dict[str, Any]:
+    """Build a structured error dict from an exception.
+
+    Args:
+        exc: The caught exception. ``str(exc)`` is always placed in ``error``.
+        retryable: Override the inferred retryability.
+        hint: Override the inferred hint.
+        **context: Identifying arguments to echo back (e.g. ``dag_id=dag_id``).
+            ``None`` values are dropped so we never echo empty identifiers.
+
+    Returns:
+        A JSON-serializable dict with at least ``error``, ``error_type``,
+        ``hint`` and ``retryable`` keys, plus any non-None context.
+    """
+    inferred_retryable, inferred_hint = _classify(exc)
+    payload: dict[str, Any] = {
+        "error": str(exc) or exc.__class__.__name__,
+        "error_type": exc.__class__.__name__,
+        "hint": hint if hint is not None else inferred_hint,
+        "retryable": retryable if retryable is not None else inferred_retryable,
+    }
+    for key, value in context.items():
+        if value is not None:
+            payload[key] = value
+    return payload
+
+
+def tool_error(
+    exc: Exception,
+    *,
+    retryable: bool | None = None,
+    hint: str | None = None,
+    **context: Any,
+) -> str:
+    """JSON-string form of :func:`error_payload` for MCP tool return values."""
+    return json.dumps(error_payload(exc, retryable=retryable, hint=hint, **context), indent=2)

--- a/astro-airflow-mcp/src/astro_airflow_mcp/tools/admin.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/tools/admin.py
@@ -9,6 +9,8 @@ from astro_airflow_mcp.server import (
     _wrap_list_response,
     mcp,
 )
+from astro_airflow_mcp.tool_annotations import read_only
+from astro_airflow_mcp.tool_errors import tool_error
 from astro_airflow_mcp.utils import filter_connection_passwords
 
 
@@ -50,7 +52,7 @@ def _list_connections_impl(
             return json.dumps(result, indent=2)
         return f"No connections found. Response: {data}"
     except Exception as e:
-        return str(e)
+        return tool_error(e)
 
 
 def _get_variable_impl(
@@ -69,7 +71,7 @@ def _get_variable_impl(
         data = adapter.get_variable(variable_key)
         return json.dumps(data, indent=2)
     except Exception as e:
-        return str(e)
+        return tool_error(e, variable_key=variable_key)
 
 
 def _list_variables_impl(
@@ -93,7 +95,7 @@ def _list_variables_impl(
             return _wrap_list_response(data["variables"], "variables", data)
         return f"No variables found. Response: {data}"
     except Exception as e:
-        return str(e)
+        return tool_error(e)
 
 
 def _get_version_impl() -> str:
@@ -107,7 +109,7 @@ def _get_version_impl() -> str:
         data = adapter.get_version()
         return json.dumps(data, indent=2)
     except Exception as e:
-        return str(e)
+        return tool_error(e)
 
 
 def _get_config_impl() -> str:
@@ -126,7 +128,7 @@ def _get_config_impl() -> str:
             return json.dumps(result, indent=2)
         return f"No configuration found. Response: {data}"
     except Exception as e:
-        return str(e)
+        return tool_error(e)
 
 
 def _get_pool_impl(
@@ -145,7 +147,7 @@ def _get_pool_impl(
         data = adapter.get_pool(pool_name)
         return json.dumps(data, indent=2)
     except Exception as e:
-        return str(e)
+        return tool_error(e, pool_name=pool_name)
 
 
 def _list_pools_impl(
@@ -169,7 +171,7 @@ def _list_pools_impl(
             return _wrap_list_response(data["pools"], "pools", data)
         return f"No pools found. Response: {data}"
     except Exception as e:
-        return str(e)
+        return tool_error(e)
 
 
 def _list_plugins_impl(
@@ -193,7 +195,7 @@ def _list_plugins_impl(
             return _wrap_list_response(data["plugins"], "plugins", data)
         return f"No plugins found. Response: {data}"
     except Exception as e:
-        return str(e)
+        return tool_error(e)
 
 
 def _list_providers_impl() -> str:
@@ -210,10 +212,10 @@ def _list_providers_impl() -> str:
             return _wrap_list_response(data["providers"], "providers", data)
         return f"No providers found. Response: {data}"
     except Exception as e:
-        return str(e)
+        return tool_error(e)
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def list_connections() -> str:
     """Get connection configurations for external systems (databases, APIs, services).
 
@@ -245,7 +247,7 @@ def list_connections() -> str:
     return _list_connections_impl()
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def get_variable(variable_key: str) -> str:
     """Get a specific Airflow variable by key.
 
@@ -272,7 +274,7 @@ def get_variable(variable_key: str) -> str:
     return _get_variable_impl(variable_key=variable_key)
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def list_variables() -> str:
     """Get all Airflow variables (key-value configuration pairs).
 
@@ -301,7 +303,7 @@ def list_variables() -> str:
     return _list_variables_impl()
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def get_airflow_version() -> str:
     """Get version information for the Airflow instance.
 
@@ -327,7 +329,7 @@ def get_airflow_version() -> str:
     return _get_version_impl()
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def get_airflow_config() -> str:
     """Get Airflow instance configuration and settings.
 
@@ -359,7 +361,7 @@ def get_airflow_config() -> str:
     return _get_config_impl()
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def get_pool(pool_name: str) -> str:
     """Get detailed information about a specific resource pool.
 
@@ -390,7 +392,7 @@ def get_pool(pool_name: str) -> str:
     return _get_pool_impl(pool_name=pool_name)
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def list_pools() -> str:
     """Get resource pools for managing task concurrency and resource allocation.
 
@@ -420,7 +422,7 @@ def list_pools() -> str:
     return _list_pools_impl()
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def list_plugins() -> str:
     """Get information about installed Airflow plugins.
 
@@ -449,7 +451,7 @@ def list_plugins() -> str:
     return _list_plugins_impl()
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def list_providers() -> str:
     """Get information about installed Airflow provider packages.
 

--- a/astro-airflow-mcp/src/astro_airflow_mcp/tools/asset.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/tools/asset.py
@@ -8,6 +8,8 @@ from astro_airflow_mcp.server import (
     _wrap_list_response,
     mcp,
 )
+from astro_airflow_mcp.tool_annotations import read_only
+from astro_airflow_mcp.tool_errors import tool_error
 
 
 def _list_assets_impl(
@@ -31,7 +33,7 @@ def _list_assets_impl(
             return _wrap_list_response(data["assets"], "assets", data)
         return f"No assets found. Response: {data}"
     except Exception as e:
-        return str(e)
+        return tool_error(e)
 
 
 def _list_asset_events_impl(
@@ -67,7 +69,12 @@ def _list_asset_events_impl(
             return _wrap_list_response(data["asset_events"], "asset_events", data)
         return f"No asset events found. Response: {data}"
     except Exception as e:
-        return str(e)
+        return tool_error(
+            e,
+            source_dag_id=source_dag_id,
+            source_run_id=source_run_id,
+            source_task_id=source_task_id,
+        )
 
 
 def _get_upstream_asset_events_impl(
@@ -99,10 +106,10 @@ def _get_upstream_asset_events_impl(
             )
         return json.dumps(data, indent=2)
     except Exception as e:
-        return str(e)
+        return tool_error(e, dag_id=dag_id, dag_run_id=dag_run_id)
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def list_assets() -> str:
     """Get data assets and datasets tracked by Airflow (data lineage).
 
@@ -130,7 +137,7 @@ def list_assets() -> str:
     return _list_assets_impl()
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def list_asset_events(
     source_dag_id: str | None = None,
     source_run_id: str | None = None,
@@ -174,7 +181,7 @@ def list_asset_events(
     )
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def get_upstream_asset_events(
     dag_id: str,
     dag_run_id: str,

--- a/astro-airflow-mcp/src/astro_airflow_mcp/tools/dag.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/tools/dag.py
@@ -8,6 +8,8 @@ from astro_airflow_mcp.server import (
     _wrap_list_response,
     mcp,
 )
+from astro_airflow_mcp.tool_annotations import read_only, write
+from astro_airflow_mcp.tool_errors import tool_error
 
 
 def _get_dag_details_impl(dag_id: str) -> str:
@@ -24,10 +26,10 @@ def _get_dag_details_impl(dag_id: str) -> str:
         data = adapter.get_dag(dag_id)
         return json.dumps(data, indent=2)
     except Exception as e:
-        return str(e)
+        return tool_error(e, dag_id=dag_id)
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def get_dag_details(dag_id: str) -> str:
     """Get detailed information about a specific Apache Airflow DAG.
 
@@ -86,10 +88,10 @@ def _list_dags_impl(
             return _wrap_list_response(data["dags"], "dags", data)
         return f"No DAGs found. Response: {data}"
     except Exception as e:
-        return str(e)
+        return tool_error(e)
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def list_dags() -> str:
     """Get information about all Apache Airflow DAGs (Directed Acyclic Graphs).
 
@@ -130,10 +132,10 @@ def _get_dag_source_impl(dag_id: str) -> str:
         source_data = adapter.get_dag_source(dag_id)
         return json.dumps(source_data, indent=2)
     except Exception as e:
-        return str(e)
+        return tool_error(e, dag_id=dag_id)
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def get_dag_source(dag_id: str) -> str:
     """Get the source code for a specific Apache Airflow DAG.
 
@@ -171,10 +173,10 @@ def _get_dag_stats_impl(dag_ids: list[str] | None = None) -> str:
         stats_data = adapter.get_dag_stats(dag_ids=dag_ids)
         return json.dumps(stats_data, indent=2)
     except Exception as e:
-        return str(e)
+        return tool_error(e, dag_ids=dag_ids)
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def get_dag_stats(dag_ids: list[str] | None = None) -> str:
     """Get statistics about DAG runs (success/failure counts by state).
 
@@ -217,10 +219,10 @@ def _pause_dag_impl(dag_id: str) -> str:
         data = adapter.pause_dag(dag_id)
         return json.dumps(data, indent=2)
     except Exception as e:
-        return str(e)
+        return tool_error(e, dag_id=dag_id)
 
 
-@mcp.tool()
+@mcp.tool(annotations=write(destructive=False, idempotent=True))
 def pause_dag(dag_id: str) -> str:
     """Pause a DAG to prevent new scheduled runs from starting.
 
@@ -261,10 +263,10 @@ def _unpause_dag_impl(dag_id: str) -> str:
         data = adapter.unpause_dag(dag_id)
         return json.dumps(data, indent=2)
     except Exception as e:
-        return str(e)
+        return tool_error(e, dag_id=dag_id)
 
 
-@mcp.tool()
+@mcp.tool(annotations=write(destructive=False, idempotent=True))
 def unpause_dag(dag_id: str) -> str:
     """Unpause a DAG to allow scheduled runs to resume.
 

--- a/astro-airflow-mcp/src/astro_airflow_mcp/tools/dag_run.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/tools/dag_run.py
@@ -10,6 +10,8 @@ from astro_airflow_mcp.server import (
     _wrap_list_response,
     mcp,
 )
+from astro_airflow_mcp.tool_annotations import read_only, write
+from astro_airflow_mcp.tool_errors import error_payload, tool_error
 from astro_airflow_mcp.utils import extract_failed_tasks
 
 
@@ -39,7 +41,7 @@ def _list_dag_runs_impl(
             return _wrap_list_response(data["dag_runs"], "dag_runs", data)
         return f"No DAG runs found. Response: {data}"
     except Exception as e:
-        return str(e)
+        return tool_error(e, dag_id=dag_id)
 
 
 def _get_dag_run_impl(
@@ -60,7 +62,7 @@ def _get_dag_run_impl(
         data = adapter.get_dag_run(dag_id, dag_run_id)
         return json.dumps(data, indent=2)
     except Exception as e:
-        return str(e)
+        return tool_error(e, dag_id=dag_id, dag_run_id=dag_run_id)
 
 
 def _trigger_dag_impl(
@@ -89,7 +91,7 @@ def _trigger_dag_impl(
         data = adapter.trigger_dag_run(dag_id=dag_id, conf=conf)
         return json.dumps(data, indent=2)
     except Exception as e:
-        return str(e)
+        return tool_error(e, dag_id=dag_id)
 
 
 def _get_failed_task_instances(
@@ -140,20 +142,35 @@ def _trigger_dag_and_wait_impl(
 
     try:
         trigger_data = json.loads(trigger_response)
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as e:
         return json.dumps(
             {
-                "error": f"Failed to trigger DAG: {trigger_response}",
+                **error_payload(
+                    e,
+                    hint=f"The trigger response was not valid JSON: {trigger_response}",
+                    retryable=False,
+                    dag_id=dag_id,
+                ),
                 "timed_out": False,
             },
             indent=2,
         )
 
+    # If triggering itself failed, _trigger_dag_impl returns a structured error
+    # (with hint/retryable); propagate it rather than polling a run that was
+    # never created.
+    if isinstance(trigger_data, dict) and "error" in trigger_data:
+        return json.dumps({**trigger_data, "timed_out": False}, indent=2)
+
     dag_run_id = trigger_data.get("dag_run_id")
     if not dag_run_id:
         return json.dumps(
             {
-                "error": f"No dag_run_id in trigger response: {trigger_response}",
+                **error_payload(
+                    RuntimeError(f"No dag_run_id in trigger response: {trigger_response}"),
+                    retryable=False,
+                    dag_id=dag_id,
+                ),
                 "timed_out": False,
             },
             indent=2,
@@ -215,7 +232,7 @@ def _trigger_dag_and_wait_impl(
             return json.dumps(result, indent=2)
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def list_dag_runs(
     dag_id: str | None = None,
     limit: int = DEFAULT_LIMIT,
@@ -264,7 +281,7 @@ def list_dag_runs(
     )
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def get_dag_run(dag_id: str, dag_run_id: str) -> str:
     """Get detailed information about a specific DAG run execution.
 
@@ -301,7 +318,7 @@ def get_dag_run(dag_id: str, dag_run_id: str) -> str:
     return _get_dag_run_impl(dag_id=dag_id, dag_run_id=dag_run_id)
 
 
-@mcp.tool()
+@mcp.tool(annotations=write(destructive=False))
 def trigger_dag(dag_id: str, conf: dict | None = None) -> str:
     """Trigger a new DAG run (start a workflow execution manually).
 
@@ -346,7 +363,7 @@ def trigger_dag(dag_id: str, conf: dict | None = None) -> str:
     )
 
 
-@mcp.tool()
+@mcp.tool(annotations=write(destructive=False))
 def trigger_dag_and_wait(
     dag_id: str,
     conf: dict | None = None,
@@ -437,7 +454,7 @@ def _delete_dag_run_impl(dag_id: str, dag_run_id: str) -> str:
             result["deleted_run"] = run_details
         return json.dumps(result, indent=2)
     except Exception as e:
-        return str(e)
+        return tool_error(e, dag_id=dag_id, dag_run_id=dag_run_id)
 
 
 def _clear_dag_run_impl(
@@ -460,10 +477,10 @@ def _clear_dag_run_impl(
         data = adapter.clear_dag_run(dag_id, dag_run_id, dry_run=dry_run)
         return json.dumps(data, indent=2)
     except Exception as e:
-        return str(e)
+        return tool_error(e, dag_id=dag_id, dag_run_id=dag_run_id)
 
 
-@mcp.tool()
+@mcp.tool(annotations=write())
 def delete_dag_run(dag_id: str, dag_run_id: str) -> str:
     """Delete a specific DAG run permanently.
 
@@ -489,7 +506,7 @@ def delete_dag_run(dag_id: str, dag_run_id: str) -> str:
     return _delete_dag_run_impl(dag_id=dag_id, dag_run_id=dag_run_id)
 
 
-@mcp.tool()
+@mcp.tool(annotations=write(destructive=True, idempotent=True))
 def clear_dag_run(
     dag_id: str,
     dag_run_id: str,

--- a/astro-airflow-mcp/src/astro_airflow_mcp/tools/diagnostic.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/tools/diagnostic.py
@@ -9,6 +9,8 @@ from astro_airflow_mcp.server import (
     _wrap_list_response,
     mcp,
 )
+from astro_airflow_mcp.tool_annotations import read_only
+from astro_airflow_mcp.tool_errors import error_payload, tool_error
 
 
 def _list_dag_warnings_impl(
@@ -32,7 +34,7 @@ def _list_dag_warnings_impl(
             return _wrap_list_response(data["dag_warnings"], "dag_warnings", data)
         return f"No DAG warnings found. Response: {data}"
     except Exception as e:
-        return str(e)
+        return tool_error(e)
 
 
 def _list_import_errors_impl(
@@ -56,10 +58,10 @@ def _list_import_errors_impl(
             return _wrap_list_response(data["import_errors"], "import_errors", data)
         return f"No import errors found. Response: {data}"
     except Exception as e:
-        return str(e)
+        return tool_error(e)
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def list_dag_warnings() -> str:
     """Get warnings and issues detected in DAG definitions.
 
@@ -81,7 +83,7 @@ def list_dag_warnings() -> str:
     return _list_dag_warnings_impl()
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def list_import_errors() -> str:
     """Get import errors from DAG files that failed to parse or load.
 
@@ -117,7 +119,7 @@ def list_import_errors() -> str:
 # =============================================================================
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def explore_dag(dag_id: str) -> str:
     """Comprehensive investigation of a DAG - get all relevant info in one call.
 
@@ -148,25 +150,25 @@ def explore_dag(dag_id: str) -> str:
     try:
         result["dag_info"] = adapter.get_dag(dag_id)
     except Exception as e:
-        result["dag_info"] = {"error": str(e)}
+        result["dag_info"] = error_payload(e, dag_id=dag_id)
 
     # Get tasks
     try:
         tasks_data = adapter.list_tasks(dag_id)
         result["tasks"] = tasks_data.get("tasks", [])
     except Exception as e:
-        result["tasks"] = {"error": str(e)}
+        result["tasks"] = error_payload(e, dag_id=dag_id)
 
     # Get DAG source
     try:
         result["source"] = adapter.get_dag_source(dag_id)
     except Exception as e:
-        result["source"] = {"error": str(e)}
+        result["source"] = error_payload(e, dag_id=dag_id)
 
     return json.dumps(result, indent=2)
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def diagnose_dag_run(dag_id: str, dag_run_id: str) -> str:
     """Diagnose issues with a specific DAG run - get run details and failed tasks.
 
@@ -198,7 +200,7 @@ def diagnose_dag_run(dag_id: str, dag_run_id: str) -> str:
     try:
         result["run_info"] = adapter.get_dag_run(dag_id, dag_run_id)
     except Exception as e:
-        result["run_info"] = {"error": str(e)}
+        result["run_info"] = error_payload(e, dag_id=dag_id, dag_run_id=dag_run_id)
         return json.dumps(result, indent=2)
 
     # Get task instances for this run
@@ -230,12 +232,12 @@ def diagnose_dag_run(dag_id: str, dag_run_id: str) -> str:
             "failed_tasks": failed_tasks,
         }
     except Exception as e:
-        result["task_instances"] = {"error": str(e)}
+        result["task_instances"] = error_payload(e, dag_id=dag_id, dag_run_id=dag_run_id)
 
     return json.dumps(result, indent=2)
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def get_system_health() -> str:
     """Get overall Airflow system health - import errors, warnings, and DAG stats.
 
@@ -264,7 +266,7 @@ def get_system_health() -> str:
     try:
         result["version"] = adapter.get_version()
     except Exception as e:
-        result["version"] = {"error": str(e)}
+        result["version"] = error_payload(e)
 
     # Get import errors
     try:
@@ -275,7 +277,7 @@ def get_system_health() -> str:
             "errors": import_errors,
         }
     except Exception as e:
-        result["import_errors"] = {"error": str(e)}
+        result["import_errors"] = error_payload(e)
 
     # Get DAG warnings
     try:
@@ -286,7 +288,7 @@ def get_system_health() -> str:
             "warnings": dag_warnings,
         }
     except Exception as e:
-        result["dag_warnings"] = {"error": str(e)}
+        result["dag_warnings"] = error_payload(e)
 
     # Get DAG stats
     try:

--- a/astro-airflow-mcp/src/astro_airflow_mcp/tools/task.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/tools/task.py
@@ -3,6 +3,8 @@
 import json
 
 from astro_airflow_mcp.server import _get_adapter, _wrap_list_response, mcp
+from astro_airflow_mcp.tool_annotations import read_only, write
+from astro_airflow_mcp.tool_errors import tool_error
 
 
 def _get_task_impl(dag_id: str, task_id: str) -> str:
@@ -20,7 +22,7 @@ def _get_task_impl(dag_id: str, task_id: str) -> str:
         data = adapter.get_task(dag_id, task_id)
         return json.dumps(data, indent=2)
     except Exception as e:
-        return str(e)
+        return tool_error(e, dag_id=dag_id, task_id=task_id)
 
 
 def _list_tasks_impl(dag_id: str) -> str:
@@ -40,7 +42,7 @@ def _list_tasks_impl(dag_id: str) -> str:
             return _wrap_list_response(data["tasks"], "tasks", data)
         return f"No tasks found. Response: {data}"
     except Exception as e:
-        return str(e)
+        return tool_error(e, dag_id=dag_id)
 
 
 def _get_task_instance_impl(dag_id: str, dag_run_id: str, task_id: str) -> str:
@@ -59,7 +61,7 @@ def _get_task_instance_impl(dag_id: str, dag_run_id: str, task_id: str) -> str:
         data = adapter.get_task_instance(dag_id, dag_run_id, task_id)
         return json.dumps(data, indent=2)
     except Exception as e:
-        return str(e)
+        return tool_error(e, dag_id=dag_id, dag_run_id=dag_run_id, task_id=task_id)
 
 
 def _get_task_logs_impl(
@@ -93,7 +95,7 @@ def _get_task_logs_impl(
         )
         return json.dumps(data, indent=2)
     except Exception as e:
-        return str(e)
+        return tool_error(e, dag_id=dag_id, dag_run_id=dag_run_id, task_id=task_id)
 
 
 def _clear_task_instances_impl(
@@ -136,10 +138,10 @@ def _clear_task_instances_impl(
         )
         return json.dumps(data, indent=2)
     except Exception as e:
-        return str(e)
+        return tool_error(e, dag_id=dag_id, dag_run_id=dag_run_id, task_ids=task_ids)
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def get_task(dag_id: str, task_id: str) -> str:
     """Get detailed information about a specific task definition in a DAG.
 
@@ -177,7 +179,7 @@ def get_task(dag_id: str, task_id: str) -> str:
     return _get_task_impl(dag_id=dag_id, task_id=task_id)
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def list_tasks(dag_id: str) -> str:
     """Get all tasks defined in a specific DAG.
 
@@ -209,7 +211,7 @@ def list_tasks(dag_id: str) -> str:
     return _list_tasks_impl(dag_id=dag_id)
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def get_task_instance(dag_id: str, dag_run_id: str, task_id: str) -> str:
     """Get detailed information about a specific task instance execution.
 
@@ -242,7 +244,7 @@ def get_task_instance(dag_id: str, dag_run_id: str, task_id: str) -> str:
     return _get_task_instance_impl(dag_id=dag_id, dag_run_id=dag_run_id, task_id=task_id)
 
 
-@mcp.tool()
+@mcp.tool(annotations=read_only())
 def get_task_logs(
     dag_id: str,
     dag_run_id: str,
@@ -290,7 +292,7 @@ def get_task_logs(
     )
 
 
-@mcp.tool()
+@mcp.tool(annotations=write(destructive=True, idempotent=True))
 def clear_task_instances(
     dag_id: str,
     dag_run_id: str,

--- a/astro-airflow-mcp/src/astro_airflow_mcp/utils.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/utils.py
@@ -14,12 +14,19 @@ def normalize_airflow_url(url: str) -> str:
     ``https://host/dep?orgId=foo/api/v2/version`` — the path stays at ``/dep``
     and ``/api/...`` ends up inside the query string. Normalizing once at the
     boundary keeps every downstream call safe.
+
+    Any userinfo (``user:password@``) is also dropped: credentials are supplied
+    separately via the token/basic-auth getters, and the normalized URL can end
+    up in logs and in structured tool errors surfaced to the model.
     """
     if not url:
         return url
     parts = urlsplit(url)
     path = parts.path.rstrip("/")
-    return urlunsplit((parts.scheme, parts.netloc, path, "", ""))
+    # Strip any ``user:password@`` userinfo while preserving host[:port] (and
+    # IPv6 brackets) verbatim.
+    netloc = parts.netloc.rsplit("@", 1)[-1]
+    return urlunsplit((parts.scheme, netloc, path, "", ""))
 
 
 def filter_connection_passwords(connections: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/astro-airflow-mcp/tests/test_consolidated_tools.py
+++ b/astro-airflow-mcp/tests/test_consolidated_tools.py
@@ -311,6 +311,36 @@ class TestClearDagRunTool:
         assert "Server error" in result
 
 
+class TestTriggerDagAndWait:
+    """Tests for trigger_dag_and_wait error propagation."""
+
+    def test_propagates_structured_trigger_failure_without_polling(self, mocker):
+        """If triggering fails, return the structured error and never poll."""
+        trigger_error = json.dumps(
+            {
+                "error": "boom",
+                "error_type": "NotFoundError",
+                "hint": "check the dag_id",
+                "retryable": True,
+            }
+        )
+        mocker.patch.object(dag_run_module, "_trigger_dag_impl", return_value=trigger_error)
+        sleep = mocker.patch("astro_airflow_mcp.tools.dag_run.time.sleep")
+        get_run = mocker.patch.object(dag_run_module, "_get_dag_run_impl")
+
+        result = dag_run_module._trigger_dag_and_wait_impl(dag_id="my_dag")
+        data = json.loads(result)
+
+        # Structured error fields survive the hand-off; timed_out is annotated.
+        assert data["error"] == "boom"
+        assert data["error_type"] == "NotFoundError"
+        assert data["retryable"] is True
+        assert data["timed_out"] is False
+        # We must not poll a run that was never created.
+        sleep.assert_not_called()
+        get_run.assert_not_called()
+
+
 class TestGetSystemHealth:
     """Tests for get_system_health consolidated tool."""
 

--- a/astro-airflow-mcp/tests/test_tool_annotations.py
+++ b/astro-airflow-mcp/tests/test_tool_annotations.py
@@ -1,0 +1,118 @@
+"""Tests for MCP tool safety annotations and the end-to-end error round-trip.
+
+The end-to-end tests drive the real FastMCP server through an in-memory
+``Client``, so they exercise tool registration, annotation serialization, and
+the full call -> tool -> JSON-error path the way a real MCP client would.
+"""
+
+import asyncio
+import json
+from unittest.mock import MagicMock
+
+from fastmcp import Client
+
+from astro_airflow_mcp.adapters.base import NotFoundError, ReadOnlyError
+from astro_airflow_mcp.server import mcp
+from astro_airflow_mcp.tool_annotations import read_only, write
+
+# Every write tool and its expected (destructiveHint, idempotentHint).
+# Everything not listed here must be advertised as read-only.
+WRITE_TOOLS = {
+    "pause_dag": (False, True),
+    "unpause_dag": (False, True),
+    "trigger_dag": (False, False),
+    "trigger_dag_and_wait": (False, False),
+    "delete_dag_run": (True, False),
+    "clear_dag_run": (True, True),
+    "clear_task_instances": (True, True),
+}
+
+
+def _list_tools():
+    async def run():
+        async with Client(mcp) as client:
+            return await client.list_tools()
+
+    return asyncio.run(run())
+
+
+def _call_tool(name: str, args: dict):
+    async def run():
+        async with Client(mcp) as client:
+            return await client.call_tool(name, args)
+
+    return asyncio.run(run())
+
+
+class TestAnnotationHelpers:
+    def test_read_only_is_safe_and_idempotent(self):
+        ann = read_only()
+        assert ann.readOnlyHint is True
+        assert ann.destructiveHint is False
+        assert ann.idempotentHint is True
+        assert ann.openWorldHint is True
+
+    def test_write_defaults_are_cautious(self):
+        ann = write()
+        assert ann.readOnlyHint is False
+        assert ann.destructiveHint is True
+        assert ann.idempotentHint is False
+
+    def test_write_can_be_narrowed(self):
+        ann = write(destructive=False, idempotent=True)
+        assert ann.destructiveHint is False
+        assert ann.idempotentHint is True
+
+
+class TestServerAnnotations:
+    def test_every_tool_is_annotated(self):
+        tools = _list_tools()
+        assert tools  # server registered something
+        missing = [t.name for t in tools if not t.annotations]
+        assert missing == []
+
+    def test_write_tools_have_correct_hints(self):
+        tools = {t.name: t for t in _list_tools()}
+        for name, (destructive, idempotent) in WRITE_TOOLS.items():
+            ann = tools[name].annotations
+            assert ann is not None, name
+            assert ann.readOnlyHint is False, name
+            assert ann.destructiveHint is destructive, name
+            assert ann.idempotentHint is idempotent, name
+
+    def test_all_other_tools_are_read_only(self):
+        tools = {t.name: t for t in _list_tools()}
+        read_names = set(tools) - set(WRITE_TOOLS)
+        for name in read_names:
+            assert tools[name].annotations.readOnlyHint is True, name
+
+
+class TestStructuredErrorRoundTrip:
+    """A failing tool returns structured JSON through the MCP protocol."""
+
+    def test_not_found_error_round_trips(self, mocker):
+        mock_adapter = MagicMock()
+        mock_adapter.get_dag.side_effect = NotFoundError("dags/nope")
+        mocker.patch("astro_airflow_mcp.tools.dag._get_adapter", return_value=mock_adapter)
+
+        result = _call_tool("get_dag_details", {"dag_id": "nope"})
+        data = json.loads(result.content[0].text)
+
+        assert data["error_type"] == "NotFoundError"
+        assert data["dag_id"] == "nope"
+        assert data["retryable"] is True
+        assert data["hint"]
+
+    def test_read_only_block_round_trips(self, mocker, monkeypatch):
+        monkeypatch.setenv("AF_READ_ONLY", "true")
+        mock_adapter = MagicMock()
+        mock_adapter.pause_dag.side_effect = ReadOnlyError("PATCH dags/my_dag")
+        mocker.patch("astro_airflow_mcp.tools.dag._get_adapter", return_value=mock_adapter)
+
+        result = _call_tool("pause_dag", {"dag_id": "my_dag"})
+        data = json.loads(result.content[0].text)
+
+        assert data["error_type"] == "ReadOnlyError"
+        assert data["retryable"] is False
+        assert "read-only mode" in data["error"]
+        assert data["dag_id"] == "my_dag"

--- a/astro-airflow-mcp/tests/test_tool_errors.py
+++ b/astro-airflow-mcp/tests/test_tool_errors.py
@@ -1,0 +1,117 @@
+"""Tests for structured, agent-friendly tool error responses (``tool_errors``)."""
+
+import json
+
+import httpx
+import pytest
+
+from astro_airflow_mcp.adapters.base import NotFoundError, ReadOnlyError
+from astro_airflow_mcp.tool_errors import error_payload, tool_error
+
+
+def _http_status_error(status: int) -> httpx.HTTPStatusError:
+    """Build an httpx.HTTPStatusError carrying the given status code."""
+    request = httpx.Request("GET", "http://airflow.example/api/v2/dags")
+    response = httpx.Response(status_code=status, request=request)
+    return httpx.HTTPStatusError(f"HTTP {status}", request=request, response=response)
+
+
+class TestErrorPayloadShape:
+    """The payload always carries error/error_type/hint/retryable."""
+
+    def test_includes_message_type_hint_and_retryable(self):
+        payload = error_payload(ValueError("boom"))
+
+        assert payload["error"] == "boom"
+        assert payload["error_type"] == "ValueError"
+        assert payload["hint"]  # non-empty
+        assert payload["retryable"] is False  # unknown -> don't spin
+
+    def test_empty_message_falls_back_to_class_name(self):
+        payload = error_payload(ValueError())
+
+        assert payload["error"] == "ValueError"
+
+    def test_echoes_context_and_drops_none(self):
+        payload = error_payload(ValueError("x"), dag_id="d", dag_run_id=None)
+
+        assert payload["dag_id"] == "d"
+        assert "dag_run_id" not in payload
+
+    def test_explicit_overrides_win_over_inference(self):
+        payload = error_payload(ValueError("x"), retryable=True, hint="do this")
+
+        assert payload["retryable"] is True
+        assert payload["hint"] == "do this"
+
+
+class TestExceptionClassification:
+    """Retryability is inferred from the exception type / status code."""
+
+    def test_not_found_is_retryable(self):
+        payload = error_payload(NotFoundError("dags/missing"))
+
+        assert payload["error_type"] == "NotFoundError"
+        assert payload["retryable"] is True
+
+    def test_read_only_blocks_and_preserves_substrings(self):
+        # Backward-compat: callers/tests scanned the old bare string for these.
+        exc = ReadOnlyError("PATCH dags/my_dag")
+        payload = error_payload(exc, dag_id="my_dag")
+
+        assert payload["retryable"] is False
+        assert "read-only mode" in payload["error"]
+        assert "PATCH dags/my_dag" in payload["error"]
+        assert payload["dag_id"] == "my_dag"
+
+    @pytest.mark.parametrize(
+        ("status", "retryable"),
+        [
+            (400, True),
+            (422, True),
+            (401, False),
+            (403, False),
+            (404, True),
+            (409, False),
+            (429, True),
+            (500, False),
+            (503, False),
+        ],
+    )
+    def test_http_status_classification(self, status, retryable):
+        payload = error_payload(_http_status_error(status))
+
+        assert payload["retryable"] is retryable
+        assert str(status) in payload["hint"]
+
+    def test_http_status_error_echoes_context(self):
+        payload = error_payload(_http_status_error(404), dag_id="etl", dag_run_id=None)
+
+        assert payload["dag_id"] == "etl"
+        assert "dag_run_id" not in payload
+        assert payload["retryable"] is True
+
+    def test_timeout_is_not_retryable(self):
+        payload = error_payload(httpx.TimeoutException("slow"))
+
+        assert payload["retryable"] is False
+        assert "respond" in payload["hint"].lower()
+
+    def test_connect_error_is_not_retryable(self):
+        payload = error_payload(httpx.ConnectError("connection refused"))
+
+        assert payload["retryable"] is False
+        assert "reach airflow" in payload["hint"].lower()
+
+
+class TestToolError:
+    """``tool_error`` is the JSON-string form returned by MCP tools."""
+
+    def test_returns_parseable_json(self):
+        result = tool_error(NotFoundError("dags/x"), dag_id="x")
+        data = json.loads(result)
+
+        assert data["error_type"] == "NotFoundError"
+        assert data["dag_id"] == "x"
+        assert data["retryable"] is True
+        assert data["hint"]

--- a/astro-airflow-mcp/tests/test_utils.py
+++ b/astro-airflow-mcp/tests/test_utils.py
@@ -224,3 +224,12 @@ class TestNormalizeAirflowUrl:
     def test_strips_query_and_fragment_and_slash(self):
         url = "https://h/p/?x=1#y"
         assert normalize_airflow_url(url) == "https://h/p"
+
+    def test_strips_embedded_credentials(self):
+        # Userinfo must never survive normalization — the URL can surface in
+        # logs and in structured tool errors returned to the model.
+        url = "https://user:pw@host.example.com/dep"
+        assert normalize_airflow_url(url) == "https://host.example.com/dep"
+
+    def test_preserves_host_and_port_when_stripping_credentials(self):
+        assert normalize_airflow_url("http://u:p@host:8080/api") == "http://host:8080/api"


### PR DESCRIPTION
## Summary

MCP tools previously collapsed every failure to a bare `str(e)`. An agent calling, say, `get_task_instance("my_dag", "run_1", "extract")` got back `"404 Not Found"` with no way to tell a **wrong `dag_id`** (fix the argument and retry) from **Airflow being unreachable** (stop, surface to the user) — the same opaque string, opposite correct responses.

This PR makes every tool return a **structured error payload** and stamps **MCP safety annotations** on all 34 tools.

### Structured errors-as-data

A new `tool_errors` module turns exceptions into:

```json
{
  "error": "Endpoint not found: dags/my_dag",
  "error_type": "NotFoundError",
  "hint": "The resource was not found. Check dag_id/dag_run_id/task_id — a list_* tool can confirm valid values.",
  "retryable": true,
  "dag_id": "my_dag"
}
```

- `retryable` distinguishes caller-fixable problems (bad arg, 400/404/429) from hard blocks (auth, 5xx, read-only, unreachable), so the agent knows whether a corrected retry can help.
- `hint` gives the next action; identifying arguments are echoed back so the model has what it needs to self-correct.
- Classifies `ReadOnlyError`, `NotFoundError`, Astro auth errors, `httpx` status codes (400/401/404/409/429/5xx), timeouts, and transport errors.
- `str(e)` is always preserved inside `error`, so anything that scanned the old bare-string responses keeps working.

The 30 `except Exception: return str(e)` sites, the consolidated tools' per-section error embeds, and `trigger_dag_and_wait`'s trigger-failure path all use this now.

### MCP safety annotations

`read_only()` / `write(...)` helpers (default-cautious) stamp `ToolAnnotations` on every tool: 27 reads as read-only + idempotent; 7 writes with accurate hints — `delete_dag_run` destructive + non-idempotent, `clear_*` destructive + idempotent, `pause`/`unpause` non-destructive + idempotent, `trigger*` non-destructive + non-idempotent. Clients can gate writes **before** invocation, complementing the existing `AF_READ_ONLY` guard (which only refuses *after* the model has decided to call).

## Design rationale

- **Why keep `str(e)` in `error`?** Backward compatibility — existing tests and any consumer that grepped the old string still find their substrings. New consumers get the structured fields.
- **Why a `retryable` boolean instead of leaving it to the model?** The retry/stop decision is the single highest-value signal for agent self-correction and shouldn't depend on the model re-deriving it from prose each time.
- **Why default-cautious annotations?** A tool is only advertised "safe" when it explicitly opts in via `read_only()`; a new write tool that forgets to annotate is treated as destructive, not auto-approvable.
- **`normalize_airflow_url` now strips `user:password@`** from the netloc (preserving host/port/IPv6 verbatim). Credentials are supplied separately via the auth getters, and the normalized URL can appear in logs and in the URL embedded in error messages now surfaced to the model.

## Usage example

```python
# Read tools auto-approvable; writes gated
result = await client.call_tool("get_dag_details", {"dag_id": "nope"})
# -> {"error": "...", "error_type": "NotFoundError", "hint": "...", "retryable": true, "dag_id": "nope"}
```

## Tradeoffs / known issues

- When Airflow is unreachable, the adapter wraps the `httpx.ConnectError` in a bare `RuntimeError` ("Ensure Airflow is running and accessible") with no chained cause, so the classifier falls to the generic hint and `retryable=false`. That is correct behavior, and the message itself carries the guidance; a follow-up could chain the cause in `detect_version` and classify on it for a sharper hint.
- The `"No DAGs found. Response: …"`-style fallbacks on the *success* path (API returned an unexpected shape) remain plain strings; they are not error paths and are out of scope here.
