### PR TITLE
fix: Prevent FastMCP 3.4.3 host guard from 421-ing the plugin endpoint

### DIFF
--- a/astro-airflow-mcp/pyproject.toml
+++ b/astro-airflow-mcp/pyproject.toml
@@ -5,7 +5,10 @@ description = "A FastMCP server for Airflow integration that can run standalone 
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "fastmcp>=0.1.0",
+    # Pinned to a bounded range: 3.4.3 introduced HostOriginGuardMiddleware and the
+    # host_origin_protection/allowed_hosts kwargs the plugin relies on (see plugin.py).
+    # The upper bound guards against another default-behavior change in a new major.
+    "fastmcp>=3.4.3,<4",
     "filelock>=3.0.0",
     "httpx>=0.27.0",
     "packaging>=21.0",

--- a/astro-airflow-mcp/src/astro_airflow_mcp/plugin.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/plugin.py
@@ -12,6 +12,7 @@ import logging
 import os
 import threading
 from typing import Any
+from urllib.parse import urlparse
 
 from astro_airflow_mcp import __version__
 
@@ -40,20 +41,29 @@ def _host_guard_kwargs() -> dict[str, Any]:
     which only accepts loopback Host headers (127.0.0.1/localhost/::1) plus the
     ASGI ``scope["server"]`` host and returns ``421 "Misdirected Request"`` for
     anything else. In plugin mode the MCP app is embedded in the Airflow
-    webserver and reachable only through the platform ingress — which
-    terminates TLS for the Deployment's hostname, runs forward-auth, and
-    requires a bearer token — so Host/Origin are enforced there and the
-    loopback-only default rejects every real request. Delegate that check to
-    the ingress by default.
+    webserver, reached over the Deployment's own hostname, so the loopback-only
+    default rejects every real request.
 
-    Set ``ASTRO_MCP_ALLOWED_HOSTS`` (comma-separated hostnames) to instead keep
-    the guard enabled with an explicit allowlist. Standalone mode
-    (``__main__.py``, served via ``mcp.run``) keeps FastMCP's default
-    protection, which is what a locally-bound server needs.
+    Rather than disable the guard, keep it enabled and scope it to the
+    Deployment's hostname, which Astro injects as ``AIRFLOW__WEBSERVER__BASE_URL``
+    (an env var, so it's available at import time — unlike Airflow's ``conf``,
+    which is populated later). ``ASTRO_MCP_ALLOWED_HOSTS`` (comma-separated)
+    overrides the allowlist for custom domains or extra hosts.
+
+    If no hostname can be determined (non-Astro embedding), fall back to
+    delegating the check to whatever fronts the app. Standalone mode
+    (``__main__.py``, ``mcp.run``) keeps FastMCP's default protection, which is
+    what a locally-bound server needs.
     """
     allowed = os.environ.get("ASTRO_MCP_ALLOWED_HOSTS", "").strip()
     if allowed:
         return {"allowed_hosts": [h.strip() for h in allowed.split(",") if h.strip()]}
+
+    base_url = os.environ.get("AIRFLOW__WEBSERVER__BASE_URL", "").strip()
+    host = urlparse(base_url).hostname if base_url else None
+    if host:
+        return {"allowed_hosts": [host]}
+
     return {"host_origin_protection": False}
 
 

--- a/astro-airflow-mcp/src/astro_airflow_mcp/plugin.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/plugin.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import asyncio
 import contextvars
-import inspect
 import logging
 import os
 import threading
@@ -34,7 +33,7 @@ _request_basic_auth: contextvars.ContextVar[tuple[str, str] | None] = contextvar
 )
 
 
-def _host_guard_kwargs(http_app: Any) -> dict[str, Any]:
+def _host_guard_kwargs() -> dict[str, Any]:
     """Host/Origin guard settings for the embedded (plugin-mode) MCP app.
 
     FastMCP >= 3.4.3 ships ``HostOriginGuardMiddleware``, enabled by default,
@@ -43,29 +42,19 @@ def _host_guard_kwargs(http_app: Any) -> dict[str, Any]:
     anything else. In plugin mode the MCP app is embedded in the Airflow
     webserver and reachable only through the platform ingress — which
     terminates TLS for the Deployment's hostname, runs forward-auth, and
-    requires a bearer token — so Host/Origin/DNS-rebinding are enforced there.
-    The loopback-only default therefore rejects every real request. Delegate
-    that check to the ingress by default.
+    requires a bearer token — so Host/Origin are enforced there and the
+    loopback-only default rejects every real request. Delegate that check to
+    the ingress by default.
 
     Set ``ASTRO_MCP_ALLOWED_HOSTS`` (comma-separated hostnames) to instead keep
-    the in-app guard enabled with an explicit allowlist.
-
-    The relevant keywords only exist on FastMCP >= 3.4.3, so we probe
-    ``http_app``'s signature and return nothing on older versions (which have
-    no such guard to configure). Standalone mode (``__main__.py``, served via
-    ``mcp.run``) is intentionally left on FastMCP's default protection, since a
-    locally-bound server is the case DNS-rebinding protection is meant for.
+    the guard enabled with an explicit allowlist. Standalone mode
+    (``__main__.py``, served via ``mcp.run``) keeps FastMCP's default
+    protection, which is what a locally-bound server needs.
     """
-    try:
-        params = inspect.signature(http_app).parameters
-    except (TypeError, ValueError):
-        return {}
     allowed = os.environ.get("ASTRO_MCP_ALLOWED_HOSTS", "").strip()
-    if allowed and "allowed_hosts" in params:
+    if allowed:
         return {"allowed_hosts": [h.strip() for h in allowed.split(",") if h.strip()]}
-    if "host_origin_protection" in params:
-        return {"host_origin_protection": False}
-    return {}
+    return {"host_origin_protection": False}
 
 
 try:
@@ -102,9 +91,7 @@ try:
     # Get the native MCP protocol ASGI app from FastMCP
     # Use stateless_http=True so sessions aren't stored in-memory,
     # which is required for multi-replica deployments (e.g., Astro)
-    mcp_protocol_app = mcp.http_app(
-        path="/", stateless_http=True, **_host_guard_kwargs(mcp.http_app)
-    )
+    mcp_protocol_app = mcp.http_app(path="/", stateless_http=True, **_host_guard_kwargs())
 
     # Wrap in a FastAPI app with the MCP app's lifespan
     # This is required for FastMCP to initialize its task group
@@ -208,9 +195,7 @@ if _airflow_major == 2 and not fastapi_apps_config:
             return f"http://localhost:{_plugin_port_v2}{_get_base_path()}"
 
         # ASGI app — same as the AF3 path but we call it from Flask
-        _mcp_asgi_app = mcp.http_app(
-            path="/", stateless_http=True, **_host_guard_kwargs(mcp.http_app)
-        )
+        _mcp_asgi_app = mcp.http_app(path="/", stateless_http=True, **_host_guard_kwargs())
 
         # --- Lazy init: event loop + ASGI lifespan ---
         # FastMCP needs a running lifespan to initialize its task group.

--- a/astro-airflow-mcp/src/astro_airflow_mcp/plugin.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/plugin.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import contextvars
+import inspect
 import logging
 import os
 import threading
@@ -31,6 +32,41 @@ _request_auth_token: contextvars.ContextVar[str | None] = contextvars.ContextVar
 _request_basic_auth: contextvars.ContextVar[tuple[str, str] | None] = contextvars.ContextVar(
     "mcp_request_basic_auth", default=None
 )
+
+
+def _host_guard_kwargs(http_app: Any) -> dict[str, Any]:
+    """Host/Origin guard settings for the embedded (plugin-mode) MCP app.
+
+    FastMCP >= 3.4.3 ships ``HostOriginGuardMiddleware``, enabled by default,
+    which only accepts loopback Host headers (127.0.0.1/localhost/::1) plus the
+    ASGI ``scope["server"]`` host and returns ``421 "Misdirected Request"`` for
+    anything else. In plugin mode the MCP app is embedded in the Airflow
+    webserver and reachable only through the platform ingress — which
+    terminates TLS for the Deployment's hostname, runs forward-auth, and
+    requires a bearer token — so Host/Origin/DNS-rebinding are enforced there.
+    The loopback-only default therefore rejects every real request. Delegate
+    that check to the ingress by default.
+
+    Set ``ASTRO_MCP_ALLOWED_HOSTS`` (comma-separated hostnames) to instead keep
+    the in-app guard enabled with an explicit allowlist.
+
+    The relevant keywords only exist on FastMCP >= 3.4.3, so we probe
+    ``http_app``'s signature and return nothing on older versions (which have
+    no such guard to configure). Standalone mode (``__main__.py``, served via
+    ``mcp.run``) is intentionally left on FastMCP's default protection, since a
+    locally-bound server is the case DNS-rebinding protection is meant for.
+    """
+    try:
+        params = inspect.signature(http_app).parameters
+    except (TypeError, ValueError):
+        return {}
+    allowed = os.environ.get("ASTRO_MCP_ALLOWED_HOSTS", "").strip()
+    if allowed and "allowed_hosts" in params:
+        return {"allowed_hosts": [h.strip() for h in allowed.split(",") if h.strip()]}
+    if "host_origin_protection" in params:
+        return {"host_origin_protection": False}
+    return {}
+
 
 try:
     from airflow.plugins_manager import AirflowPlugin
@@ -66,7 +102,9 @@ try:
     # Get the native MCP protocol ASGI app from FastMCP
     # Use stateless_http=True so sessions aren't stored in-memory,
     # which is required for multi-replica deployments (e.g., Astro)
-    mcp_protocol_app = mcp.http_app(path="/", stateless_http=True)
+    mcp_protocol_app = mcp.http_app(
+        path="/", stateless_http=True, **_host_guard_kwargs(mcp.http_app)
+    )
 
     # Wrap in a FastAPI app with the MCP app's lifespan
     # This is required for FastMCP to initialize its task group
@@ -170,7 +208,9 @@ if _airflow_major == 2 and not fastapi_apps_config:
             return f"http://localhost:{_plugin_port_v2}{_get_base_path()}"
 
         # ASGI app — same as the AF3 path but we call it from Flask
-        _mcp_asgi_app = mcp.http_app(path="/", stateless_http=True)
+        _mcp_asgi_app = mcp.http_app(
+            path="/", stateless_http=True, **_host_guard_kwargs(mcp.http_app)
+        )
 
         # --- Lazy init: event loop + ASGI lifespan ---
         # FastMCP needs a running lifespan to initialize its task group.

--- a/astro-airflow-mcp/tests/test_plugin.py
+++ b/astro-airflow-mcp/tests/test_plugin.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from astro_airflow_mcp.plugin import _host_guard_kwargs
+
 
 def test_plugin_import():
     """Test that the plugin can be imported."""
@@ -97,36 +99,15 @@ def test_plugin_mutual_exclusivity():
 
 
 def test_host_guard_kwargs_disables_by_default(monkeypatch):
-    """With no env override, the host guard is disabled on FastMCP >= 3.4.3."""
+    """With no env override, the host guard is disabled (delegated to the ingress)."""
     monkeypatch.delenv("ASTRO_MCP_ALLOWED_HOSTS", raising=False)
-    from astro_airflow_mcp.plugin import _host_guard_kwargs
-
-    def http_app(path=None, stateless_http=False, host_origin_protection=True, allowed_hosts=None):
-        pass
-
-    assert _host_guard_kwargs(http_app) == {"host_origin_protection": False}
+    assert _host_guard_kwargs() == {"host_origin_protection": False}
 
 
 def test_host_guard_kwargs_allowlist_from_env(monkeypatch):
     """ASTRO_MCP_ALLOWED_HOSTS keeps the guard on with an explicit allowlist."""
     monkeypatch.setenv("ASTRO_MCP_ALLOWED_HOSTS", "a.example.com, b.example.com ,")
-    from astro_airflow_mcp.plugin import _host_guard_kwargs
-
-    def http_app(path=None, stateless_http=False, host_origin_protection=True, allowed_hosts=None):
-        pass
-
-    assert _host_guard_kwargs(http_app) == {"allowed_hosts": ["a.example.com", "b.example.com"]}
-
-
-def test_host_guard_kwargs_noop_on_old_fastmcp(monkeypatch):
-    """Older FastMCP without the guard kwargs gets no extra kwargs (no crash)."""
-    monkeypatch.delenv("ASTRO_MCP_ALLOWED_HOSTS", raising=False)
-    from astro_airflow_mcp.plugin import _host_guard_kwargs
-
-    def http_app(path=None, stateless_http=False):
-        pass
-
-    assert _host_guard_kwargs(http_app) == {}
+    assert _host_guard_kwargs() == {"allowed_hosts": ["a.example.com", "b.example.com"]}
 
 
 def test_auth_contextvars_isolated_per_context():

--- a/astro-airflow-mcp/tests/test_plugin.py
+++ b/astro-airflow-mcp/tests/test_plugin.py
@@ -96,6 +96,39 @@ def test_plugin_mutual_exclusivity():
         assert AirflowMCPPlugin.flask_blueprints == []
 
 
+def test_host_guard_kwargs_disables_by_default(monkeypatch):
+    """With no env override, the host guard is disabled on FastMCP >= 3.4.3."""
+    monkeypatch.delenv("ASTRO_MCP_ALLOWED_HOSTS", raising=False)
+    from astro_airflow_mcp.plugin import _host_guard_kwargs
+
+    def http_app(path=None, stateless_http=False, host_origin_protection=True, allowed_hosts=None):
+        pass
+
+    assert _host_guard_kwargs(http_app) == {"host_origin_protection": False}
+
+
+def test_host_guard_kwargs_allowlist_from_env(monkeypatch):
+    """ASTRO_MCP_ALLOWED_HOSTS keeps the guard on with an explicit allowlist."""
+    monkeypatch.setenv("ASTRO_MCP_ALLOWED_HOSTS", "a.example.com, b.example.com ,")
+    from astro_airflow_mcp.plugin import _host_guard_kwargs
+
+    def http_app(path=None, stateless_http=False, host_origin_protection=True, allowed_hosts=None):
+        pass
+
+    assert _host_guard_kwargs(http_app) == {"allowed_hosts": ["a.example.com", "b.example.com"]}
+
+
+def test_host_guard_kwargs_noop_on_old_fastmcp(monkeypatch):
+    """Older FastMCP without the guard kwargs gets no extra kwargs (no crash)."""
+    monkeypatch.delenv("ASTRO_MCP_ALLOWED_HOSTS", raising=False)
+    from astro_airflow_mcp.plugin import _host_guard_kwargs
+
+    def http_app(path=None, stateless_http=False):
+        pass
+
+    assert _host_guard_kwargs(http_app) == {}
+
+
 def test_auth_contextvars_isolated_per_context():
     """Per-request auth ContextVars must not leak across request contexts.
 

--- a/astro-airflow-mcp/tests/test_plugin.py
+++ b/astro-airflow-mcp/tests/test_plugin.py
@@ -98,16 +98,25 @@ def test_plugin_mutual_exclusivity():
         assert AirflowMCPPlugin.flask_blueprints == []
 
 
-def test_host_guard_kwargs_disables_by_default(monkeypatch):
-    """With no env override, the host guard is disabled (delegated to the ingress)."""
+def test_host_guard_kwargs_scopes_to_deployment_host(monkeypatch):
+    """On Astro the guard stays enabled, scoped to the webserver base-URL hostname."""
     monkeypatch.delenv("ASTRO_MCP_ALLOWED_HOSTS", raising=False)
-    assert _host_guard_kwargs() == {"host_origin_protection": False}
+    monkeypatch.setenv("AIRFLOW__WEBSERVER__BASE_URL", "https://dep.d1.astronomer.run/dabc1234")
+    assert _host_guard_kwargs() == {"allowed_hosts": ["dep.d1.astronomer.run"]}
 
 
-def test_host_guard_kwargs_allowlist_from_env(monkeypatch):
-    """ASTRO_MCP_ALLOWED_HOSTS keeps the guard on with an explicit allowlist."""
+def test_host_guard_kwargs_env_override_wins(monkeypatch):
+    """ASTRO_MCP_ALLOWED_HOSTS overrides the derived Deployment host."""
+    monkeypatch.setenv("AIRFLOW__WEBSERVER__BASE_URL", "https://dep.d1.astronomer.run/dabc1234")
     monkeypatch.setenv("ASTRO_MCP_ALLOWED_HOSTS", "a.example.com, b.example.com ,")
     assert _host_guard_kwargs() == {"allowed_hosts": ["a.example.com", "b.example.com"]}
+
+
+def test_host_guard_kwargs_falls_back_when_no_host(monkeypatch):
+    """With no override and no base URL, delegate host validation downstream."""
+    monkeypatch.delenv("ASTRO_MCP_ALLOWED_HOSTS", raising=False)
+    monkeypatch.delenv("AIRFLOW__WEBSERVER__BASE_URL", raising=False)
+    assert _host_guard_kwargs() == {"host_origin_protection": False}
 
 
 def test_auth_contextvars_isolated_per_context():


### PR DESCRIPTION
## Summary

FastMCP 3.4.3 added `HostOriginGuardMiddleware`, enabled by default: it only accepts loopback `Host` headers (`127.0.0.1`/`localhost`/`::1`) plus the ASGI `scope["server"]` host, and returns `421 Misdirected Request` for anything else.

In plugin mode the MCP app is embedded in the Airflow webserver and reached over the Deployment's own hostname, so with an unpinned install that resolves fastmcp 3.4.3, every `/mcp/v1/` request is rejected with `421`. (The AF2 Flask bridge also builds the ASGI scope with no `server` key, so the scope-server fallback doesn't apply.)

This keeps the guard enabled but scoped to the Deployment's hostname, restoring `/mcp/v1/` to a normal `200` MCP handshake. Standalone/local mode is untouched.

## What changed

- `plugin.py`: both `mcp.http_app()` calls (AF3 FastAPI + AF2 Flask) keep `HostOriginGuardMiddleware` **enabled**, scoped to the Deployment hostname derived from `AIRFLOW__WEBSERVER__BASE_URL` (an env var, so present at import — Airflow's `conf` isn't yet). Falls back to `host_origin_protection=False` only when no hostname is derivable (non-Astro embeddings).
- `ASTRO_MCP_ALLOWED_HOSTS` (comma-separated) overrides the derived allowlist — custom domains or extra hosts.
- Pin `fastmcp>=3.4.3,<4`: the kwargs only exist from 3.4.3, and the upper bound stops the next default-behaviour change from silently breaking installs.

## Design rationale

- **Scope the guard vs. disable it:** keeping the guard on preserves DNS-rebinding protection. `base_url` is Astro's canonical hostname source — both the deployment ingress route (Host preserved, no authority rewrite) and the auth-proxy's `changeOrigin` converge on that same per-deployment hostname — so scoping to it matches the `Host` that actually arrives, and it auto-tracks any future hostname change rather than going stale.
- **Custom domains / other Host values:** handled by `ASTRO_MCP_ALLOWED_HOSTS`; the disable-fallback covers non-Astro embeddings where no hostname is known.
- **Scope:** only the embedded/plugin path changes. Standalone (`__main__.py`, `mcp.run`) keeps FastMCP's loopback default, since a locally-bound server is what DNS-rebinding protection is for.

## Interim workaround (no plugin upgrade needed)

Pin `fastmcp<3.4.3` in the Astro project's `requirements.txt` and redeploy.
