### PR TITLE
Document `DBT_DOCS_DIR` alongside `DBT_DOCS_PROJECTS` in cosmos-dbt-core

### DIFF
--- a/skills/cosmos-dbt-core/SKILL.md
+++ b/skills/cosmos-dbt-core/SKILL.md
@@ -329,7 +329,25 @@ my_dag = DbtDag(
 )
 ```
 
-### dbt Docs Hosting (Airflow 3.1+ / Cosmos 1.11+)
+### dbt Docs Hosting
+
+Cosmos serves dbt docs in the Airflow UI. The config depends on your Airflow major
+version (each uses a different UI plugin system) — it is not a free single-vs-multi choice:
+
+| Airflow         | Config                                                            | Scope                | Since          |
+|-----------------|------------------------------------------------------------------|----------------------|----------------|
+| 2 (FAB plugin)  | `DBT_DOCS_DIR` (+ `DBT_DOCS_CONN_ID`, `DBT_DOCS_INDEX_FILE_NAME`) | Single project       | Cosmos 1.4.0+  |
+| 3.1+ (FastAPI)  | `DBT_DOCS_PROJECTS` (JSON)                                        | One or more projects | Cosmos 1.11.0+ |
+
+Airflow 2:
+
+```bash
+AIRFLOW__COSMOS__DBT_DOCS_DIR="path/to/docs"                   # local path or S3/GCS/Azure/HTTP URI; defaults to the dbt target/ folder
+AIRFLOW__COSMOS__DBT_DOCS_CONN_ID="my_conn_id"                 # optional; for cloud storage
+AIRFLOW__COSMOS__DBT_DOCS_INDEX_FILE_NAME="static_index.html"  # optional; only if docs built with --static
+```
+
+Airflow 3.1+:
 
 ```bash
 AIRFLOW__COSMOS__DBT_DOCS_PROJECTS='{
@@ -341,6 +359,10 @@ AIRFLOW__COSMOS__DBT_DOCS_PROJECTS='{
     }
 }'
 ```
+
+Pick by Airflow version, not project count. The single-project settings are the Airflow 2
+path; Cosmos publishes no deprecation notice for them — do not describe them as "legacy"
+or "deprecated."
 
 Reference: https://astronomer.github.io/astronomer-cosmos/configuration/hosting-docs.html
 


### PR DESCRIPTION
The cosmos-dbt-core skill's Appendix B documented only the multi-project AIRFLOW__COSMOS__DBT_DOCS_PROJECTS knob, tagged "Airflow 3.1+ / Cosmos 1.11+". The single-project form (DBT_DOCS_DIR, DBT_DOCS_CONN_ID, DBT_DOCS_INDEX_FILE_NAME) was absent, leading the model to infer it was "legacy" and assert that without verifying upstream.

Reframe the subsection around the Airflow major version (the actual axis upstream uses, since Airflow 2 and 3 use different UI plugin systems):

- Airflow 2 (FAB plugin): DBT_DOCS_DIR family, single project, Cosmos 1.4.0+
- Airflow 3.1+ (FastAPI plugin): DBT_DOCS_PROJECTS JSON, one or more projects, Cosmos 1.11.0+

Version facts verified against the upstream hosting-docs page, CHANGELOG (PR #737 / 1.4.0, PR #2009 / 1.11.0) and cosmos/plugin/airflow3.py. Instruct against "legacy"/"deprecated" framing rather than asserting a deprecation status either direction, since Cosmos publishes no formal deprecation notice.

There was no dbt Fusion equivalent content, so no change there. We may want to review the split between dbt Core and Fusion, since dbt Labs seems to be merging them within [dbt Core 2.0](https://github.com/dbt-labs/dbt-core/blob/main/docs/roadmap/2026-06-announcing-v2.md).

Refs BOSS-473