### PR TITLE
Standardize skill descriptions for reliable loading

### DIFF
--- a/skills/airflow-hitl/SKILL.md
+++ b/skills/airflow-hitl/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airflow-hitl
-description: Use when the user needs human-in-the-loop workflows in Airflow (approval/reject, form input, or human-driven branching). Covers ApprovalOperator, HITLOperator, HITLBranchOperator, HITLEntryOperator, HITLTrigger. Requires Airflow 3.1+. Does not cover AI/LLM calls (see airflow-ai).
+description: Builds human-in-the-loop (HITL) Airflow workflows - approval gates, form input, and human-driven branching. Use when a DAG needs a human in the loop - an approval or reject step, sign-off before a task runs, a decision or approval UI, branching on a human choice, or collecting form input mid-run; also on mentions of ApprovalOperator, HITLOperator, HITLBranchOperator, HITLEntryOperator, or HITLTrigger. Requires Airflow 3.1+. Not for AI/LLM task calls (see migrating-ai-sdk-to-common-ai).
 ---
 
 # Airflow Human-in-the-Loop Operators
@@ -11,7 +11,7 @@ Pause a DAG until a human responds via the Airflow UI or REST API. HITL operator
 >
 > **UI location**: Browse → Required Actions. Respond from the task instance page's Required Actions tab.
 >
-> **Cross-references**: `airflow-ai` for AI/LLM task decorators; `airflow` for registry and API discovery commands used below.
+> **Cross-references**: `migrating-ai-sdk-to-common-ai` for AI/LLM task decorators; `airflow` for registry and API discovery commands used below.
 
 ---
 
@@ -179,6 +179,6 @@ af registry modules standard \
 ## Related skills
 
 - **airflow** — `af registry`, `af api`, `af config` command reference.
-- **airflow-ai** — AI/LLM task decorators and GenAI patterns.
+- **migrating-ai-sdk-to-common-ai** — AI/LLM task decorators and GenAI patterns (common-ai provider).
 - **authoring-dags** — general DAG writing best practices.
 - **testing-dags** — iterative test → debug → fix cycles.

--- a/skills/airflow-plugins/SKILL.md
+++ b/skills/airflow-plugins/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airflow-plugins
-description: Build Airflow 3.1+ plugins that embed FastAPI apps, custom UI pages, React components, middleware, macros, and operator links directly into the Airflow UI. Use this skill whenever the user wants to create an Airflow plugin, add a custom UI page or nav entry to Airflow, build FastAPI-backed endpoints inside Airflow, serve static assets from a plugin, embed a React app in the Airflow UI, add middleware to the Airflow API server, create custom operator extra links, or call the Airflow REST API from inside a plugin. Also trigger when the user mentions AirflowPlugin, fastapi_apps, external_views, react_apps, plugin registration, or embedding a web app in Airflow 3.1+. If someone is building anything custom inside Airflow 3.1+ that involves Python and a browser-facing interface, this skill almost certainly applies.
+description: Builds Airflow 3.1+ plugins that embed FastAPI apps, custom UI pages, React components, middleware, macros, and operator links directly into the Airflow UI. Use when building anything custom inside Airflow 3.1+ that involves Python and a browser-facing interface - creating an Airflow plugin, adding a custom UI page or nav entry, building FastAPI-backed endpoints inside Airflow, serving static assets from a plugin, embedding a React app, adding middleware to the API server, creating custom operator extra links, or calling the Airflow REST API from inside a plugin; also when AirflowPlugin, fastapi_apps, external_views, react_apps, or plugin registration come up.
 ---
 
 # Airflow 3 Plugins

--- a/skills/airflow/SKILL.md
+++ b/skills/airflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airflow
-description: Queries, manages, and troubleshoots Apache Airflow using the af CLI. Covers listing DAGs, triggering runs, reading task logs, diagnosing failures, debugging DAG import errors, checking connections, variables, pools, and monitoring health. Also routes to sub-skills for writing DAGs, debugging, deploying, and migrating Airflow 2 to 3. Use when user mentions "Airflow", "DAG", "DAG run", "task log", "import error", "parse error", "broken DAG", or asks to "trigger a pipeline", "debug import errors", "check Airflow health", "list connections", "retry a run", or any Airflow operation. Do NOT use for warehouse/SQL analytics on Airflow metadata tables — use analyzing-data instead.
+description: Queries, manages, and troubleshoots Apache Airflow using the `af` CLI. Use when working with anything related to Airflow - a DAG, a DAG run, a task log, an import or parse error, a broken DAG, or any Airflow operation. Covers listing and triggering DAGs, retrying runs, reading task logs, diagnosing failures, debugging import and parse errors, checking connections, variables and pools, exploring the REST API, and monitoring health (for example "trigger a pipeline", "retry a run", "list connections", "check Airflow health", "why did my DAG fail"). This is the entrypoint that routes to sibling skills for authoring, testing, deploying, and migrating Airflow 2 to 3. Not for warehouse/SQL analytics on Airflow metadata tables (use analyzing-data); for deep root-cause reports use debugging-dags or airflow-investigation.
 ---
 
 # Airflow Operations

--- a/skills/analyzing-data/SKILL.md
+++ b/skills/analyzing-data/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analyzing-data
-description: Queries data warehouse and answers business questions about data. Handles questions requiring database/warehouse queries including "who uses X", "how many Y", "show me Z", "find customers", "what is the count", data lookups, metrics, trends, or SQL analysis.
+description: Queries the data warehouse with SQL and answers business questions about data. Use when answering anything that needs warehouse data - counts, metrics, trends, aggregations, joins across tables, data lookups, or ad-hoc SQL analysis (for example "who uses X", "how many Y", "show me Z", "find customers", "what is the count").
 ---
 
 # Data Analysis

--- a/skills/authoring-dags/SKILL.md
+++ b/skills/authoring-dags/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: authoring-dags
-description: Workflow and best practices for writing Apache Airflow DAGs. Use when the user wants to create a new DAG, write pipeline code, or asks about DAG patterns and conventions. For testing and debugging DAGs, see the testing-dags skill.
+description: Workflow and best practices for writing Apache Airflow DAGs. Use when creating a new DAG, write pipeline code, handling questions about DAG patterns and conventions or extending an existing DAG with a follow-up/downstream task. ANY request shaped like 'add a DAG named X', 'write a pipeline', 'add a task that runs after Y', or 'extend the DAG'. For testing and debugging DAGs, see the testing-dags skill.
 hooks:
   Stop:
     - hooks:

--- a/skills/cosmos-dbt-core/SKILL.md
+++ b/skills/cosmos-dbt-core/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cosmos-dbt-core
-description: Use when turning a dbt Core project into an Airflow DAG/TaskGroup using Astronomer Cosmos. Does not cover dbt Fusion. Before implementing, verify dbt engine, warehouse, Airflow version, execution environment, DAG vs TaskGroup, and manifest availability.
+description: Turns a dbt Core project into an Airflow DAG/TaskGroup using Astronomer Cosmos. Use turning a dbt Core project into an Airflow DAG or TaskGroup with Astronomer Cosmos. Before implementing, verify dbt engine, warehouse, Airflow version, execution environment, DAG vs TaskGroup, and manifest availability.
 ---
 
 # Cosmos + dbt Core: Implementation Checklist

--- a/skills/cosmos-dbt-fusion/SKILL.md
+++ b/skills/cosmos-dbt-fusion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cosmos-dbt-fusion
-description: Use when running a dbt Fusion project with Astronomer Cosmos. Covers Cosmos 1.11+ configuration for Fusion on Snowflake/Databricks with ExecutionMode.LOCAL. Before implementing, verify dbt engine is Fusion (not Core), warehouse is supported, and local execution is acceptable. Does not cover dbt Core.
+description: Run a dbt Fusion project with Astronomer Cosmos. Use when running a dbt Fusion project with Astronomer Cosmos (Cosmos 1.11+, ExecutionMode.LOCAL on Snowflake/Databricks). Before implementing, verify dbt engine is Fusion (not Core), the warehouse is supported, and local execution is acceptable. Does not cover dbt Core.
 ---
 
 # Cosmos + dbt Fusion: Implementation Checklist

--- a/skills/dag-factory/SKILL.md
+++ b/skills/dag-factory/SKILL.md
@@ -1,8 +1,7 @@
 ---
 name: dag-factory
-description: Author Apache Airflow DAGs declaratively with dag-factory YAML configs. Use when creating dag-factory templates, composing DAGs from YAML for dag-factory, configuring defaults/dynamic tasks/datasets/callbacks for dag-factory, or validating dag-factory configurations.
+description: Authors Apache Airflow DAGs declaratively from dag-factory YAML configs. Use when building DAGs declaratively from YAML via dag-factory; creating/editing dag-factory templates/YAML configs,reating/editing dag-factory YAML configs, defaults, dynamic tasks, datasets, or callbacks; or validating dag-factory configurations; upgrading or re-pinning dag-factory.
 ---
-
 # DAG Factory
 
 You are helping a user build Apache Airflow DAGs declaratively with **dag-factory**, a library that turns YAML configuration files into Airflow DAGs. Execute steps in order and prefer the simplest configuration that meets the user's needs.

--- a/skills/debugging-dags/SKILL.md
+++ b/skills/debugging-dags/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debugging-dags
-description: Comprehensive DAG failure diagnosis and root cause analysis. Use for complex debugging requests requiring deep investigation like "diagnose and fix the pipeline", "full root cause analysis", "why is this failing and how to prevent it". For simple debugging ("why did dag fail", "show logs"), the airflow entrypoint skill handles it directly. This skill provides structured investigation and prevention recommendations.
+description: Comprehensive DAG failure diagnosis and root-cause analysis  with structured investigation and prevention recommendations. Use when deep failure investigation is needed, a DAG fails to import/parse or 'airflow dags list' errors on a file; a task or run is failing and must be diagnosed and fixed; requests like 'why did X fail', 'my dag keeps failing — find and fix it', or fixing a broken DAG so it loads cleanly. For simple 'why did it fail / show logs', the airflow skill handles it directly.
 ---
 
 # DAG Diagnosis

--- a/skills/deploying-airflow/SKILL.md
+++ b/skills/deploying-airflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploying-airflow
-description: Deploy Airflow DAGs and projects. Use when the user wants to deploy code, push DAGs, set up CI/CD, deploy to production, or asks about deployment strategies for Airflow.
+description: Deploys Airflow DAGs and projects. Use when deploying Airflow or answering anything about deployment - deploying DAGs/projects, pushing code, setting up CI/CD, deploying to production or deployment strategies for Airflow.
 ---
 
 # Deploying Airflow

--- a/skills/migrating-ai-sdk-to-common-ai/SKILL.md
+++ b/skills/migrating-ai-sdk-to-common-ai/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: migrating-ai-sdk-to-common-ai
-description: Migrates Airflow projects from airflow-ai-sdk to apache-airflow-providers-common-ai 0.4.0+. Use this skill when the user wants to replace airflow-ai-sdk with the official Airflow AI provider, migrate LLM decorators (@task.llm, @task.agent, @task.llm_branch, @task.embed), switch from model strings/objects to connection-based LLM configuration, update imports from airflow_ai_sdk to the new provider, or upgrade an existing common-ai 0.1.x setup to 0.4.x (multimodal prompts, toolsets, embedding operators). Also trigger when the user mentions common-ai provider, AIP-99, pydanticai connection, or migrating away from airflow-ai-sdk.
+description: Migrates Airflow projects from airflow-ai-sdk to apache-airflow-providers-common-ai 0.4.0+. Use when replacing airflow-ai-sdk with the official Airflow AI provider - migrating LLM decorators (@task.llm, @task.agent, @task.llm_branch, @task.embed), switching from model strings/objects to connection-based LLM configuration, updating imports from airflow_ai_sdk to the new provider, or upgrading an existing common-ai 0.1.x setup to 0.4.x (multimodal prompts, toolsets, embedding operators); also when common-ai provider, AIP-99, a pydanticai connection or migrating away from airflow-ai-sdk come up.
 ---
 
 # Migrate airflow-ai-sdk to apache-airflow-providers-common-ai


### PR DESCRIPTION
## What this ships

Standardizes every skill's `description` so Otto loads the right skill reliably. Best practice for skill metadata is a brief **what + when**: one line on what the skill does, then an explicit **when to load it**, in consistent third-person language. We borrow this directly from Anthropic's [Agent Skills authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices). Current descriptions were inconsistent and conflated "what it does" with "when to use it", which weakened routing. This PR rewrites them to one consistent shape, expands thin/under-triggering descriptions, and fixes stale cross-references.

## Motivation: Otto omits loading skills

Otto ships vetted skills for the most common Airflow and Astro tasks, but in production it was barely loading them, so users got generic, ad-hoc behavior instead of the guardrailed workflows the skills encode. Across 300 LLM-judged production sessions, a skill loaded in only 86 (29%) of the cases where one should have. Full investigation and RCA: [AI-920](https://linear.app/astronomer/issue/AI-920/investigate-skills-under-utilization).

This PR fixes the skill-metadata half, and clears stale cross-references that pointed to skills no longer in the repo (the `airflow-ai` reference in `airflow-hitl`, in both its description and body). Core builds the skill manifest by reading each `skills/<name>/SKILL.md` frontmatter `description`, and that `description` is the only signal the model sees when deciding whether to load a skill. If it's inconsistent, conflated, or thin, routing suffers, and no amount of prompt tuning fully compensates.

## Issues

1. **No consistent format.** Four different opening styles across the catalog (imperative / noun-phrase / third-person / "Use when"-first). Only a handful were third-person.
2. **What vs. when conflated.** Descriptions mixed capability and trigger into one blob, with no clean "what it does" line followed by an explicit "when to load."
3. **Thin descriptions under-trigger.** Several (e.g. `deploying-airflow`, `tracing-*`, `checking-freshness`) were one short sentence and missed common real-world phrasings.
4. **Stale cross-references.** `airflow-hitl` pointed at a non-existent `airflow-ai` skill (in both its description and body).

## Changes

| file | what changed | why |
|---|---|---|
| `skills/airflow/SKILL.md` | Rewrote to what + when; front-loaded `Use when working with anything related to Airflow …`; added the entrypoint routing note and boundaries (`analyzing-data`, `debugging-dags`/`airflow-investigation`). | It's the hub skill; a clear trigger plus explicit routing drives both its own load rate and correct hand-off. |
| `skills/airflow-hitl/SKILL.md` | what + when rewrite; fixed the stale `airflow-ai` reference (now `migrating-ai-sdk-to-common-ai`) in both the description and the body. | Consistency, plus a dead cross-reference pointing at a non-existent skill. |
| `skills/airflow-plugins/SKILL.md` | what + when rewrite; condensed the trigger list, kept the "anything custom in the Airflow UI" catch-all. | Consistency without losing the broad coverage that made it trigger. |
| `skills/analyzing-data/SKILL.md` | what + when rewrite; kept the literal example questions ("who uses X", "how many Y"). | Consistency; situation-based trigger over a keyword blob. |
| `skills/authoring-dags/SKILL.md` | Expanded triggers to cover new-DAG, write-pipeline, extend/add-a-downstream-task, and "asks about patterns/conventions". | Was missing the "extend an existing DAG" and Q&A intents that users actually phrase. |
| `skills/cosmos-dbt-core/SKILL.md` | what + when rewrite; kept the pre-flight "verify engine/warehouse/version…" checklist; boundary vs Fusion. | Consistency while preserving the required preconditions. |
| `skills/cosmos-dbt-fusion/SKILL.md` | what + when rewrite; kept preconditions; boundary vs Core. | Consistency; disambiguate the two cosmos skills. |
| `skills/dag-factory/SKILL.md` | what + when rewrite; added an upgrade/re-pin trigger; boundary vs `blueprint`/`authoring-dags`. | Consistency plus missing intents; route the declarative-YAML cluster correctly. |
| `skills/debugging-dags/SKILL.md` | what + when rewrite; added import/parse-failure triggers ("broken DAG won't load"); kept the hand-off to `airflow` for simple log lookups. | Cover the common "DAG won't import" case and disambiguate from the `airflow` entrypoint. |
| `skills/deploying-airflow/SKILL.md` | Expanded the thin one-liner to cover deploy targets, CI/CD, production, and "asks about deployment strategies". | It was a single sentence and under-triggered. |
| `skills/migrating-ai-sdk-to-common-ai/SKILL.md` | what + when rewrite; kept the decorator/keyword triggers (`@task.llm`, AIP-99, `pydanticai`); boundary vs `migrating-airflow-2-to-3`. | Consistency; keep the high-signal literal triggers. |

## Results

Measured on [airflow-bench](https://github.com/astronomer/airflow-bench/tree/main), which gives AI coding agents real Apache Airflow jobs and checks whether they actually completed them. The gain is cumulative across the companion PRs:

| Otto build | generic skill | airflow-upgrade | any skill |
|---|---|---|---|
| Current Otto (baseline) | 5 | 32 | 35 (44%) |
| + system-prompt (otto#329) | 19 | 40 | 54 (68%) |
| + manifest / descriptions (agents#237, kb#138, astro) **(this PR's layer)** | 25 | 46 | 64 (82%) |

## Companion PRs

Four coordinated PRs from the skill-loading work, each in its own repo and layer. The reliability gain comes from all of them together:

| PR | repo | layer | what it does |
|---|---|---|---|
| [otto#329](https://github.com/astronomer/otto/pull/329) | astronomer/otto | prompt / tool-guidance | Makes skill-loading a blocking, intent-matched step so the model reaches for skills. |
| [agents#237](https://github.com/astronomer/agents/pull/237) | astronomer/agents | skill descriptions | Standardizes repo-backed skill descriptions to what + when. **← this PR** |
| [otto-upgrade-kb#138](https://github.com/astronomer/otto-upgrade-kb/pull/138) | astronomer/otto-upgrade-kb | airflow-upgrade (canonical) | Adds the when-to-load trigger to the airflow-upgrade `tool_description`. |
## Validation

Linted every description: third-person, contains an explicit `Use when`, ≤ 1024 chars, every cross-referenced skill resolves.

## Rollback

Description/text-level changes only. Revert the `SKILL.md` files.
