### PR TITLE
feat: Add `--end-date-gte` / `--end-date-lte` filters to `af runs list`

### DIFF
--- a/astro-airflow-mcp/src/astro_airflow_mcp/cli/runs.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/cli/runs.py
@@ -54,6 +54,18 @@ def list_dag_runs(
             "--start-date-lte", help="Runs with start_date <= value (e.g., 2024-01-01T00:00:00Z)"
         ),
     ] = None,
+    end_date_gte: Annotated[
+        str | None,
+        typer.Option(
+            "--end-date-gte", help="Runs with end_date >= value (e.g., 2024-01-01T00:00:00Z)"
+        ),
+    ] = None,
+    end_date_lte: Annotated[
+        str | None,
+        typer.Option(
+            "--end-date-lte", help="Runs with end_date <= value (e.g., 2024-01-01T00:00:00Z)"
+        ),
+    ] = None,
 ) -> None:
     """List DAG runs (workflow executions).
 
@@ -70,6 +82,10 @@ def list_dag_runs(
             kwargs["start_date_gte"] = start_date_gte
         if start_date_lte:
             kwargs["start_date_lte"] = start_date_lte
+        if end_date_gte:
+            kwargs["end_date_gte"] = end_date_gte
+        if end_date_lte:
+            kwargs["end_date_lte"] = end_date_lte
 
         adapter = get_adapter()
         data = adapter.list_dag_runs(dag_id=dag_id, limit=limit, offset=offset, **kwargs)

--- a/astro-airflow-mcp/tests/test_cli_runs.py
+++ b/astro-airflow-mcp/tests/test_cli_runs.py
@@ -46,3 +46,31 @@ class TestRunsListCommand:
             offset=0,
             order_by="id",
         )
+
+    def test_end_date_filters_forwarded(self, mocker):
+        """--end-date-gte / --end-date-lte are forwarded to the adapter as kwargs."""
+        mock_adapter = MagicMock()
+        mock_adapter.list_dag_runs.return_value = {"dag_runs": [], "total_entries": 0}
+        mocker.patch("astro_airflow_mcp.cli.runs.get_adapter", return_value=mock_adapter)
+
+        result = runner.invoke(
+            app,
+            [
+                "runs",
+                "list",
+                "--end-date-gte",
+                "2026-06-10T15:00:00Z",
+                "--end-date-lte",
+                "2026-06-10T15:15:00Z",
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock_adapter.list_dag_runs.assert_called_once_with(
+            dag_id=None,
+            limit=100,
+            offset=0,
+            order_by="-start_date",
+            end_date_gte="2026-06-10T15:00:00Z",
+            end_date_lte="2026-06-10T15:15:00Z",
+        )


### PR DESCRIPTION
## Summary

Adds `--end-date-gte` / `--end-date-lte` options to `af runs list`, matching the existing `--start-date-gte` / `--start-date-lte` filters.

A lot of run-level monitoring is keyed off when a run *finished*, not when it started — e.g. "which runs completed in the last 15 minutes and how did they end" for a recovery sweep. The runs list endpoint supports this via `end_date_gte` / `end_date_lte`, but the CLI only surfaced the start-date filters, so completed-run queries had to drop down to the raw API call:

```
af api "dags/~/dagRuns" -F end_date_gte=2026-06-10T15:00:00Z
```

Closes #225.

## Design rationale

No adapter change is needed. `list_dag_runs` (in both the v2 and v3 adapters) already forwards arbitrary filters into the request params via `**kwargs`, and `base._call` merges them into the query string and drops `None` values. The only gap was that the CLI didn't expose the options, so this mirrors the existing start-date plumbing exactly: two `typer.Option`s plus four lines folding them into `kwargs`.

## Usage

```bash
# Runs that finished in a window (cross-DAG; --dag-id is optional)
af runs list --end-date-gte 2026-06-10T15:00:00Z --end-date-lte 2026-06-10T15:15:00Z

# Combine with state for a recovery sweep
af runs list --end-date-gte 2026-06-10T15:00:00Z --state failed
```

Values are ISO 8601 timestamps, the same format the start-date options accept.
