### PR TITLE
fix(diagnostic): page through all task instances in diagnose_dag_run

### DIFF
--- a/astro-airflow-mcp/src/astro_airflow_mcp/adapters/base.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/adapters/base.py
@@ -430,6 +430,28 @@ class AirflowAdapter(ABC):
             offset: Offset for pagination
         """
 
+    def get_all_task_instances(
+        self, dag_id: str, dag_run_id: str, page_size: int = 100
+    ) -> dict[str, Any]:
+        """Return every task instance for a DAG run, paging past the limit.
+
+        ``get_task_instances`` returns a single page (``page_size`` 100 by
+        default). On a run with many dynamically mapped instances, a failure at
+        a high ``map_index`` falls past the first page and is silently missed.
+        This pages through ``get_task_instances`` until a short page is
+        returned, so it works unchanged for every adapter version.
+        """
+        merged: list[dict[str, Any]] = []
+        offset = 0
+        while True:
+            page = self.get_task_instances(dag_id, dag_run_id, limit=page_size, offset=offset)
+            batch = page.get("task_instances", [])
+            merged.extend(batch)
+            offset += len(batch)
+            if len(batch) < page_size:
+                break
+        return {"task_instances": merged, "total_entries": len(merged)}
+
     @abstractmethod
     def get_task_logs(
         self,

--- a/astro-airflow-mcp/src/astro_airflow_mcp/tools/dag_run.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/tools/dag_run.py
@@ -109,7 +109,9 @@ def _get_failed_task_instances(
     """
     try:
         adapter = _get_adapter()
-        data = adapter.get_task_instances(dag_id, dag_run_id)
+        # Page through all task instances so failures past the first page
+        # (e.g. a high map_index on a large mapped DAG run) are not missed.
+        data = adapter.get_all_task_instances(dag_id, dag_run_id)
         task_instances = data.get("task_instances", [])
         return extract_failed_tasks(task_instances)
     except Exception:

--- a/astro-airflow-mcp/src/astro_airflow_mcp/tools/diagnostic.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/tools/diagnostic.py
@@ -205,7 +205,9 @@ def diagnose_dag_run(dag_id: str, dag_run_id: str) -> str:
 
     # Get task instances for this run
     try:
-        tasks_data = adapter.get_task_instances(dag_id, dag_run_id)
+        # Page through every task instance: a single page (100) can hide a
+        # failed mapped instance at a high map_index on large DAG runs.
+        tasks_data = adapter.get_all_task_instances(dag_id, dag_run_id)
         task_instances = tasks_data.get("task_instances", [])
         result["task_instances"] = task_instances
 
@@ -219,6 +221,7 @@ def diagnose_dag_run(dag_id: str, dag_run_id: str) -> str:
                 failed_tasks.append(
                     {
                         "task_id": ti.get("task_id"),
+                        "map_index": ti.get("map_index"),
                         "state": state,
                         "start_date": ti.get("start_date"),
                         "end_date": ti.get("end_date"),

--- a/astro-airflow-mcp/tests/test_adapters.py
+++ b/astro-airflow-mcp/tests/test_adapters.py
@@ -1525,3 +1525,66 @@ class TestAdapterManagerSSL:
         mgr.get_adapter()
 
         assert mock_create.call_args[1]["verify"] is True
+
+
+class TestGetAllTaskInstances:
+    """Tests for AirflowAdapter.get_all_task_instances pagination helper."""
+
+    def _adapter(self):
+        return AirflowV3Adapter("http://localhost:8080", "3.1.0")
+
+    def test_pages_through_all_results(self, mocker):
+        """It walks every page and merges results past the first page.
+
+        Regression for the bug where a failed instance at a high map_index
+        (beyond page 1) was silently dropped because only one page was read.
+        """
+        adapter = self._adapter()
+        page1 = {
+            "task_instances": [
+                {"task_id": "t", "map_index": 0, "state": "success"},
+                {"task_id": "t", "map_index": 1, "state": "success"},
+            ],
+            "total_entries": 3,
+        }
+        page2 = {
+            "task_instances": [
+                {"task_id": "t", "map_index": 14, "state": "failed"},
+            ],
+            "total_entries": 3,
+        }
+        mock_get = mocker.patch.object(adapter, "get_task_instances", side_effect=[page1, page2])
+
+        result = adapter.get_all_task_instances("dag", "run", page_size=2)
+
+        assert mock_get.call_count == 2
+        assert mock_get.call_args_list[0][1] == {"limit": 2, "offset": 0}
+        assert mock_get.call_args_list[1][1] == {"limit": 2, "offset": 2}
+        assert result["total_entries"] == 3
+        states = [(ti["map_index"], ti["state"]) for ti in result["task_instances"]]
+        assert (14, "failed") in states
+
+    def test_single_short_page_stops_immediately(self, mocker):
+        """A first page shorter than page_size needs no further requests."""
+        adapter = self._adapter()
+        page = {
+            "task_instances": [{"task_id": "t", "map_index": -1, "state": "success"}],
+            "total_entries": 1,
+        }
+        mock_get = mocker.patch.object(adapter, "get_task_instances", side_effect=[page])
+
+        result = adapter.get_all_task_instances("dag", "run", page_size=100)
+
+        assert mock_get.call_count == 1
+        assert result == {"task_instances": page["task_instances"], "total_entries": 1}
+
+    def test_unavailable_endpoint_yields_empty_result(self, mocker):
+        """A payload without a task_instances key yields an empty result."""
+        adapter = self._adapter()
+        not_found = {"available": False, "note": "Endpoint not available"}
+        mock_get = mocker.patch.object(adapter, "get_task_instances", side_effect=[not_found])
+
+        result = adapter.get_all_task_instances("dag", "run")
+
+        assert mock_get.call_count == 1
+        assert result == {"task_instances": [], "total_entries": 0}

--- a/astro-airflow-mcp/tests/test_consolidated_tools.py
+++ b/astro-airflow-mcp/tests/test_consolidated_tools.py
@@ -85,7 +85,7 @@ class TestDiagnoseDagRun:
         # Create mock adapter
         mock_adapter = MagicMock()
         mock_adapter.get_dag_run.return_value = mock_run
-        mock_adapter.get_task_instances.return_value = mock_task_instances
+        mock_adapter.get_all_task_instances.return_value = mock_task_instances
 
         mocker.patch("astro_airflow_mcp.tools.diagnostic._get_adapter", return_value=mock_adapter)
 
@@ -103,6 +103,48 @@ class TestDiagnoseDagRun:
         assert data["summary"]["state_counts"]["failed"] == 1
         assert data["summary"]["state_counts"]["upstream_failed"] == 1
         assert len(data["summary"]["failed_tasks"]) == 2
+
+    def test_diagnose_dag_run_surfaces_failed_mapped_instance_beyond_first_page(self, mocker):
+        """A failed mapped instance past the first page must appear in failed_tasks.
+
+        Regression test: diagnose_dag_run must page through every task instance
+        (via get_all_task_instances), otherwise a failure at a high map_index on
+        a large DAG run is silently dropped and the run looks healthy.
+        """
+        mock_run = {"dag_run_id": "scheduled__2026-06-16", "state": "running"}
+        # Simulate the merged result of paging: 100 successful instances plus a
+        # failed mapped instance that lived on a later page (map_index 14).
+        merged = {
+            "task_instances": (
+                [
+                    {"task_id": "lake_load.events_pagepath", "map_index": i, "state": "success"}
+                    for i in range(100)
+                ]
+                + [
+                    {
+                        "task_id": "lake_load.events_pagepath",
+                        "map_index": 14,
+                        "state": "failed",
+                        "try_number": 3,
+                    }
+                ]
+            )
+        }
+
+        mock_adapter = MagicMock()
+        mock_adapter.get_dag_run.return_value = mock_run
+        mock_adapter.get_all_task_instances.return_value = merged
+
+        mocker.patch("astro_airflow_mcp.tools.diagnostic._get_adapter", return_value=mock_adapter)
+
+        diagnose_fn = get_tool_fn(diagnostic_module, "diagnose_dag_run")
+        data = json.loads(diagnose_fn("dwh_analytics_12h", "scheduled__2026-06-16"))
+
+        failed = data["summary"]["failed_tasks"]
+        assert len(failed) == 1
+        assert failed[0]["task_id"] == "lake_load.events_pagepath"
+        assert failed[0]["map_index"] == 14
+        assert data["summary"]["total_tasks"] == 101
 
     def test_diagnose_dag_run_not_found(self, mocker):
         """Test diagnose_dag_run handles missing run."""


### PR DESCRIPTION
## Summary

Fixes #228.

`diagnose_dag_run` (and the `_get_failed_task_instances` helper) read a **single page** of task instances — `get_task_instances(dag_id, dag_run_id)` defaults to `limit=100, offset=0` with no pagination. On a DAG run with many **dynamically mapped** task instances, a failed instance at a high `map_index` falls past the first 100, so it never enters `failed_tasks` / `state_counts` and the run is reported as healthy with zero failures.

## Changes

- **`adapters/base.py`** — add a concrete `get_all_task_instances()` that pages through the existing `get_task_instances()` primitive until a short page is returned, merging the results. It's a composition over an existing endpoint (not a new one), so it lives as one concrete method on the base class and works unchanged for both Airflow 2 and 3 — no per-version duplication.
- **`tools/diagnostic.py`** and **`tools/dag_run.py`** — both callers now use `get_all_task_instances()`.
- **`tools/diagnostic.py`** — include `map_index` in the `failed_tasks` payload. This does not affect which failures are found (the pagination does that); it lets a consumer tell apart multiple failed mapped instances that share the same `task_id`.

## Tests

- `tests/test_adapters.py::TestGetAllTaskInstances` — paging merges across pages (incl. a failure on a later page), a short first page stops immediately, and a payload with no `task_instances` yields an empty result.
- `tests/test_consolidated_tools.py` — regression test asserting a failed mapped instance beyond the first page surfaces in `failed_tasks`.

Run with `uv run pytest tests/ --ignore=tests/integration/`.
