### PR TITLE
feat: Auto-bump astronomer-data plugin version on content changes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "astronomer-data",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Data engineering plugin - warehouse exploration, pipeline authoring, Airflow integration",
   "hooks": {
     "SessionStart": [

--- a/.github/workflows/plugin-version-bump.yml
+++ b/.github/workflows/plugin-version-bump.yml
@@ -1,0 +1,95 @@
+name: "astronomer-data: Auto-bump plugin version"
+
+# Why this exists:
+# The astronomer-data plugin's version lives in .claude-plugin/plugin.json and is
+# read verbatim by Claude Code at whatever commit a marketplace pins. Both our own
+# marketplace (source "./") and the official Anthropic marketplace
+# (anthropics/claude-plugins-official, which lists us with "version": null) resolve
+# the plugin version from this file. Claude Code's update detection SKIPS a plugin
+# when the resolved version matches what a user already has -- so if this string
+# never changes, users never receive new skills, even when the pinned sha moves.
+#
+# This workflow guarantees the version advances on every content change to main, so
+# updates actually propagate. Minor/major bumps are still done by hand in the PR
+# (edit plugin.json); this only fills in the automatic patch increment when a content
+# change lands without one.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "skills/**"
+      - ".claude-plugin/marketplace.json"
+      # plugin.json is deliberately NOT a trigger path: the bump commit below only
+      # touches plugin.json, so excluding it here stops this workflow from
+      # retriggering itself.
+
+permissions:
+  contents: write
+
+concurrency:
+  group: plugin-version-bump
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    name: Bump patch version
+    runs-on: ubuntu-latest
+    # Belt-and-suspenders against self-retrigger.
+    if: github.actor != 'github-actions[bot]'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: true # needed so the bump commit can be pushed
+
+      - name: Bump patch version unless this push already changed it
+        id: bump
+        run: |
+          set -euo pipefail
+          manifest=.claude-plugin/plugin.json
+
+          read_version() { grep -oE '"version"[[:space:]]*:[[:space:]]*"[^"]+"' | head -1 | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/'; }
+
+          current=$(read_version < "$manifest")
+
+          # Version on the previous main tip. If the push already advanced it (a
+          # deliberate minor/major bump in the merged PR), respect that and stop.
+          before='${{ github.event.before }}'
+          previous=""
+          if git cat-file -e "${before}:${manifest}" 2>/dev/null; then
+            previous=$(git show "${before}:${manifest}" | read_version)
+          fi
+          echo "current=${current} previous=${previous:-<none>}"
+
+          if [ -n "$previous" ] && [ "$current" != "$previous" ]; then
+            echo "Version already changed (${previous} -> ${current}); nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          IFS=. read -r major minor patch <<< "$current"
+          next="${major}.${minor}.$((patch + 1))"
+
+          # Format-preserving: replace only the first version value, leaving
+          # indentation and the trailing comma untouched.
+          sed -i -E "0,/\"version\"[[:space:]]*:[[:space:]]*\"[0-9]+\.[0-9]+\.[0-9]+\"/s//\"version\": \"${next}\"/" "$manifest"
+          echo "Bumped ${current} -> ${next}"
+          echo "next=${next}" >> "$GITHUB_OUTPUT"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push bump
+        if: steps.bump.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .claude-plugin/plugin.json
+          git commit -m "chore: Bump astronomer-data plugin to ${{ steps.bump.outputs.next }}"
+          # Rebase-retry once in case main advanced while this job ran.
+          git push origin HEAD:main \
+            || { git fetch origin main && git rebase origin/main && git push origin HEAD:main; }
+
+      # If main is protected against direct pushes by Actions, grant
+      # github-actions[bot] a bypass, or replace the step above with a PR via
+      # peter-evans/create-pull-request. See the PR description for details.


### PR DESCRIPTION
## Summary

The `astronomer-data` plugin has shipped from `.claude-plugin/plugin.json` with `"version": "0.1.0"` since the manifest was first created, and the string never moved. Claude Code resolves a plugin's version from `plugin.json` first, and **skips an update whenever the resolved version matches what a user already has**. So every user — including everyone on the official Anthropic marketplace, where we're listed as `astronomer-data-agents`, `data`, and `data-engineering`, all with `"version": null` (which falls through to this file) — has been frozen on whatever they first installed. New skills never reached them.

This PR does two things:

1. **Catches the version up to `0.2.0`** so the next time our pinned sha is refreshed, the accumulated skill changes since `0.1.0` actually get delivered.
2. **Adds a workflow that auto-increments the patch version** on every push to `main` that touches `skills/**` or the marketplace manifest — so we can't silently re-freeze.

## Design rationale

- **Why automate instead of bumping by hand?** Manual bumping is exactly what failed — the field sat at `0.1.0` across dozens of skill changes. The workflow makes the version advance a side effect of merging content.
- **Why patch-only auto-bump?** Monotonic increase is all that's needed for update detection to fire. Deliberate minor/major bumps are still done by editing `plugin.json` in the PR; the workflow detects that the push already changed the version and skips its own bump, so it never fights a manual decision.
- **Why exclude `plugin.json` from the trigger paths?** The bump commit only touches `plugin.json`; excluding it from `paths` stops the workflow from retriggering itself.
- **Format-preserving edit.** The bump replaces only the version value via `sed`, leaving indentation and the trailing comma intact, so the manifest stays clean in diffs.
- This mirrors how peer data-platform plugins handle it — Databricks (`databricks-agent-skills`) sits at `0.2.9` and Snowflake (`snowflake-ai-kit`) at `3.2.2`; both bump on release rather than freezing.

## Gotchas / tradeoffs

- **Direct push to `main`.** The workflow commits the bump back to `main` using the default `GITHUB_TOKEN`. If `main` is protected against pushes from Actions, either grant `github-actions[bot]` a bypass, or swap the final step for a PR (e.g. `peter-evans/create-pull-request`) — flagged inline in the workflow.
- **Fork PRs** that change skills won't auto-bump on their own merge (fork-token limitations); the next intra-repo push to `main` will catch the version up.
- Every skill-touching merge now advances the patch version. That's intended — each change is meant to reach users — but it does mean a steady stream of `chore: Bump ...` commits.

## Follow-up (not in this PR)

The bigger reach lever is that the official Anthropic marketplace pins our sha and only re-points it periodically, and we currently appear under three names there (`astronomer-data-agents`, `data`, `data-engineering`). Worth a separate cleanup/refresh conversation.
