### PR TITLE
Fix analyzing-data kernel wrapper timeout, concurrency, and lifecycle issues

### DIFF
--- a/skills/analyzing-data/SKILL.md
+++ b/skills/analyzing-data/SKILL.md
@@ -49,8 +49,21 @@ Answer business questions by querying the data warehouse. The kernel auto-starts
 |----------|---------|
 | `run_sql(query, limit=100)` | Polars DataFrame |
 | `run_sql_pandas(query, limit=100)` | Pandas DataFrame |
+| `run_sql_many(queries, limit=100)` | List of Polars DataFrames (one per query) |
 
 `pl` (Polars) and `pd` (Pandas) are pre-imported.
+
+**Run independent queries together** with `run_sql_many` — they execute concurrently (Snowflake async / connection-pool fan-out) instead of one at a time:
+
+```bash
+uv run scripts/cli.py exec "dfs = run_sql_many(['SELECT ...', 'SELECT ...']); print(dfs[0])"
+```
+
+`run_sql_many` is **fail-fast**: if any query errors, the call raises and the results of the queries that succeeded are discarded. Use separate `run_sql` calls if you need partial results.
+
+**Timeouts:** `exec` waits up to 120s by default, then interrupts the query and returns a "client stopped waiting" message (the query may still finish server-side). Raise it for known long-running queries: `uv run scripts/cli.py exec "..." -t 600`.
+
+**Idle kernel:** the kernel self-terminates after 2h idle (preserving state until then). Override with `ASTRO_KERNEL_IDLE_TIMEOUT` (seconds; `0` disables).
 
 ## CLI Reference
 

--- a/skills/analyzing-data/scripts/cli.py
+++ b/skills/analyzing-data/scripts/cli.py
@@ -121,7 +121,13 @@ def start(warehouse: str | None):
 
 @main.command("exec")
 @click.argument("code")
-@click.option("--timeout", "-t", default=30.0, help="Timeout in seconds")
+@click.option(
+    "--timeout",
+    "-t",
+    default=120.0,
+    help="Seconds the client waits before interrupting the query (it may keep "
+    "running server-side). Raise for known long-running queries.",
+)
 def execute(code: str, timeout: float):
     """Execute Python code in the kernel. Auto-starts kernel if not running."""
     km = KernelManager()

--- a/skills/analyzing-data/scripts/connectors.py
+++ b/skills/analyzing-data/scripts/connectors.py
@@ -264,7 +264,7 @@ import os""")
         if self.query_tag:
             status_lines.append(f'print(f"   Query Tag: {self.query_tag}")')
         status_lines.append(
-            'print("\\nAvailable: run_sql(query) -> polars, run_sql_pandas(query) -> pandas")'
+            'print("\\nAvailable: run_sql(query) -> polars, run_sql_pandas(query) -> pandas, run_sql_many([q1, q2]) -> [polars, ...]")'
         )
         sections.append("\n".join(status_lines))
 
@@ -328,22 +328,26 @@ class PostgresConnector(DatabaseConnector):
         return env_vars
 
     def to_python_prelude(self) -> str:
-        lines = ["_conn = psycopg.connect("]
-        lines.append(f"    host={self.host!r},")
-        lines.append(f"    port={self.port},")
-        lines.append(f"    user={self.user!r},")
+        # Build a _connect() factory (not a bare connection) so run_sql_many can
+        # open one connection per worker thread for real concurrency.
+        lines = ["    return psycopg.connect("]
+        lines.append(f"        host={self.host!r},")
+        lines.append(f"        port={self.port},")
+        lines.append(f"        user={self.user!r},")
         if self.password_env_var:
-            lines.append(f"    password=os.environ.get({self.password_env_var!r}),")
+            lines.append(f"        password=os.environ.get({self.password_env_var!r}),")
         elif self.password:
-            lines.append(f"    password={self.password!r},")
-        lines.append(f"    dbname={self.database!r},")
+            lines.append(f"        password={self.password!r},")
+        lines.append(f"        dbname={self.database!r},")
         if self.sslmode:
-            lines.append(f"    sslmode={self.sslmode!r},")
+            lines.append(f"        sslmode={self.sslmode!r},")
         if self.application_name:
-            lines.append(f"    application_name={self.application_name!r},")
-        lines.append("    autocommit=True,")
-        lines.append(")")
-        connection_code = "\n".join(lines)
+            lines.append(f"        application_name={self.application_name!r},")
+        lines.append("        autocommit=True,")
+        lines.append("    )")
+        connection_code = (
+            "def _connect():\n" + "\n".join(lines) + "\n\n_conn = _connect()"
+        )
 
         status_lines = [
             'print("PostgreSQL connection established")',
@@ -354,11 +358,12 @@ class PostgresConnector(DatabaseConnector):
         if self.application_name:
             status_lines.append(f'print("   Application: {self.application_name}")')
         status_lines += [
-            'print("\\nAvailable: run_sql(query) -> polars, run_sql_pandas(query) -> pandas")',
+            'print("\\nAvailable: run_sql(query) -> polars, run_sql_pandas(query) -> pandas, run_sql_many([q1, q2]) -> [polars, ...]")',
         ]
         status_code = "\n".join(status_lines)
 
         return f'''import psycopg
+from concurrent.futures import ThreadPoolExecutor
 import polars as pl
 import pandas as pd
 import os
@@ -387,6 +392,33 @@ def run_sql_pandas(query: str, limit: int = 100):
         rows = cursor.fetchall()
         df = pd.DataFrame(rows, columns=columns)
         return df.head(limit) if limit > 0 and len(df) > limit else df
+
+
+def run_sql_many(queries, limit: int = 100):
+    """Run independent queries concurrently, one connection per worker thread,
+    returning one Polars DataFrame per query in input order.
+
+    Fail-fast: raises on the first failing query (in input order); queued queries
+    that haven't started are cancelled and the call won't block on the rest, but
+    queries already running aren't cancelled and may finish server-side."""
+    def _one(query):
+        with _connect() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(query)
+                if cursor.description is None:
+                    return pl.DataFrame()
+                columns = [desc[0] for desc in cursor.description]
+                rows = cursor.fetchall()
+                df = pl.DataFrame(rows, schema=columns, orient="row")
+                return df.head(limit) if limit > 0 and len(df) > limit else df
+    ex = ThreadPoolExecutor(max_workers=min(len(queries), 8) or 1)
+    try:
+        futures = [ex.submit(_one, q) for q in queries]
+        return [f.result() for f in futures]
+    finally:
+        # Don't block on in-flight queries when a sibling fails or the cell is
+        # interrupted; cancel anything still queued so the kernel frees up fast.
+        ex.shutdown(wait=False, cancel_futures=True)
 
 {status_code}'''
 
@@ -492,11 +524,12 @@ _client = bigquery.Client(project={self.project!r}, credentials=_credentials)"""
         if self.labels:
             status_lines.append(f'print(f"   Labels: {self.labels!r}")')
         status_lines.append(
-            'print("\\nAvailable: run_sql(query) -> polars, run_sql_pandas(query) -> pandas")'
+            'print("\\nAvailable: run_sql(query) -> polars, run_sql_pandas(query) -> pandas, run_sql_many([q1, q2]) -> [polars, ...]")'
         )
         status_code = "\n".join(status_lines)
 
         return f'''from google.cloud import bigquery
+from concurrent.futures import ThreadPoolExecutor
 import polars as pl
 import pandas as pd
 import os
@@ -518,6 +551,28 @@ def run_sql_pandas(query: str, limit: int = 100):
     query_job = _client.query(query, job_config=job_config{query_extra_args})
     df = query_job.to_dataframe()
     return df.head(limit) if limit > 0 and len(df) > limit else df
+
+
+def run_sql_many(queries, limit: int = 100):
+    """Run independent queries concurrently (the BigQuery client is thread-safe),
+    returning one Polars DataFrame per query in input order.
+
+    Fail-fast: raises on the first failing query (in input order); queued queries
+    that haven't started are cancelled and the call won't block on the rest, but
+    queries already running aren't cancelled and may finish server-side."""
+    def _one(query):
+        job_config = bigquery.QueryJobConfig({job_config_str})
+        query_job = _client.query(query, job_config=job_config{query_extra_args})
+        result = pl.from_pandas(query_job.to_dataframe())
+        return result.head(limit) if limit > 0 and len(result) > limit else result
+    ex = ThreadPoolExecutor(max_workers=min(len(queries), 8) or 1)
+    try:
+        futures = [ex.submit(_one, q) for q in queries]
+        return [f.result() for f in futures]
+    finally:
+        # Don't block on in-flight queries when a sibling fails or the cell is
+        # interrupted; cancel anything still queued so the kernel frees up fast.
+        ex.shutdown(wait=False, cancel_futures=True)
 
 {status_code}'''
 
@@ -678,6 +733,7 @@ class SQLAlchemyConnector(DatabaseConnector):
         databases_str = ", ".join(self.databases)
 
         return f'''from sqlalchemy import create_engine, text
+from concurrent.futures import ThreadPoolExecutor
 import polars as pl
 import pandas as pd
 import os
@@ -708,9 +764,37 @@ def run_sql_pandas(query: str, limit: int = 100):
         return df.head(limit) if limit > 0 and len(df) > limit else df
     return pd.DataFrame()
 
+
+def run_sql_many(queries, limit: int = 100):
+    """Run independent queries concurrently via the engine's connection pool,
+    returning one Polars DataFrame per query in input order. Each query runs on
+    its own pooled connection in a worker thread (the pool serializes access per
+    connection, so this is safe for both server and file databases).
+
+    Fail-fast: raises on the first failing query (in input order); queued queries
+    that haven't started are cancelled and the call won't block on the rest, but
+    queries already running aren't cancelled and may finish server-side."""
+    def _one(query):
+        with _engine.connect() as conn:
+            result = conn.execute(text(query))
+            if not result.returns_rows:
+                return pl.DataFrame()
+            columns = list(result.keys())
+            rows = result.fetchall()
+            df = pl.DataFrame(rows, schema=columns, orient="row")
+            return df.head(limit) if limit > 0 and len(df) > limit else df
+    ex = ThreadPoolExecutor(max_workers=min(len(queries), {self.pool_size}) or 1)
+    try:
+        futures = [ex.submit(_one, q) for q in queries]
+        return [f.result() for f in futures]
+    finally:
+        # Don't block on in-flight queries when a sibling fails or the cell is
+        # interrupted; cancel anything still queued so the kernel frees up fast.
+        ex.shutdown(wait=False, cancel_futures=True)
+
 print("{db_type} connection established (via SQLAlchemy)")
 print(f"   Database(s): {databases_str}")
-print("\\nAvailable: run_sql(query) -> polars, run_sql_pandas(query) -> pandas")'''
+print("\\nAvailable: run_sql(query) -> polars, run_sql_pandas(query) -> pandas, run_sql_many([q1, q2]) -> [polars, ...]")'''
 
 
 __all__ = [

--- a/skills/analyzing-data/scripts/kernel.py
+++ b/skills/analyzing-data/scripts/kernel.py
@@ -1,6 +1,9 @@
 """Jupyter kernel manager for executing Python code with persistent state."""
 
+import hashlib
+import os
 import shutil
+import signal
 import subprocess
 import sys
 import time
@@ -32,6 +35,10 @@ class ExecutionResult:
     success: bool
     output: str
     error: str | None = None
+    # True when the client stopped waiting (and interrupted the cell) rather
+    # than the query itself failing. Lets callers treat "I gave up" differently
+    # from "the query errored".
+    timed_out: bool = False
 
 
 class KernelManager:
@@ -54,6 +61,31 @@ class KernelManager:
         if sys.platform == "win32":
             return self.venv_dir / "Scripts" / "python.exe"
         return self.venv_dir / "bin" / "python"
+
+    @property
+    def pid_file(self) -> Path:
+        """Sidecar holding the running kernel's OS PID, used to interrupt it."""
+        return self.connection_file.with_suffix(".pid")
+
+    @property
+    def _deps_marker(self) -> Path:
+        """Records the package set the venv was last provisioned with."""
+        return self.venv_dir / ".astro-deps-hash"
+
+    def _deps_signature(self, packages: list[str]) -> str:
+        """Stable hash of the desired packages + kernel name."""
+        payload = "\n".join(sorted(packages) + [self.kernel_name])
+        return hashlib.sha256(payload.encode()).hexdigest()
+
+    def _kernel_registered(self) -> bool:
+        """Whether this kernel's spec is still installed. Used to avoid skipping
+        re-registration when the kernelspec was never written or got removed."""
+        try:
+            from jupyter_client.kernelspec import KernelSpecManager
+
+            return self.kernel_name in KernelSpecManager().find_kernel_specs()
+        except Exception:
+            return False
 
     @property
     def is_running(self) -> bool:
@@ -84,6 +116,19 @@ class KernelManager:
         if extra_packages:
             packages.extend(extra_packages)
 
+        # Skip the (slow) install + kernel registration when the existing venv
+        # was already provisioned with this exact package set AND the kernelspec
+        # is still registered. This makes restart/idle-kill recovery near-instant
+        # instead of a full reinstall, without caching a broken environment.
+        signature = self._deps_signature(packages)
+        if self.venv_dir.exists() and self.python_path.exists():
+            try:
+                marker_ok = self._deps_marker.read_text().strip() == signature
+            except OSError:
+                marker_ok = False
+            if marker_ok and self._kernel_registered():
+                return
+
         if not self.venv_dir.exists():
             print(f"Creating environment at {self.venv_dir}")
             subprocess.run(
@@ -100,8 +145,9 @@ class KernelManager:
         )
 
         # Register kernel
+        registered = False
         try:
-            subprocess.run(
+            result = subprocess.run(
                 [
                     str(self.python_path),
                     "-m",
@@ -116,8 +162,17 @@ class KernelManager:
                 capture_output=True,
                 timeout=30,
             )
+            registered = result.returncode == 0
         except Exception:
-            pass
+            registered = False
+
+        # Only record the marker once the environment is actually healthy, so a
+        # failed/missing registration is never cached as "skip next time".
+        if registered:
+            try:
+                self._deps_marker.write_text(signature)
+            except OSError:
+                pass
 
     def start(
         self,
@@ -131,11 +186,14 @@ class KernelManager:
         self.ensure_environment(extra_packages=extra_packages)
         print("Starting kernel...")
 
+        # Drop any stale PID sidecar before we start. If _write_pid can't
+        # discover the new kernel's PID, the absence of a file makes _interrupt a
+        # safe no-op rather than signaling a dead/reused PID.
+        self.pid_file.unlink(missing_ok=True)
+
         self._km = JupyterKernelManager(kernel_name=self.kernel_name)
 
         if env_vars:
-            import os
-
             for key, value in env_vars.items():
                 os.environ[key] = value
 
@@ -143,6 +201,7 @@ class KernelManager:
 
         self.connection_file.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(self._km.connection_file, self.connection_file)
+        self._write_pid()
 
         kc = self._km.client()
         kc.start_channels()
@@ -154,28 +213,98 @@ class KernelManager:
         finally:
             kc.stop_channels()
 
-        # Inject idle timeout watchdog into the kernel
-        self._km.client().execute(
-            "import threading, time, os, signal\n"
-            "_idle_timeout = 1800\n"  # 30 minutes
-            "_last_active = [time.time()]\n"
-            "_orig_execute = get_ipython().run_cell\n"
-            "def _tracked_execute(*a, **kw):\n"
-            "    _last_active[0] = time.time()\n"
-            "    return _orig_execute(*a, **kw)\n"
-            "get_ipython().run_cell = _tracked_execute\n"
-            "def _idle_watchdog():\n"
-            "    while True:\n"
-            "        time.sleep(60)\n"
-            "        if time.time() - _last_active[0] > _idle_timeout:\n"
-            "            os._exit(0)\n"
-            "_t = threading.Thread(target=_idle_watchdog, daemon=True)\n"
-            "_t.start()\n",
-            silent=True,
-        )
+        # Inject idle-timeout watchdog into the kernel. The timeout is read from
+        # ASTRO_KERNEL_IDLE_TIMEOUT (seconds); default 2h, 0 disables the
+        # watchdog entirely. Interactive sessions have long think-gaps, so the
+        # old 30-min default killed live kernels and lost their state.
+        idle_timeout = self._idle_timeout_seconds()
+        if idle_timeout > 0:
+            self._km.client().execute(
+                "import threading, time, os\n"
+                f"_idle_timeout = {idle_timeout}\n"
+                "_last_active = [time.time()]\n"
+                "_busy = [False]\n"
+                "_orig_execute = get_ipython().run_cell\n"
+                "def _tracked_execute(*a, **kw):\n"
+                "    _busy[0] = True\n"
+                "    _last_active[0] = time.time()\n"
+                "    try:\n"
+                "        return _orig_execute(*a, **kw)\n"
+                "    finally:\n"
+                "        _busy[0] = False\n"
+                "        _last_active[0] = time.time()\n"
+                "get_ipython().run_cell = _tracked_execute\n"
+                "def _idle_watchdog():\n"
+                "    while True:\n"
+                "        time.sleep(60)\n"
+                # Never kill a kernel that's actively running a cell, and measure
+                # idleness from when the last cell *finished*, not when it started.
+                "        if _busy[0]:\n"
+                "            continue\n"
+                "        if time.time() - _last_active[0] > _idle_timeout:\n"
+                "            _c = globals().get('_conn')\n"
+                "            if _c is not None:\n"
+                "                try:\n"
+                "                    _c.close()\n"
+                "                except Exception:\n"
+                "                    pass\n"
+                "            _e = globals().get('_engine')\n"
+                "            if _e is not None:\n"
+                "                try:\n"
+                "                    _e.dispose()\n"
+                "                except Exception:\n"
+                "                    pass\n"
+                "            os._exit(0)\n"
+                "_t = threading.Thread(target=_idle_watchdog, daemon=True)\n"
+                "_t.start()\n",
+                silent=True,
+            )
 
         self._km = None
         print(f"Kernel started ({self.connection_file})")
+
+    def _idle_timeout_seconds(self) -> int:
+        """Idle-watchdog timeout in seconds. Env-configurable, default 2h, 0=off."""
+        raw = os.environ.get("ASTRO_KERNEL_IDLE_TIMEOUT", "7200")
+        try:
+            return max(0, int(raw))
+        except ValueError:
+            return 7200
+
+    def _write_pid(self) -> None:
+        """Persist the kernel's OS PID so a later execute() can interrupt it."""
+        pid = None
+        for attr in ("provisioner", "kernel"):
+            pid = getattr(getattr(self._km, attr, None), "pid", None)
+            if pid:
+                break
+        if not pid:
+            return
+        try:
+            self.pid_file.write_text(str(pid))
+        except OSError:
+            pass
+
+    def _read_pid(self) -> int | None:
+        try:
+            return int(self.pid_file.read_text().strip())
+        except (OSError, ValueError):
+            return None
+
+    def _interrupt(self) -> None:
+        """Interrupt the running cell so the kernel stays responsive after a
+        client-side timeout, rather than leaving a query running that blocks
+        every subsequent execute(). SIGINT raises KeyboardInterrupt in the cell,
+        which the DB drivers turn into a query cancel."""
+        if sys.platform == "win32":
+            return  # SIGINT-by-PID is unreliable on Windows; skip.
+        pid = self._read_pid()
+        if pid is None:
+            return
+        try:
+            os.kill(pid, signal.SIGINT)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
 
     def stop(self) -> None:
         if not self.connection_file.exists():
@@ -193,9 +322,10 @@ class KernelManager:
 
         if self.connection_file.exists():
             self.connection_file.unlink()
+        self.pid_file.unlink(missing_ok=True)
         print('{"message": "Kernel stopped"}')
 
-    def execute(self, code: str, timeout: float = 30.0) -> ExecutionResult:
+    def execute(self, code: str, timeout: float = 120.0) -> ExecutionResult:
         if not self.connection_file.exists():
             return ExecutionResult(
                 False, "", "Kernel not running. Start with: uv run scripts/cli.py start"
@@ -243,8 +373,18 @@ class KernelManager:
         kc.stop_channels()
 
         if not done:
+            # The client gave up waiting, but the cell is still running. Interrupt
+            # it so the kernel stays responsive for the next call instead of
+            # queueing behind a query we abandoned. This is "I gave up", not
+            # "the query failed" -- flagged via timed_out so callers can tell.
+            self._interrupt()
             return ExecutionResult(
-                False, "".join(output_parts), f"Timeout after {timeout}s"
+                False,
+                "".join(output_parts),
+                f"Client stopped waiting after {timeout:.0f}s and interrupted the "
+                f"query (it may have kept running server-side). Re-run with a "
+                f"larger --timeout for known long-running queries.",
+                timed_out=True,
             )
 
         return ExecutionResult(status == "ok", "".join(output_parts), error_msg)

--- a/skills/analyzing-data/scripts/pyproject.toml
+++ b/skills/analyzing-data/scripts/pyproject.toml
@@ -8,7 +8,15 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest", "sqlalchemy", "polars", "pandas", "pyyaml", "python-dotenv"]
+test = [
+    "pytest",
+    "sqlalchemy",
+    "polars",
+    "pandas",
+    "pyyaml",
+    "python-dotenv",
+    "jupyter-client>=8.0.0",
+]
 test-integration = [
     "pytest",
     "sqlalchemy",
@@ -19,4 +27,6 @@ test-integration = [
     "psycopg[binary]",
     "duckdb",
     "duckdb-engine",
+    "jupyter-client>=8.0.0",
+    "ipykernel>=6.0.0",
 ]

--- a/skills/analyzing-data/scripts/templates.py
+++ b/skills/analyzing-data/scripts/templates.py
@@ -44,6 +44,44 @@ def run_sql_pandas(query: str, limit: int = 100):
         return df.head(limit) if limit > 0 and len(df) > limit else df
     finally:
         cursor.close()
+
+
+def run_sql_many(queries, limit: int = 100):
+    """Run independent queries concurrently, returning one Polars DataFrame per
+    query in input order. Submits all via Snowflake async execution so the
+    warehouse runs them in parallel instead of one-at-a-time.
+
+    Fail-fast: raises on the first failing query; the results of sibling queries
+    are discarded. Queries already submitted to the warehouse are not cancelled
+    and may keep running server-side (same caveat as a single run_sql timeout)."""
+    cursors = []
+    try:
+        for q in queries:
+            cur = _conn.cursor()
+            cursors.append(cur)  # track before submit so a failure can't leak it
+            cur.execute_async(q)
+        results = []
+        for cur in cursors:
+            cur.get_results_from_sfqid(cur.sfqid)  # blocks until this one finishes
+            try:
+                result = pl.from_pandas(cur.fetch_pandas_all())
+            except Exception:
+                rows = cur.fetchall()
+                columns = (
+                    [desc[0] for desc in cur.description] if cur.description else []
+                )
+                result = pl.DataFrame(rows, schema=columns, orient="row")
+            results.append(
+                result.head(limit) if limit > 0 and len(result) > limit else result
+            )
+        return results
+    finally:
+        # Close every cursor we opened, even if submission/collection failed partway.
+        for cur in cursors:
+            try:
+                cur.close()
+            except Exception:
+                pass
 '''
 
 # --- Private Key Templates (for Snowflake auth) ---

--- a/skills/analyzing-data/scripts/tests/integration/test_kernel_interrupt.py
+++ b/skills/analyzing-data/scripts/tests/integration/test_kernel_interrupt.py
@@ -1,0 +1,64 @@
+"""Integration test for fix #1: a client-side timeout interrupts the running
+cell and leaves the kernel responsive for the next execute().
+
+This is the one behavior the mock-based unit tests can't prove -- that SIGINT
+actually unwinds a blocking cell and the kernel recovers. It starts a real
+Jupyter kernel (no warehouse needed), so it's gated behind `uv` availability
+and lives under tests/integration (excluded from the default unit run).
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from kernel import KernelManager
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("uv") is None, reason="uv required to build the kernel venv"
+)
+
+
+@pytest.fixture
+def live_kernel():
+    """A real, started kernel using throwaway venv/connection paths."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        km = KernelManager(
+            venv_dir=tmp / "venv",
+            kernel_name="astro-ai-kernel-itest",  # unique: don't clobber real kernel
+        )
+        km.connection_file = tmp / "kernel.json"
+        try:
+            km.start()
+        except Exception as e:  # pragma: no cover - environment dependent
+            pytest.skip(f"could not start kernel: {e}")
+        try:
+            yield km
+        finally:
+            km.stop()
+
+
+def test_timeout_interrupts_then_kernel_stays_responsive(live_kernel):
+    # Sanity: kernel runs normal code.
+    warmup = live_kernel.execute("print('ready')", timeout=30)
+    assert warmup.success, warmup.error
+    assert "ready" in warmup.output
+
+    # A long cell with a short client timeout must report timed_out (not a
+    # generic failure) and interrupt the cell rather than abandoning it.
+    slow = live_kernel.execute("import time; time.sleep(30)", timeout=2)
+    assert slow.timed_out is True
+    assert slow.success is False
+
+    # The kernel must remain usable immediately afterwards -- the whole point of
+    # interrupting instead of leaving the query running and blocking the queue.
+    after = live_kernel.execute("print(6 * 7)", timeout=30)
+    assert after.success, after.error
+    assert "42" in after.output
+
+
+def test_pid_file_written_and_cleared(live_kernel):
+    assert live_kernel.pid_file.exists()
+    assert live_kernel._read_pid() is not None

--- a/skills/analyzing-data/scripts/tests/test_connectors.py
+++ b/skills/analyzing-data/scripts/tests/test_connectors.py
@@ -14,6 +14,7 @@ from connectors import (
     get_connector_class,
     list_connector_types,
 )
+from templates import HELPERS_CODE
 
 
 class TestRegistry:
@@ -1065,3 +1066,159 @@ class TestSQLiteEndToEnd:
             result_pd = local_vars["run_sql_pandas"]("SELECT * FROM users")
             assert len(result_pd) == 2
             assert "dataframe" in str(type(result_pd)).lower()
+
+
+class TestRunSqlMany:
+    """#2 concurrency: every connector exposes a concurrent run_sql_many."""
+
+    @pytest.mark.parametrize(
+        "connector",
+        [
+            SnowflakeConnector(
+                account="a", user="u", password="p", warehouse="WH", databases=["DB"]
+            ),
+            PostgresConnector(
+                host="h", port=5432, user="u", database="db", databases=["db"]
+            ),
+            BigQueryConnector(project="p", databases=["p"]),
+            SQLAlchemyConnector(url="postgresql://u:p@h/d", databases=["d"]),
+        ],
+        ids=["snowflake", "postgres", "bigquery", "sqlalchemy"],
+    )
+    def test_prelude_defines_run_sql_many(self, connector):
+        prelude = connector.to_python_prelude()
+        assert "def run_sql_many" in prelude
+        # advertised in the connection banner
+        assert "run_sql_many" in prelude.split("Available:")[-1]
+
+    def test_snowflake_uses_async_submission(self):
+        prelude = SnowflakeConnector(
+            account="a", user="u", password="p", databases=["DB"]
+        ).to_python_prelude()
+        assert "execute_async" in prelude
+        assert "get_results_from_sfqid" in prelude
+
+    def test_postgres_builds_connection_factory(self):
+        """run_sql_many needs a per-thread connection, so a _connect() factory
+        must exist (not just a bare _conn)."""
+        prelude = PostgresConnector(
+            host="localhost", user="u", database="db", databases=["db"]
+        ).to_python_prelude()
+        assert "def _connect()" in prelude
+        assert "_conn = _connect()" in prelude
+        assert "ThreadPoolExecutor" in prelude
+
+    def test_sqlalchemy_run_sql_many_executes_concurrently(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = SQLAlchemyConnector(url=f"sqlite:///{db_path}", databases=["test"])
+            local_vars: dict = {}
+            exec(conn.to_python_prelude(), local_vars)
+            local_vars["_conn"].execute(
+                local_vars["text"]("CREATE TABLE t (id INTEGER PRIMARY KEY, n TEXT)")
+            )
+            local_vars["_conn"].execute(
+                local_vars["text"]("INSERT INTO t (n) VALUES ('a'), ('b'), ('c')")
+            )
+            local_vars["_conn"].commit()
+
+            dfs = local_vars["run_sql_many"](
+                ["SELECT * FROM t", "SELECT count(*) AS c FROM t"]
+            )
+            assert len(dfs) == 2
+            assert len(dfs[0]) == 3
+            assert dfs[1][0, 0] == 3
+            # order preserved, polars returned
+            assert all("polars" in str(type(df)).lower() for df in dfs)
+
+    def test_sqlalchemy_run_sql_many_empty(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = SQLAlchemyConnector(url=f"sqlite:///{db_path}", databases=["test"])
+            local_vars: dict = {}
+            exec(conn.to_python_prelude(), local_vars)
+            assert local_vars["run_sql_many"]([]) == []
+
+    def test_sqlalchemy_run_sql_many_raises_on_bad_query(self):
+        # A failing query must propagate (fail-fast) and not hang on the executor.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = SQLAlchemyConnector(url=f"sqlite:///{db_path}", databases=["test"])
+            local_vars: dict = {}
+            exec(conn.to_python_prelude(), local_vars)
+            local_vars["_conn"].execute(
+                local_vars["text"]("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+            )
+            local_vars["_conn"].commit()
+            with pytest.raises(Exception):  # noqa: B017 - any DB error is acceptable
+                local_vars["run_sql_many"](["SELECT * FROM t", "SELECT * FROM nope"])
+
+
+class TestSnowflakeRunSqlManyCursors:
+    """Snowflake run_sql_many must close every cursor it opens, even when a
+    query fails partway through collection (no cursor leak on the shared conn)."""
+
+    def _exec_helpers(self, fail_at=None, fail_submit_at=None):
+        import pandas as pd
+        import polars as pl
+
+        cursors = []
+
+        class FakeCursor:
+            def __init__(self, idx):
+                self.idx = idx
+                self.sfqid = f"qid-{idx}"
+                self.description = [("n",)]
+                self.closed = False
+
+            def execute_async(self, query):
+                if fail_submit_at is not None and self.idx == fail_submit_at:
+                    raise RuntimeError("submit failed")
+
+            def get_results_from_sfqid(self, qid):
+                if fail_at is not None and self.idx == fail_at:
+                    raise RuntimeError("query failed")
+
+            def fetch_pandas_all(self):
+                return pd.DataFrame({"n": [self.idx]})
+
+            def fetchall(self):
+                return [(self.idx,)]
+
+            def close(self):
+                self.closed = True
+
+        class FakeConn:
+            def cursor(self):
+                cur = FakeCursor(len(cursors))
+                cursors.append(cur)
+                return cur
+
+        namespace = {"_conn": FakeConn(), "pl": pl, "pd": pd}
+        exec(HELPERS_CODE, namespace)
+        return namespace["run_sql_many"], cursors
+
+    def test_success_returns_ordered_results_and_closes_all(self):
+        run_sql_many, cursors = self._exec_helpers()
+        dfs = run_sql_many(["q0", "q1", "q2"])
+        assert len(dfs) == 3
+        assert [df[0, 0] for df in dfs] == [0, 1, 2]  # order preserved
+        assert len(cursors) == 3
+        assert all(c.closed for c in cursors)
+
+    def test_failure_midbatch_still_closes_every_cursor(self):
+        run_sql_many, cursors = self._exec_helpers(fail_at=1)
+        with pytest.raises(RuntimeError, match="query failed"):
+            run_sql_many(["q0", "q1", "q2"])
+        # all three were opened in the submit loop; none may leak
+        assert len(cursors) == 3
+        assert all(c.closed for c in cursors), [c.closed for c in cursors]
+
+    def test_failure_during_submit_closes_opened_cursors(self):
+        # execute_async raising must not leak the cursor it was raised on, nor
+        # any opened before it (the cursor is tracked before submission).
+        run_sql_many, cursors = self._exec_helpers(fail_submit_at=1)
+        with pytest.raises(RuntimeError, match="submit failed"):
+            run_sql_many(["q0", "q1", "q2"])
+        assert len(cursors) == 2  # third was never created
+        assert all(c.closed for c in cursors), [c.closed for c in cursors]

--- a/skills/analyzing-data/scripts/tests/test_kernel.py
+++ b/skills/analyzing-data/scripts/tests/test_kernel.py
@@ -1,0 +1,183 @@
+"""Tests for KernelManager lifecycle helpers (timeout, idle, deps marker, PID).
+
+These cover the pure logic added for the kernel-wrapper fixes without needing a
+live Jupyter kernel.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from kernel import ExecutionResult, KernelManager
+
+
+@pytest.fixture
+def km(tmp_path):
+    """KernelManager pointed at throwaway venv/connection paths."""
+    manager = KernelManager(venv_dir=tmp_path / "venv")
+    manager.connection_file = tmp_path / "kernel.json"
+    return manager
+
+
+class TestExecutionResult:
+    def test_timed_out_defaults_false(self):
+        result = ExecutionResult(success=True, output="ok")
+        assert result.timed_out is False
+
+    def test_timed_out_can_be_set(self):
+        result = ExecutionResult(
+            success=False, output="", error="gave up", timed_out=True
+        )
+        assert result.timed_out is True
+
+
+class TestIdleTimeoutSeconds:
+    @pytest.mark.parametrize(
+        "env_value,expected",
+        [
+            (None, 7200),  # unset -> 2h default
+            ("0", 0),  # explicit disable
+            ("3600", 3600),
+            ("-5", 0),  # negatives clamp to 0
+            ("garbage", 7200),  # invalid -> default
+        ],
+        ids=["unset", "disabled", "custom", "negative", "invalid"],
+    )
+    def test_idle_timeout_seconds(self, km, monkeypatch, env_value, expected):
+        if env_value is None:
+            monkeypatch.delenv("ASTRO_KERNEL_IDLE_TIMEOUT", raising=False)
+        else:
+            monkeypatch.setenv("ASTRO_KERNEL_IDLE_TIMEOUT", env_value)
+        assert km._idle_timeout_seconds() == expected
+
+
+class TestDepsSignature:
+    def test_order_insensitive(self, km):
+        assert km._deps_signature(["b", "a"]) == km._deps_signature(["a", "b"])
+
+    def test_content_sensitive(self, km):
+        assert km._deps_signature(["a", "b"]) != km._deps_signature(["a", "b", "c"])
+
+    def test_kernel_name_sensitive(self, tmp_path):
+        a = KernelManager(venv_dir=tmp_path / "v", kernel_name="one")
+        b = KernelManager(venv_dir=tmp_path / "v", kernel_name="two")
+        assert a._deps_signature(["x"]) != b._deps_signature(["x"])
+
+
+class TestDerivedPaths:
+    def test_pid_file_next_to_connection_file(self, km):
+        assert km.pid_file == km.connection_file.with_suffix(".pid")
+
+    def test_deps_marker_inside_venv(self, km):
+        assert km._deps_marker.parent == km.venv_dir
+
+
+class TestEnsureEnvironmentSkip:
+    """#4: a provisioned venv with a matching signature AND a registered
+    kernelspec must not reinstall; anything less must repair."""
+
+    def _provision(self, km, packages):
+        km.python_path.parent.mkdir(parents=True, exist_ok=True)
+        km.python_path.write_text("")  # pretend interpreter exists
+        km._deps_marker.write_text(km._deps_signature(packages))
+
+    def test_skips_install_when_signature_matches_and_registered(self, km):
+        self._provision(km, km.packages.copy())
+        with (
+            patch("kernel.shutil.which", return_value="/usr/bin/uv"),
+            patch.object(KernelManager, "_kernel_registered", return_value=True),
+            patch("kernel.subprocess.run") as run,
+        ):
+            km.ensure_environment()
+        run.assert_not_called()
+
+    def test_reinstalls_when_kernelspec_missing(self, km):
+        """Marker matches but the kernelspec is gone -> must re-register, not skip."""
+        self._provision(km, km.packages.copy())
+        with (
+            patch("kernel.shutil.which", return_value="/usr/bin/uv"),
+            patch.object(KernelManager, "_kernel_registered", return_value=False),
+            patch("kernel.subprocess.run") as run,
+        ):
+            km.ensure_environment()
+        assert run.called
+
+    def test_reinstalls_when_extra_packages_change(self, km):
+        self._provision(km, km.packages.copy())  # marker has no extras
+        with (
+            patch("kernel.shutil.which", return_value="/usr/bin/uv"),
+            patch.object(KernelManager, "_kernel_registered", return_value=True),
+            patch("kernel.subprocess.run") as run,
+        ):
+            km.ensure_environment(extra_packages=["snowflake-connector-python"])
+        assert run.called
+
+    def test_writes_marker_after_successful_registration(self, km):
+        with (
+            patch("kernel.shutil.which", return_value="/usr/bin/uv"),
+            patch("kernel.subprocess.run") as run,
+        ):
+            run.return_value.returncode = 0  # registration succeeds
+            km.venv_dir.mkdir(parents=True, exist_ok=True)
+            km.ensure_environment()
+        assert km._deps_marker.read_text() == km._deps_signature(km.packages.copy())
+
+    def test_marker_not_written_when_registration_fails(self, km):
+        with (
+            patch("kernel.shutil.which", return_value="/usr/bin/uv"),
+            patch("kernel.subprocess.run") as run,
+        ):
+            run.return_value.returncode = 1  # ipykernel install failed
+            km.venv_dir.mkdir(parents=True, exist_ok=True)
+            km.ensure_environment()
+        assert not km._deps_marker.exists()
+
+    def test_missing_uv_raises(self, km):
+        with patch("kernel.shutil.which", return_value=None):
+            with pytest.raises(RuntimeError, match="uv is not installed"):
+                km.ensure_environment()
+
+
+class TestInterruptGuards:
+    def test_read_pid_missing_file_returns_none(self, km):
+        assert km._read_pid() is None
+
+    def test_read_pid_roundtrip(self, km):
+        km.pid_file.parent.mkdir(parents=True, exist_ok=True)
+        km.pid_file.write_text("4242")
+        assert km._read_pid() == 4242
+
+    def test_read_pid_garbage_returns_none(self, km):
+        km.pid_file.parent.mkdir(parents=True, exist_ok=True)
+        km.pid_file.write_text("not-a-pid")
+        assert km._read_pid() is None
+
+    def test_interrupt_noop_without_pid(self, km):
+        # No pid file -> must not raise and must not signal anything.
+        with patch("kernel.os.kill") as kill:
+            km._interrupt()
+        kill.assert_not_called()
+
+    def test_interrupt_signals_pid(self, km):
+        km.pid_file.parent.mkdir(parents=True, exist_ok=True)
+        km.pid_file.write_text("4242")
+        with patch("kernel.sys.platform", "darwin"), patch("kernel.os.kill") as kill:
+            km._interrupt()
+        kill.assert_called_once()
+        assert kill.call_args.args[0] == 4242
+
+    def test_interrupt_skipped_on_windows(self, km):
+        km.pid_file.parent.mkdir(parents=True, exist_ok=True)
+        km.pid_file.write_text("4242")
+        with patch("kernel.sys.platform", "win32"), patch("kernel.os.kill") as kill:
+            km._interrupt()
+        kill.assert_not_called()
+
+    def test_interrupt_swallows_dead_pid(self, km):
+        km.pid_file.parent.mkdir(parents=True, exist_ok=True)
+        km.pid_file.write_text("4242")
+        with (
+            patch("kernel.sys.platform", "darwin"),
+            patch("kernel.os.kill", side_effect=ProcessLookupError),
+        ):
+            km._interrupt()  # must not propagate


### PR DESCRIPTION
## Summary

The `analyzing-data` kernel wrapper had four issues that caused friction in long, multi-query analysis sessions. This PR fixes all four and adds tests.

### 1. Client timeout no longer abandons a running query

The `exec` client timeout was 30s and, on expiry, reported failure without interrupting the cell — so a normal 30–90s analytical query looked like a failure, kept running server-side, and blocked the next `exec` (the kernel appeared stuck).

- Default `--timeout` raised 30s → 120s.
- On timeout, the running cell is interrupted (SIGINT to the kernel via a PID sidecar) so the kernel stays responsive for the next call.
- The result now carries `timed_out=True` with a "client stopped waiting" message, distinct from a query error. Pass `-t 600` for known long-running queries.

### 2. `run_sql_many()` for concurrent queries

Independent queries serialized on a single shared connection. The new `run_sql_many(queries)` helper on every connector runs them concurrently:

- **Snowflake:** `execute_async()` submission so the warehouse runs them in parallel.
- **SQLAlchemy / Postgres / BigQuery:** thread-pool fan-out (per-worker pooled/own connection; BigQuery's client is thread-safe).
- The long-lived `_conn` is kept for sequential `run_sql`, preserving cross-call session state (temp tables, session vars).

```python
dfs = run_sql_many(["SELECT ...", "SELECT ..."])  # list of DataFrames, in input order
```

### 3. Configurable idle timeout

The idle watchdog killed the kernel after 30 min and lost in-kernel state — too short for interactive sessions with think-gaps.

- Default raised to 2h, configurable via `ASTRO_KERNEL_IDLE_TIMEOUT` (seconds; `0` disables).
- Never fires while a cell is actively running; idle is measured from the last cell's completion.
- Closes the DB connection/engine before self-terminating.

### 4. Skip redundant reinstall on restart

`ensure_environment` ran `uv pip install` on every start, making idle-kill recovery slow.

- Caches a hash of the resolved package set; skips reinstall + kernel registration when the venv already satisfies it and the kernelspec is still registered.
- The marker is written only after a successful install + registration, so a broken environment is never cached as healthy.

## Design notes / tradeoffs

- **Interrupt via PID sidecar:** `execute()` runs in a separate CLI process from `start()`, so there is no live kernel-manager handle to interrupt with. The kernel PID is persisted at start and cleared on each start; if it cannot be discovered, `_interrupt` is a safe no-op rather than risk signaling a reused PID.
- **`run_sql_many` is fail-fast:** it raises on the first failing query and discards sibling results; queued work is cancelled and the call does not block on in-flight queries, but queries already running are not cancelled and may finish server-side (same caveat as a single-query timeout). Use separate `run_sql` calls if you need partial results.

## Known follow-ups

- `execute()` opens a fresh kernel client per call; over very long sessions this can accumulate file descriptors. Worth pooling the client in a follow-up.
