### PR TITLE
Add skill: migrating-dagster-to-airflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,19 @@ jobs:
         working-directory: skills/analyzing-data/scripts
         run: uv run --extra test pytest tests/ --ignore=tests/integration -v
 
+  dagster-migration-tests:
+    name: migrating-dagster-to-airflow script tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.3.0
+
+      - name: Run unit tests
+        working-directory: skills/migrating-dagster-to-airflow/scripts
+        run: uv run --extra test pytest tests/ -q
+
   integration-test:
     name: Integration tests
     runs-on: ubuntu-latest

--- a/skills/migrating-dagster-to-airflow/SKILL.md
+++ b/skills/migrating-dagster-to-airflow/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: migrating-dagster-to-airflow
+description: Guide for migrating Dagster projects to Apache Airflow 3 on Astro. Use when the user mentions migrating, converting, or porting Dagster (or Dagster+) code to Airflow or Astro, wants to plan or assess such a migration, or asks what a Dagster construct maps to in Airflow. Covers assets, partitions, schedules, sensors, declarative automation, resources, IO managers, ops/jobs, dbt, Pipes, Components, and Dagster+ platform config. Always load this skill as the first step for any Dagster-to-Airflow request.
+hooks:
+  PostToolUse:
+    - matcher: "Edit"
+      hooks:
+        - type: command
+          command: "echo 'Migrated DAG edited: consider re-running gates 1-3: python3 scripts/validate_dag.py <astro_project> --manifest manifest.json'"
+---
+
+# Dagster → Airflow 3 (Astro) migration
+
+Migrate a Dagster project to Airflow 3 on Astro Runtime, honestly. The migration is asset-first (Dagster asset graphs translate to Airflow assets and asset-aware schedules, not flattened DAGs), incremental (domain by domain, Dagster stays authoritative until parity), and honest (every definition gets an explicit disposition; semantic deltas are documented, never papered over).
+
+First time driving this? Read `reference/quickstart.md` first: hour-one commands, the glossary, and what can and cannot break.
+
+## Migration at a glance
+
+1. Baseline the source project's tests, then inventory it read-only (`scripts/inventory.py` → manifest).
+2. Review classifications (MECH/JUDG/REDESIGN/NONE per `reference/mapping.md`); make the go/no-go call (three outcomes; migrate-with-conditions is the common case, stay is the narrow one); plan DAG boundaries, per-edge IO decisions, and Gate 3 expectations into the manifest.
+3. Trial-migrate 2-3 representative units end-to-end through every validation gate.
+4. Migrate domain by domain through the six-gate ladder (`reference/validation.md`), tracking per-unit state (`scripts/status.py`); fix failure classes via `reference/troubleshooting.md`, never stub.
+5. Map the platform layer (secrets, alerts, CI/CD, Deployments) per `reference/astro-deployment.md`.
+6. Run side by side, then cut over per domain (consumers unpause first; see the checklist), keeping rollback one step away.
+7. Deliver the migration report: every definition dispositioned, an equivalence row per trigger, losses stated plainly.
+
+## Version drift
+
+Verified against Airflow 3.3.0 / Astro Runtime 3.3-2 / astronomer-cosmos 1.15 / Dagster 1.13 (2026-07). Version-sensitive rows in the references carry their floor (notably the 3.2-vs-3.3 partition surface). Before relying on a version-gated claim: check the target (`airflow version`, `astro deployment inspect`), probe imports for sdk surface (`python3 -c "from airflow.sdk import X"`), and prefer `--help` / API spec discovery over assuming verbatim CLI/REST contracts on newer versions. Playbook entries are version-scoped per entry.
+
+## Requirements
+
+- Target **Astro Runtime 3.3+** (Airflow 3.3+); the native asset-partition surface requires it. Below 3.2 the mapping degrades badly; say so and recommend upgrading before migrating.
+- The Dagster repo, and ideally a running Dagster instance (its materialization metadata provides parity-test fixtures).
+- `astro` CLI for the target project.
+
+## Hard rules
+
+1. **Never stub.** A translated unit either works through its validation gate or is deferred with a written reason. Fake-success bodies and workaround code with long justifying comments are failures.
+2. **No silent omissions.** Every record in the inventory manifest ends `complete` or `deferred (reason)`. `scripts/status.py summary` exits nonzero otherwise; run it before claiming done.
+3. **Equivalence rows for every trigger.** Each schedule/sensor/automation condition gets a report row: source spelling, target spelling, delta in one sentence. Semantic deltas exist (catchup, on_cron inversion, eager guarantees); the sin is not the delta, it is the undocumented delta.
+4. **Fix classes, not instances.** When a translation pattern fails validation, fix the pattern (and record it in `reference/troubleshooting.md`), then re-apply; do not hand-patch one unit.
+5. **Do not invent APIs.** The references contain verified names only. Anything not covered there gets verified against official docs before use.
+
+## Workflow
+
+### Phase 0: Preflight
+
+Confirm target Runtime version, `astro` CLI presence, and repo access. Detect the project layout: classic (`@repository`/`workspace.yaml`), modern (`Definitions`), or Components (`pyproject.toml [tool.dg]`, `defs.yaml` files); all three occur, sometimes together. Baseline the source project's test suite now: pre-existing failures are recorded and excluded from migration blame.
+
+### Phase 1: Inventory (read-only)
+
+```
+python3 scripts/inventory.py <dagster_repo> --out manifest.json          # static scan
+python3 scripts/inventory.py <dagster_repo> --runtime --out manifest.json # + runtime introspection when the project imports
+```
+
+The manifest lists every definition with file:line, captured params, current-vs-deprecated spelling, and dependency edges with their IO manager; every record starts `classification: "pending"`. Classifying is YOUR first judgment task: assign each record MECH / JUDG / REDESIGN / NONE from its row in `reference/mapping.md` and write it into the manifest. The scanner enumerates (deterministic completeness); the agent classifies (judgment). A record you cannot map to a mapping.md row is itself a finding: record it, do not guess. Also grep for `DAGSTER_CLOUD_` and `EnvVar(` (platform layer, Phase 5).
+
+Manifest conventions: the canonical manifest lives in the migration run directory. Once the Astro project exists (Phase 2 scaffold), copy the manifest to its `include/inventory/manifest.json` so the Gate 3 pytest and `status.py` defaults find it; until then it just stays in the run dir (keep the two in sync afterward, the run-dir copy wins). Static records are the canonical migration units; runtime-mode enrichment merges into them, and only genuinely runtime-only definitions (factory-generated) become new units.
+
+Emit the migration report skeleton now: one section per manifest record, plus the secrets/env naming map from `reference/astro-deployment.md`. Scale the skeleton to the project: a secretless local project gets a one-line "no secrets/platform layer" note, not empty boilerplate sections.
+
+### Phase 1.5: Go/no-go (the honest gate)
+
+Before translating anything, answer the project-level question the inventory makes answerable: **what does this team give up by migrating, and does each loss have an acceptable answer?** Assess the NONE and REDESIGN rows against what is load-bearing for THIS team, evaluating the mitigation, not just the loss:
+
+| If load-bearing | The Airflow-world answer | Stay-signal only if |
+|---|---|---|
+| dbt rebuild-on-code-change (`code_version_changed()`) | State-aware dbt builds on a cron (Fusion / dbt State skip unchanged models per run, so the post-deploy tick rebuilds exactly what changed), and/or CI-triggered `dbt build` on merge (PR-gated, often an upgrade) | The team can neither run a state-aware dbt stack nor dbt from CI |
+| Freshness driving materialization | Astro Observe freshness SLAs / Timeliness alerts + scheduled runs sized to the SLA | Freshness-triggered compute is genuinely irreplaceable by schedule+alerting |
+| Per-asset cost accounting (Insights) | Astro Observe pipeline-level warehouse cost management; per-asset granularity is lost | Per-ASSET chargeback is a contractual/organizational requirement |
+| Asset catalog / column-level lineage as daily tools | Airflow 3 asset views + OpenLineage/Astro lineage (asset-level) | Column-level lineage is embedded in daily workflows with no external catalog |
+| Deep AutomationCondition compositions, `can_subset`, selective per-partition materialization | Most decompose to cron/asset schedules (see `reference/automation.md`); the residue is redesigned per domain | Multiple domains depend on compositions that decompose to nothing |
+| Sensor cursor transactionality, run-scoped teardown | Idempotent consumers + `max_active_runs`; context managers in task bodies | Exactly-once event coalescing is a correctness requirement that idempotency cannot absorb |
+
+One rule the table implies, stated plainly: **no dbt-only condition reaches "stay."** Between Cosmos, state-aware dbt builds, and CI-triggered builds, every dbt-workflow loss has an accepted-practice mitigation (execution-proven in this skill's eval program, including on a real warehouse); dbt items are conditions to record, never blockers. The observability rows (per-asset cost, column-level lineage) are separate conditions and are evaluated on their own, even for dbt-heavy teams.
+
+The gate's outcome is three-valued, and the middle one is the common case:
+
+- **Migrate**: no stay-signals; proceed to Phase 2.
+- **Migrate with conditions** (most real projects): losses exist, mitigations are named and accepted in writing in the report's first section, specific domains may carry REDESIGN work; proceed to Phase 2 with those conditions recorded.
+- **Stay on Dagster, today**: reserved for the case where MULTIPLE stay-signal conditions in the right column genuinely hold at once and the migration is not externally mandated. Then the honest deliverable is that recommendation, in writing, with the specific unmitigated losses named, and the run stops there. A migration guide that cannot say "don't" cannot be trusted when it says "do", but "don't" is earned by unmitigatable losses, not by the mere existence of deltas.
+
+### Phase 2: Plan
+
+- **DAG boundaries**: decide which asset-dependency edges become asset-aware schedules (cross-DAG) vs task ordering (intra-DAG). Group by domain/schedule cadence/team ownership; `define_asset_job` selections usually name the natural domains.
+- **Per-edge IO decisions** via the tree in `reference/io-and-data-passing.md` (fuse / explicit storage / XCom).
+- **Order**: leaf domains first, dependency order after; the platform layer last.
+- **Fill each planned unit's target expectations into the manifest**: `dag_id`, `task_count`, `edges`, `schedule`, `asset_outlets` per unit. Gate 3 asserts against exactly these fields; a unit without them is skipped by validation, so an unenriched manifest means Gate 3 checks nothing (validate_dag reports skipped counts loudly, do not ignore them).
+- Scaffold the target: `astro dev init`, shared helpers under `include/`. House conventions the scaffold imposes (e.g. a test demanding `retries >= 2`) do NOT override source fidelity: source behavior wins; convention adoption is a post-cutover improvement listed in the report, and the scaffold test gets skipped with an explicit reason.
+
+### Phase 3: Trial
+
+Migrate 2-3 representative units end-to-end through every gate before fanning out. Pick one MECH asset, one partitioned asset, one JUDG case, or the nearest available mix (small projects may have no partitioned or no MECH assets; pick one full path through a real DAG instead). What the trial teaches goes into `reference/troubleshooting.md` before scaling; if the trial fails structurally, stop and rework the plan, not the units.
+
+### Phase 4: Migrate, domain by domain
+
+Per unit, the state machine (tracked in the manifest):
+
+```
+pending → translate → fix-import → fix-lint → fix-tests → verify-parity → complete
+                                    ↘ deferred (reason required)
+```
+
+- Translate using the reference file for the construct (routing table below). Rich context beats cleverness: read the source unit, its mapping rows, and a nearby already-migrated example.
+- Validate through the gates: `python3 scripts/validate_dag.py <astro_project> --manifest manifest.json` (gates 1-3), then execution and parity per `reference/validation.md`.
+- On gate failure, retry with the latest validator output in context (cap ~10 attempts, then defer with the failure class).
+- Advance state only on gate pass: `python3 scripts/status.py advance <unit-id> ...`. A wrong disposition is corrected with `status.py reopen <unit-id> --reason ...`. The no-hand-editing rule applies to the STATE field (`status`) only; the PLAN fields (`dag_id`, `task_count`, `edges`, `schedule`, `asset_outlets`, `target`) are the planner's to write in Phase 2.
+- Units that deliberately translate to NO DAG of their own (helpers absorbed into tasks, policies that became alerts, resources that became connections) are dispositioned `complete` with `target: "none"` and evidence naming where they went; Gate 3 skips them by design.
+- Commit per unit, atomically.
+
+### Phase 5: Platform layer
+
+`reference/astro-deployment.md`: Deployments topology, secrets/connection naming map, CI/CD and preview Deployments, alert-policy mapping, Observe/lineage expectations, the `DAGSTER_CLOUD_*` in-code rewrite checklist.
+
+### Phase 6: Side-by-side and cutover
+
+Dagster remains authoritative. Run migrated DAGs shadowed/paused; compare outputs over the same logical window (row counts + checksums; recompute expected values from the Dagster-produced output itself, using recorded materialization metadata only opportunistically, per `reference/validation.md` Gate 5). Flip schedules one domain per change window: pause the Dagster schedule, unpause the Airflow DAG; rollback is the reverse. Keep Dagster readable after cutover (run history does not migrate).
+
+### Phase 7: Final report
+
+`scripts/status.py summary` must pass. The report contains: the go/no-go assessment (Phase 1.5) and its rationale, disposition table for every definition, all equivalence rows, the NONE/REDESIGN losses stated plainly (lineage depth, code_version triggers, Insights cost accounting, sensor cursor transactionality), the secrets map, and the deferred list with reasons. Spot-check ten `complete` claims before delivering it.
+
+## Reference routing
+
+| Construct encountered | Read |
+|---|---|
+| First hour, glossary, what can break | `reference/quickstart.md` |
+| Anything (first stop: one row per construct) | `reference/mapping.md` |
+| Asset-key → URI convention, translation granularity, external/observable assets | `reference/assets.md` |
+| Asset deps, IO managers, XCom, storage decisions | `reference/io-and-data-passing.md` |
+| Any `partitions_def`, partition mappings, backfills | `reference/partitions.md` |
+| Schedules, sensors, AutomationCondition, freshness | `reference/automation.md` |
+| `@dbt_assets`, translators, dbt Cloud | `reference/dbt.md` |
+| Components (defs.yaml), custom Component subclasses, dynamic generation | `reference/components.md` |
+| dagster_cloud.yaml, secrets, alerts, CI/CD, cutover | `reference/astro-deployment.md` |
+| Gates, parity testing, state machine | `reference/validation.md` |
+| Failure classes seen before | `reference/troubleshooting.md` |
+
+## Scripts
+
+| Script | Purpose |
+|---|---|
+| `scripts/inventory.py` | Scan the Dagster repo → JSON manifest (static + optional runtime mode) |
+| `scripts/validate_dag.py` | Gates 1-3 against the generated Astro project |
+| `scripts/status.py` | Per-unit state machine + completeness gate |

--- a/skills/migrating-dagster-to-airflow/reference/assets.md
+++ b/skills/migrating-dagster-to-airflow/reference/assets.md
@@ -1,0 +1,55 @@
+# Assets: keys, URIs, and translation granularity
+
+> **STATUS: reviewed; URI convention runtime-verified in testing.**
+
+## The URI convention (the one rule everything depends on)
+
+Dagster identifies assets by key (a list of parts, e.g. `["snowflake", "core", "comments"]`). Airflow identifies assets by URI string. Every generated outlet, every asset-aware schedule, every Gate 3 assertion, and every equivalence row must agree on ONE deterministic mapping, implemented once:
+
+```python
+# include/asset_uris.py
+def asset_uri(*key_parts: str) -> str:
+    """The canonical Airflow Asset URI for a Dagster asset key. One implementation, imported everywhere."""
+    return "dagster://assets/" + "/".join(key_parts)
+```
+
+The fixed `assets` authority segment is deliberate: Airflow normalizes host-only URIs by appending a trailing slash (`Asset("dagster://foo").uri == "dagster://foo/"`, testing runtime probe), so single-part keys without the segment silently mismatch every Gate 3 assertion and `schedule=[Asset(...)]` comparison. With the authority segment, every URI has a path and round-trips unchanged.
+
+Rules:
+
+1. **Prefer the physical URI when the asset has one authoritative physical target** and the Dagster project already thought of it that way: `s3://bucket/prefix/...` for object-store assets, `snowflake://db/schema/table` for warehouse tables. Physical URIs make lineage and external-event wiring natural.
+2. **Otherwise use the logical scheme** `dagster://<key-parts-joined-by-slash>`, preserving the full Dagster key including `key_prefix`. Never invent shortened names; key collisions after prefix-stripping are silent.
+3. **Pick 1 or 2 per project, once, during Phase 2 planning, and record it in the migration report.** Mixed conventions are allowed across assets (warehouse tables physical, everything else logical) but a single asset must have exactly one URI everywhere it appears.
+4. The inventory manifest stores the computed URI per asset; Gate 3 asserts against the manifest, so the convention is enforced mechanically after that point.
+5. Asset **names**: Airflow assets also have a name; use the terminal key part. URIs must be RFC-3986-ish opaque strings (no globs); avoid characters needing escaping.
+
+dbt models: Cosmos emits its own Asset URIs per model. When Python assets depend on dbt models cross-DAG, resolve the URI Cosmos actually emits (inspect one rendered DAG) rather than assuming this convention; record the dbt-side URI form in the report. See `dbt.md`.
+
+## Translation granularity (asset → what, exactly?)
+
+Decision order for each asset group/domain:
+
+1. **Domain DAG** (default): a group of assets that share a schedule and ownership becomes one DAG; each asset is a task with an explicit `Asset` outlet. Intra-domain deps are task ordering; cross-domain deps are asset-aware schedules.
+2. **Standalone `@asset` DAG**: an asset that is independently scheduled and consumed in multiple places. The `airflow.sdk` `@asset` decorator (auto DAG + single task + outlet) is the closest structural analog.
+3. **Fused into a consumer task**: pipeline-internal intermediates per the decision tree in `io-and-data-passing.md`.
+
+The real-world pattern that forces the choice: `define_asset_job(selection=...)` selections usually name the natural domain DAGs; overlapping selections need the dedup rules in `automation.md`.
+
+## Per-construct notes
+
+| Construct | Translation | Notes |
+|---|---|---|
+| `@asset` | Task with outlet, or standalone `@asset` DAG | Granularity above |
+| `@multi_asset(specs=...)`, `can_subset=False` | `@asset.multi` or one task with multiple outlets | MECH |
+| `@multi_asset(can_subset=True)` | Split or redesign | See mapping.md; `context.selected_asset_keys` has no analog |
+| `@graph_asset` | TaskGroup whose final task carries the outlet | Data passing between the inner ops follows `io-and-data-passing.md` |
+| External assets (bare `AssetSpec`) | `Asset` object updated by `POST /api/v2/assets/events` or an `AssetWatcher` | The external producer must be given the new endpoint + the URI from this convention |
+| Observable source assets | `AssetWatcher` (event source) or a small polling DAG emitting the asset event | The observation FUNCTION (arbitrary Python computing a DataVersion: file hash, LastModified) must be PORTED into the watcher/polling DAG; only the materialization compute is absent |
+| `SourceAsset` (deprecated spelling) | Same as external assets | Scanner catches the old spelling |
+| `MaterializeResult` metadata | `yield Metadata(self, {...})` on the outlet event | Consumers read `inlet_events[...][-1].extra` |
+| `kinds` / `tags` / `owners` / `group_name` | DAG tags + `doc_md`; group becomes the domain DAG name | Cosmetic unless something schedules on it; check before dropping |
+| `code_version` / `data_version` | No equivalent; document the loss | mapping.md section 2 |
+
+## Metadata and lineage expectations
+
+Airflow asset events carry `extra` dicts and `Metadata`; Astro lineage is OpenLineage-based and works at task/dataset level. Dagster's column-level lineage and catalog views do not carry over; per-asset descriptions land in `doc_md`. State this in the migration report once, project-wide, rather than per asset.

--- a/skills/migrating-dagster-to-airflow/reference/astro-deployment.md
+++ b/skills/migrating-dagster-to-airflow/reference/astro-deployment.md
@@ -1,0 +1,115 @@
+# Platform: Dagster+ / OSS instance → Astro
+
+> **STATUS: reviewed; hardened in testing** (dagster-open-platform platform layer).
+
+Everything outside the DAG code: topology, config, secrets, CI/CD, alerting, observability, and the cutover itself.
+
+## Topology
+
+| Dagster+ | Astro | Class | Notes |
+|---|---|---|---|
+| Organization / full deployment (prod, staging) | Workspace + one Deployment per env | JUDG | |
+| Code location (in `dagster_cloud.yaml` `locations`) | Usually one Astro project per code location; small/coupled locations can merge into one project | JUDG | Team ownership and dependency isolation drive the call |
+| `agent_queue` routing (e.g. EU location on EU agents) | Separate Astro Deployment in the right region | JUDG | Data-residency boundaries become Deployment boundaries; each has its own image registry |
+| Serverless | Astro hosted | JUDG | |
+| Hybrid agent (K8s/ECS/Docker) | Astro hosted, or dedicated/hybrid options | JUDG | Most Hybrid users migrate to hosted; keep network access requirements in view |
+| Private-network sources reachable only from the agent (VPN/Tailscale hostnames, VPC-internal DBs) | Explicit reachability plan per connection | JUDG | Invisible in code until the first run fails (verified in testing). For every Connection in the secrets map ask: reachable from Astro's workers? Answer decides hosted vs dedicated/VPC peering, and gates Gate 4 for entire ingest domains |
+
+## `dagster_cloud.yaml` → Astro project
+
+Per location: `code_source` (package/module/file) has no Airflow equivalent, DAG files in `dags/` are the unit; `build.directory`/`registry` and `image` map to the Astro project `Dockerfile` and Astro's managed image build (`astro deploy` builds and pushes); `working_directory`/`executable_path` disappear (the Runtime image defines the environment); `container_context` is where the real content lives:
+
+| `container_context` key | Astro | Class |
+|---|---|---|
+| `k8s.env_vars` | Deployment environment variables (UI/API/`astro deployment variable`) | MECH |
+| `k8s.env_secrets` (named K8s secrets) | Astro Environment secrets (secret env vars) and/or Airflow Connections | JUDG |
+| `k8s.namespace`, `service_account_name`, `server_k8s_config`, `run_k8s_config` | Managed by Astro; per-task pod tweaks via `executor_config`/`pod_override` | JUDG |
+| `ecs.*` (task roles, subnets, security groups) | Astro workload identity / cloud connection config | JUDG |
+
+**Secrets naming map.** Build this table during inventory and fill the right column deliberately; nothing does it automatically:
+
+| Dagster reference | Kind | Astro target |
+|---|---|---|
+| `EnvVar("SNOWFLAKE_PASSWORD")` | resource credential | Airflow Connection `snowflake_default` (password field) |
+| `env_secrets: [cloud-ops-slack-token]` | K8s secret NAME (not an env var) | The secret object's KEYS are the env-var names, and they are not in dagster_cloud.yaml; inspect the cluster (`kubectl get secret cloud-ops-slack-token -o yaml`) to enumerate them, then map each key to an Astro secret env var or Connection |
+| `os.getenv(...)` at definition load | plain env var | Deployment env var (note: load-time in Dagster, parse-time in Airflow) |
+
+Snowflake specifics (verified in testing): key-pair auth wires via the Connection's `extra.private_key_file` pointing at a gitignored mounted key (never `private_key_content` in a committed file), and dbt-snowflake's profile takes `private_key_path`; pin `session_parameters` (TIMEZONE, TIMESTAMP_TYPE_MAPPING) on the Connection to match the Dagster resource's session, because window predicates can silently change meaning under different mappings (see `io-and-data-passing.md`).
+
+Rule of thumb: anything a provider Hook can consume becomes a Connection (typed, per-Deployment, testable); everything else becomes a Deployment env var, secret-flagged when sensitive.
+
+## CI/CD and branch deployments
+
+Dagster+ branch deployments (ephemeral per-PR deployments) map to **Astro preview Deployments**: per-branch ephemeral Deployments created/deleted by CI, mirroring a base Deployment's config. The `astronomer/deploy-action` GitHub Action ships sub-actions for the full lifecycle (create on branch create, deploy on push, delete on branch delete, deploy to base on merge). Templates: astronomer.io/docs/astro/ci-cd-templates/github-actions-deployment-preview.
+
+| Dagster+ | Astro | Class |
+|---|---|---|
+| `dg plus deploy` / `dagster-cloud ci` pipeline | `astro deploy` in CI (deploy-action or plain CLI) | MECH |
+| Branch deployment per PR | Preview Deployment per branch | JUDG |
+| Change Tracking on branch deployments | PR diff + preview Deployment testing; no direct asset-diff feature | NONE (document) |
+| `DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT`, `DAGSTER_CLOUD_PULL_REQUEST_ID` **referenced in code** | Rewrite against env vars you set on preview Deployments in CI | JUDG |
+
+That last row is a code-migration task, not a platform task: grep the repo for `DAGSTER_CLOUD_` before claiming the platform layer is done. Real projects do exactly this (PR-numbered database clones in the dbt translator; see `dbt.md`).
+
+## Alerting
+
+Dagster+ alert policies map onto Astro alerts (UI-configured, no DAG code) plus Airflow-level callbacks for in-code reactions. Real deployments usually configure alerts in the Dagster+ UI with NOTHING in the repo (verified in testing): the migration plan needs an export-at-cutover step (pull live alert policies via the UI/API) rather than assuming an `alert_policies` YAML exists. Likewise, verify each `dagster_cloud.yaml` code location's module actually exists in the repo you're migrating; mirrors and partial checkouts lie.
+
+| Dagster+ `event_types` | Astro alert type | Class |
+|---|---|---|
+| `JOB_FAILURE` / `JOB_SUCCESS` | DAG Failure / DAG Success | MECH |
+| `JOB_LONG_RUNNING` | DAG Duration / Task Duration | MECH |
+| `ASSET_MATERIALIZATION_FAILURE`, `ASSET_CHECK_*` | Task Failure on the translated task/check task | JUDG |
+| `ASSET_FRESHNESS_PASS/WARN/FAIL` | DAG Timeliness alert and/or Astro Observe freshness SLA | JUDG |
+| `TICK_FAILURE` | No direct analog (scheduler-level); Deployment Health | NONE (document) |
+| `AGENT_UNAVAILABLE`, `CODE_LOCATION_ERROR` | Deployment Health (preview) / not applicable on hosted | JUDG |
+| `INSIGHTS_CONSUMPTION_EXCEEDED` | No direct analog | NONE |
+
+Channels line up: email/slack/pagerduty/microsoft_teams on both sides; Astro adds Opsgenie and DAG Trigger (fire a DAG via REST on alert), which can replace simple `@run_failure_sensor` remediation patterns.
+
+## Observability: Insights and the asset catalog
+
+- **Dagster+ Insights** (cost, credits, per-asset compute, freshness pass rate) → **Astro Observe** (GA): SLA dashboards for freshness/timeliness, data products (asset compositions with inferred dependencies), predictive alerting, pipeline health overview. Freshness/timeliness/health coverage is good. Cost accounting: Astro Observe ships Snowflake Cost Management (pipeline-level warehouse spend); there is no per-asset credit accounting like Insights' credits view. State the difference at that granularity in the report.
+- **Asset catalog + column-level lineage** → Airflow 3 asset views + Astro's OpenLineage-based lineage (enable per Deployment). Column-level lineage parity is partial; this is a documented loss (map section 12).
+- Run/materialization **history is not migrated**. Keep the Dagster instance readable during the grace period; export anything contractually needed (materialization metadata is also the parity-test fixture source, see `validation.md`).
+
+## OSS `dagster.yaml` → Airflow/Astro settings
+
+| `dagster.yaml` | Target | Class |
+|---|---|---|
+| `run_coordinator.QueuedRunCoordinator.max_concurrent_runs` | Deployment-level concurrency + per-DAG `max_active_runs` | JUDG |
+| `tag_concurrency_limits` | Airflow Pools on the translated tasks | JUDG |
+| `concurrency.pools` (`pool=` on ops/assets) | Airflow Pools (same name, set slot counts) | MECH |
+| `run_retries {enabled, max_retries}` | `default_args={"retries": n}` in shared DAG defaults | MECH |
+| `run_monitoring` | Astro Deployment health + alerts | JUDG |
+| `compute_logs` (S3/GCS managers) | Astro task logs (managed) | MECH |
+| `storage` (postgres/mysql) | Managed by Astro (metadata DB is Astro's) | MECH |
+| `retention.*` | Airflow DB cleanup policies / Astro defaults | JUDG |
+
+## Preflight for Dagster+ hybrid shops (do this before planning the platform layer)
+
+These four items gate cutover for hybrid deployments and are invisible in the repo code; they were day-one blockers in the at-scale eval. Each is a written answer, not a mental note:
+
+1. **Network reachability, per connection**: for every Connection in the secrets map, can Astro's workers reach it (VPN/Tailscale hostnames, VPC-internal DBs)? The answer decides hosted vs dedicated/VPC peering and gates execution for entire ingest domains.
+2. **Export Dagster+ UI-only config**: alert policies, and any connections/variables configured in the UI, exist NOWHERE in the repo. Pull them via the Dagster+ UI/API now; map them with the alert table below.
+3. **Verify every `dagster_cloud.yaml` code location's module actually exists** in the repo you were handed; mirrors and partial checkouts lie.
+4. **Enumerate K8s secret KEYS**: `env_secrets` names secret objects, not env vars; `kubectl get secret <name> -o yaml` per secret to build the real naming map.
+
+## Cutover: the 10-step methodology, adapted for a Dagster source
+
+Astronomer's Airflow-migration methodology (Prepare → metadata → code → cutover) adapts, with one honest caveat: **Starship does not apply to the Dagster leg.** It moves Airflow-to-Airflow metadata; Dagster has no Airflow metadata to move. The translation work upstream of this checklist is the whole skill.
+
+1. Freeze new pipeline development on Dagster (freeze-old/build-new).
+2. Create Workspace + Deployments (per env, per region) on Astro.
+3. `astro dev init` the project(s); wire CI/CD (`astro deploy`, preview Deployments).
+4. Build the secrets/connection naming map; create Connections + env vars per Deployment.
+5. Migrate code domain-by-domain per the skill workflow (SKILL.md), validating each unit through the ladder in `validation.md`.
+6. Run side-by-side: Dagster remains authoritative; Airflow DAGs run paused-or-shadowed until parity per domain.
+7. Configure Astro alerts (+ Observe SLAs) from the alert-policy map above.
+8. Flip schedules per domain (order rehearsal-verified, testing): unpause the Airflow CONSUMERS first, then the producer, then pause the Dagster schedule/sensor. Missed asset events never replay, so a consumer unpaused after its producer already ran has permanently skipped that event. Unpausing fires immediately: cron DAGs run the last missed tick (usually wanted); partition timetables run the CURRENT partition, which on a live domain is the in-progress window and yields PARTIAL data: time the flip just after a window closes, or pause-and-clear and backfill the completed window (unpause before backfilling; a paused DAG queues backfill runs forever). NEVER let both orchestrators run a single-writer-store domain concurrently: file-lock exclusion does NOT propagate across a Docker bind mount (host Dagster and containerized Airflow both got RW on the same DuckDB in the rehearsal), so an overlap corrupts with zero warning; the 1-slot pool protects within Airflow only. One domain per change window; rollback is the reverse (re-pause Airflow, unpause Dagster). "Shadow" running requires a separate storage prefix; with shared storage there is no shadow mode, only paused-until-flip.
+9. Decommission Dagster compute per domain once its parity window passes; keep the instance readable.
+10. After the last domain: export residual Dagster metadata, archive the repo, end the grace period.
+
+## Env var migration checklist
+
+Grep targets before declaring the platform layer done: `DAGSTER_CLOUD_` (all of them, especially `IS_BRANCH_DEPLOYMENT`, `PULL_REQUEST_ID`, `DEPLOYMENT_NAME`), `DAGSTER_DEPLOYMENT` (the OSS env-switch convention), `EnvVar(`, `env_secrets`, `os.getenv` inside `defs/`, and the **Insights code-level symbols**: `with_insights`, `InsightsBigQueryResource`, `InsightsSnowflakeResource`, `dagster_insights`. Insights is not platform-only config: those calls live in asset code and will import-error on Astro; strip them (their replacement is Astro Observe / OpenLineage at the platform layer, not an in-code call). Each hit gets a row in the secrets/env map with its Astro replacement, or an explicit "dead after migration" mark.

--- a/skills/migrating-dagster-to-airflow/reference/automation.md
+++ b/skills/migrating-dagster-to-airflow/reference/automation.md
@@ -1,0 +1,104 @@
+# Automation: schedules, sensors, declarative automation
+
+> **STATUS: reviewed; hardened through testing** (catchup run-storm, on_cron inversion, eager OR/partitioned-guard, sensor partitioned-trap, logical_date fallback applied).
+
+This is the semantic minefield of the migration: most automation constructs have an Airflow spelling that LOOKS equivalent and fires at different times. Every mapping here must produce an equivalence row in the migration report (rubric dimension 4): source trigger, target trigger, and the delta in one reviewable sentence.
+
+## Cron schedules
+
+`ScheduleDefinition(cron_schedule=..., execution_timezone=...)` → DAG `schedule` + timezone. Mechanical EXCEPT catchup:
+
+| Source | `catchup` | Why |
+|---|---|---|
+| Non-partitioned Dagster schedule | `False` | Dagster never catches up missed ticks for plain schedules; Airflow 3's default (`False`) matches, but set it explicitly |
+| Partitioned-job schedule (`build_schedule_from_partitioned_job`) | `True`, BUT check `start_date` first | Dagster fills missed partitions; without catchup the migrated DAG silently skips gaps. With an old `start_date` (e.g. 2020) `catchup=True` schedules every missed tick at unpause, a run storm in the tens of thousands. For old start dates: `catchup=False` + an explicit bounded backfill, documented in the equivalence row |
+
+Getting this wrong produces either a burst of surprise historical runs or silently missing partitions. The equivalence row must state which behavior was preserved.
+
+`@schedule` functions computing `RunRequest(run_config=...)` per tick: Airflow schedules cannot compute config. Translate to DAG `params` with defaults plus a leading task that computes and pushes the derived values (or templating when the computation is date arithmetic). Tag JUDG; diff the computed configs for a sample of ticks during validation. Date arithmetic in that leading task must use `dag_run.logical_date or dag_run.run_after`: `logical_date` is None on manually triggered runs (verified in testing), and a computed-config task that assumes it crashes exactly when a human triggers the DAG by hand.
+
+Legacy spellings to normalize first: `@hourly_schedule`/`@daily_schedule`/etc. decorators, `schedule_definition` kwargs on old jobs.
+
+## Declarative automation: decompose, then map
+
+Real projects rarely use bare `eager()`. Decompose every `AutomationCondition` expression into operators and map each:
+
+| Operator | Airflow target | Class |
+|---|---|---|
+| `cron_tick_passed(x) & ~in_progress()` (the dominant idiom in the wild) | Plain cron DAG + `max_active_runs=1` | MECH |
+| `cron_tick_passed(x)` | Cron schedule | MECH |
+| `on_cron(x)` on an asset with NO deps | Cron schedule (the dep-wait clause is vacuous) | MECH (check deps before routing on_cron to REDESIGN; the inversion below only bites when deps exist) |
+| `~in_progress()` | `max_active_runs=1` | MECH |
+| `any_deps_updated()` | Asset-aware schedule on deps | JUDG (success-only updates) |
+| `missing()` / `newly_missing()` | First-run semantics; no repeated-trigger analog | JUDG (note: `on_missing()` does not exist; `newly_missing()` is the real operator) |
+| `in_latest_time_window()` | Latest-window guard in task logic | JUDG |
+| `code_version_changed()` | Cron + state-aware dbt builds (Fusion / dbt State): each run rebuilds only changed models, skipping the rest | JUDG (latency is cadence-bounded, not deploy-triggered; state-aware stack is beta-era, verify versions; see `dbt.md`) |
+| `any_deps_match(...)`, `.allow()`, `.ignore()` | Per-dep scoping has no schedule analog | REDESIGN |
+| `.since()`, `.newly_true()`, custom compositions | Manual review | REDESIGN |
+
+Do NOT route an expression to REDESIGN before decomposing: `cron_tick_passed & ~in_progress` looks like a "complex composition" and is actually the easiest case in this file.
+
+### `eager()`
+
+`AutomationCondition.eager()` ≈ "materialize when any dep updates," and a bare asset-aware schedule approximates it while dropping four guarantees. Dagster's eager will NOT fire when:
+
+1. any upstream partition is missing,
+2. any upstream is currently in progress,
+3. the asset itself is in progress,
+4. outside the latest time window (partitioned assets).
+
+A bare asset-aware schedule fires anyway. Recoverable pieces: (3) is `max_active_runs=1`; (2) can be approximated with a leading guard task that checks upstream DAG states.
+
+Two splits matter for the default translation:
+
+- **Multi-dep assets: use the OR composition `schedule=(a | b | ...)`, not the list form.** A bracketed list `schedule=[a, b]` means ALL-updated (AND) and under-fires relative to eager, which triggers on ANY newly updated dep. Reserve the list form for assets whose automation genuinely required all deps; state the AND/OR choice in the equivalence row. One measured delta (verified in testing): `AssetAny` fires once PER EVENT, so an upstream that materializes twice in quick succession triggers two downstream runs, where a coalescing cursor sensor or eager's since-last-handled would fire once. `max_active_runs=1` bounds the concurrency but not the run count; note it in the row.
+- **Partitioned eager assets: guarantee (4) is load-bearing, keep it.** Without the latest-time-window restriction, every upstream update re-materializes old partitions (a behavior change and a cost blowup, and partitioned-eager is a common real-world pattern). Add a latest-window guard in the task or scope the trigger to the latest partition. For non-partitioned assets, (1) and (4) are generally not worth simulating.
+
+Default translation: OR-composed asset schedule + `max_active_runs=1` (+ latest-window guard when partitioned), with the remaining deltas stated in the equivalence row.
+
+### `on_cron()`: inverted, do not map naively
+
+`on_cron(cron)` = after the cron tick, wait until ALL deps have updated since that tick, then run once (AND, time-gates-data). `AssetOrTimeSchedule` = run on the tick OR on any asset update (OR). A naive swap fires early and often. Options, in preference order:
+
+1. **Cron DAG + leading dep-freshness guard**: schedule on the cron; first task checks (via `inlet_events` timestamps or `GET /api/v2/assets/events`) that every upstream updated since the previous tick, and defers/retries until true (deferrable sensor with timeout). Closest semantics; costs a guard task per DAG.
+2. **`PartitionedAssetTimetable` with a mapper carrying `wait_policy=WaitForAll`** (wait policies attach to the MAPPER, e.g. `RollupMapper(..., wait_policy=WaitForAll())`, not the timetable) when both sides are time-partitioned on compatible cadences: the wait policy IS the all-deps gate. Cleanest when it applies.
+3. **Accept `AssetOrTimeSchedule` with a documented delta** when the deps update reliably more often than the cron anyway and early fires are harmless. The report must say the AND became an OR.
+
+## Sensors
+
+Classify by SEMANTICS, not decorator. Scanner heuristic from real projects: a plain `@sensor` whose body fetches materialization events for multiple assets and combines them through a cursor is a hand-rolled multi-asset sensor; translate it as a boolean asset schedule (MECH), not as generic-sensor REDESIGN. Second heuristic: a `@sensor` that gates purely on wall-clock (checks the day/hour and fires) is a schedule wearing a sensor decorator; translate it as a cron DAG (MECH).
+
+**CRITICAL partitioned-upstream trap (verified in testing):** when ANY upstream asset is partitioned, a plain boolean asset schedule (`schedule=[a, b]` or `(a & b)`) on a non-partition-aware consumer NEVER triggers: Airflow 3.3's asset manager drops partition-stamped events for non-partitioned consumers, with no error anywhere. The correct translation is `PartitionedAssetTimetable(assets=(a & b), ...)` even when the consumer itself looks unpartitioned. Check the upstreams' partitioning BEFORE choosing the schedule form, and behaviorally verify the trigger (see `validation.md` Gate 4).
+
+| Pattern | Target | Class |
+|---|---|---|
+| Fires on materialization(s), no other logic | Boolean asset schedule (`schedule=[a]`, `(a & b)`, `(a \| b)`); partitioned upstream → `PartitionedAssetTimetable` (see trap above) | MECH |
+| Polls an external condition (file, API, queue) | Deferrable sensor / `@task.sensor(poke_interval=, timeout=, mode="reschedule")` returning `PokeReturnValue`; or `AssetWatcher` + `MessageQueueTrigger` when the source is one of the six supported queues | JUDG |
+| Cursor state | Airflow `Variable` (or XCom within one DAG); document that Dagster's per-evaluation cursor transactionality is lost | JUDG |
+| Metadata filtering, computed `run_config`, cross-job triggering | Asset schedule + guard/config task, or full redesign | REDESIGN |
+| `@run_status_sensor` / `@run_failure_sensor` | DAG/task callbacks for in-code reactions; Astro alerts for notifications (no DAG code needed) | JUDG |
+| `AddDynamicPartitionsRequest` from a sensor | Runtime partition emission or external asset events; see `partitions.md` | JUDG |
+
+Queue-backed sensors deserve special attention: if the Dagster sensor polls SQS/Kafka/Pub/Sub/Service Bus/IBM MQ/Redis, the Airflow version is BETTER than the original (event-driven `AssetWatcher`, no poll loop). Flag these as upgrade opportunities, not just translations.
+
+## Freshness
+
+Two Dagster APIs share one class name; disambiguate by call form before mapping:
+
+- `FreshnessPolicy.time_window(fail_window=, warn_window=)` / `.cron(...)` (classmethods): the current policy API.
+- `FreshnessPolicy(maximum_lag_minutes=...)` OR `FreshnessPolicy(cron_schedule=...)` (plain kwargs on the class, not classmethods) = `LegacyFreshnessPolicy` semantics. Both legacy signals matter; keying only on `maximum_lag_minutes` misclassifies legacy cron-form policies.
+- Builder trio `build_last_update_freshness_checks` / `build_time_partition_freshness_checks` / `build_sensor_for_freshness_checks`: superseded but common.
+
+ALL of them route to the observability layer: Astro **DAG Timeliness** alerts (UI-configured, no DAG code) and/or `DeadlineAlert` (3.1+, experimental; `DAGRUN_QUEUED_AT`, `AVERAGE_RUNTIME`, `FIXED_DATETIME` references). **Never translate freshness to a downstream check task**: it would be gated on the asset's success and cannot fire in exactly the stale/failed case freshness exists to catch. Two deltas to document: Dagster freshness is asset-scoped while deadline alerts are DAG-run-scoped (per-asset freshness on a multi-asset DAG needs per-asset alerts or DAG splitting), and warn/fail dual thresholds map to two alerts or one alert plus duration.
+
+Legacy `AutoMaterializePolicy.eager()/.lazy()` and `auto_materialize_policy=`: normalize to the equivalent `AutomationCondition` first (eager → eager; lazy → freshness-driven, route to observability), then map with this file.
+
+## Operational: unpausing fires immediately
+
+Unpausing a migrated DAG is not neutral (verified in testing): a cron DAG runs its last missed tick, and a partition-timetable DAG runs the CURRENT partition, the moment it is unpaused. For cron DAGs the immediate run is usually the run you wanted. For partitioned domains it is usually NOT: the current partition is the in-progress window, so the first post-flip run materializes PARTIAL data on a live project (rehearsal finding). Time the flip just after a window closes, or pause-and-clear the first run and backfill the last completed window instead. The cutover checklist in `astro-deployment.md` carries the full flip order.
+
+## Validation
+
+- Every trigger gets an equivalence row: source spelling, target spelling, delta sentence. Zero undocumented deltas is the rubric gate.
+- Simulate a week: for cron schedules, enumerate tick times in both systems (respecting timezone + catchup) and diff. For asset-driven triggers, replay a recorded day of Dagster materialization events and check which DAGs would have fired.
+- For on_cron translation option 1, test the guard's timeout path: what happens when a dep never updates (Dagster: silently waits; the guard must fail loudly or skip cleanly per the report's stated choice).

--- a/skills/migrating-dagster-to-airflow/reference/components.md
+++ b/skills/migrating-dagster-to-airflow/reference/components.md
@@ -1,0 +1,45 @@
+# Components and dynamic definition generation
+
+> **STATUS: reviewed; validated against dagster-open-platform in testing.**
+
+Components-based projects (`pyproject.toml [tool.dg]`, `defs.yaml` instance files, `src/<pkg>/defs/` autoload) are the current Dagster project shape and half of real-world code. The migration question per component instance is always the same: **is this a library component configured by YAML, or a custom `Component` subclass whose `build_defs` is a program?**
+
+## Library component instances (JUDG)
+
+A `defs.yaml` whose `type:` points at a shipped component (`DbtProjectComponent`, `SlingReplicationCollectionComponent`, ...) is configuration for a known generator. Do not migrate the YAML; migrate what it generates:
+
+1. Identify the component type and read its `attributes:` (the YAML is the inventory).
+2. Route to the integration's own mapping: dbt components → `dbt.md`, sling/dlt/fivetran/airbyte → the integration rows in `mapping.md` section 10.
+3. The YAML's config values (project paths, connection names, selectors, cron strings in attributes) carry over into the translated DAG's config.
+
+Also catch the preview-era filename `component.yaml` (same treatment).
+
+## Custom `Component` subclasses (REDESIGN)
+
+Real projects subclass `Component` (or an integration's workspace class) and override `build_defs`. These are PROGRAMS that generate definitions at load time. From real projects:
+
+- `FivetranComponent`: fetches the connector list from the LIVE Fivetran API at definition-load time, applies per-connector automation conditions from a YAML cron map, overrides `_sync_and_poll` to skip-but-succeed when Fivetran reschedules a sync, and registers a separate connection-test job + schedule.
+- `ProdDbReplicationsComponent`: fans out `@sling_assets` per shard from `shard_*.yaml` config files.
+
+Porting rule: **port the OUTPUT of `build_defs`, not the class.**
+
+1. **Snapshot to a static manifest.** Run the component in the source project (or call its discovery path) once at migration time and record what it generated: the concrete asset list, per-item schedules/conditions, connector ids. Airflow DAG parsing must not call live APIs; dynamic discovery becomes a committed manifest file plus a documented refresh procedure (regenerate the manifest, re-render the DAGs, PR the diff).
+2. **Translate the generated definitions normally** using the manifest: each generated asset/schedule/sensor goes through the same mapping as hand-written ones.
+3. **Port the embedded business logic explicitly.** Overridden methods (like skip-on-reschedule polling) are invisible in the generated definitions; read the subclass body. They usually become custom operator subclasses or `@task` wrappers around the provider hook, and they are exactly the code a provider operator does NOT give you. List each override in the migration report.
+4. **Config-file fan-out** (per-shard YAML) maps well to Airflow: keep the config files, render one task (or dynamic-mapped task) per entry at parse time from the LOCAL files (local file reads at parse time are fine; network calls are not).
+
+## Env-branched definitions
+
+Real projects branch their `Definitions` at import time on environment variables (one module returns the dbt-CLI wiring or the dbt-Cloud wiring depending on env). Treat these like a two-branch component: the scanner emits records for both branches flagged with the condition; the plan migrates the branch the target deployment actually runs and dispositions the other as a recorded alternate (with what re-activating it would take). Never let the un-taken branch vanish silently.
+
+## Blocked-at-source inputs
+
+Some component/integration domains cannot generate their input artifacts in the migration environment (a dbt manifest whose models are stripped from the mirror, a Fivetran discovery call needing live credentials). The pattern (verified in testing): ship COMPLETE translated code in a `deferred/` directory with an activation runbook (the exact commands that produce the missing artifact and move the code live), record a partial manifest with a `blocked_at_source` flag and reason, and include a refresh script so the activation is mechanical. A blocked domain with complete deferred code and a runbook is a `deferred` disposition, not a failure; a stub pretending the artifact exists is.
+
+Also flag load-time coupling: helpers like `get_asset_key_for_model(...)` called in OTHER domains couple their definition loading to the dbt manifest; a blocked dbt domain then cascades. The scanner surfaces these (`dbt_manifest_coupling`); plan migration order around them.
+
+## Scanner notes
+
+- `component_instance` records in the inventory manifest carry the `type:` and attributes; classify library types JUDG and unknown/custom types REDESIGN.
+- Custom subclasses live outside `defs/` (a `lib/` or `components/` package); inventory the class file too, since `build_defs` bodies contain schedules and jobs the YAML never shows.
+- `AutomationConditionSensorDefinition` registered by components: the sensor the Dagster daemon evaluates (~every 30s) to drive declarative automation; it does not migrate (Airflow's scheduler plays that role). Its existence just confirms the project used declarative automation; map the conditions themselves per `automation.md`.

--- a/skills/migrating-dagster-to-airflow/reference/dbt.md
+++ b/skills/migrating-dagster-to-airflow/reference/dbt.md
@@ -1,0 +1,492 @@
+> **STATUS: reviewed; runtime-verified in testing** (Cosmos 1.15 / Airflow 3.3).
+
+# dagster-dbt → Cosmos migration reference
+
+Bottom line for the go/no-go gate: **dbt is never, by itself, a reason to stay on Dagster.** Every dbt-workflow loss in this file has an accepted-practice mitigation; record the deltas and proceed. (Per-model cost/column-lineage observability is assessed separately in the gate; see SKILL.md Phase 1.5.)
+
+Your Dagster dbt integration (`@dbt_assets`, `DbtProject`, `DbtCliResource`, a
+`DagsterDbtTranslator` subclass) becomes an Astronomer **Cosmos** `DbtDag` or
+`DbtTaskGroup`. Cosmos parses your dbt `manifest.json` and renders one Airflow
+task per model (plus test tasks), so the *shape* of the graph carries over
+cleanly. What does NOT carry over is everything your translator computed in
+Python: group names, custom asset keys, per-model automation conditions, and
+branch-deployment database swaps. Those are the hard parts.
+
+Target: Airflow 3.x on Astro Runtime, `astronomer-cosmos` >= 1.15. Verify every
+Cosmos symbol against [the Cosmos docs](https://astronomer.github.io/astronomer-cosmos)
+before shipping generated code.
+
+## Quick map
+
+| Dagster | Cosmos / Airflow 3 | Class | Where covered |
+|---|---|---|---|
+| `@dbt_assets` + `DbtProject` + `DbtCliResource` | `DbtDag` or `DbtTaskGroup` + `ProjectConfig`/`ExecutionConfig` | JUDG | below |
+| dbt target switched by env var | `ProfileConfig` per Astro Deployment | JUDG | below |
+| `DagsterDbtTranslator.get_asset_key` / group / metadata | `RenderConfig(node_converters=...)` or accept Cosmos defaults | JUDG | below |
+| per-model `automation_condition` on `code_version_changed()` | cron + state-aware dbt builds (Fusion / dbt State) | JUDG | below |
+| branch-deploy DB name in translator code | `ProfileConfig` targets + rewrite the Python | JUDG | below |
+| `enable_asset_checks=True` (dbt tests as checks) | `RenderConfig(test_behavior=...)` | MECH | below |
+| `.with_insights()` / Insights resources | strip (import-error on Astro); Astro Insights is UI-only | NONE | below |
+| `.fetch_column_metadata()` / `.fetch_row_counts()` | OpenLineage / Astro lineage | JUDG | below |
+| `DbtConfig` + run-tag warehouse swap on backfill | DAG `Params` + backfill `ProfileConfig`/`profile_args` | JUDG | below |
+| `build_dbt_asset_selection` / `select=`/`exclude=` | `RenderConfig(select=[...], exclude=[...])` (comma=AND, space=OR) | JUDG | below |
+| Python `@asset` up/downstream of dbt | cross-DAG asset schedule, or task in the same DAG | JUDG | below |
+| `partitions_def` on `@dbt_assets` | partitioned dbt DAG; see `partitions.md` | JUDG | below |
+| `dagster_dbt.cloud_v2` (dbt Cloud) | `apache-airflow-providers-dbt-cloud` (job trigger + sensor), NOT Cosmos | JUDG | below |
+
+## Core structure: `@dbt_assets` → `DbtDag` / `DbtTaskGroup` (JUDG)
+
+The simplest Dagster case (from `assets_dbt_python`):
+
+```python
+# BEFORE (Dagster)
+from dagster_dbt import DbtCliResource, dbt_assets
+from ..project import dbt_project
+
+@dbt_assets(manifest=dbt_project.manifest_path)
+def dbt_project_assets(context, dbt: DbtCliResource):
+    yield from dbt.cli(["build"], context=context).stream()
+```
+
+```python
+# AFTER (Cosmos, one standalone dbt DAG)
+from cosmos import DbtDag, ProjectConfig, ProfileConfig, ExecutionConfig, RenderConfig
+from cosmos.constants import ExecutionMode, TestBehavior
+from pendulum import datetime
+
+dbt_project_assets = DbtDag(
+    dag_id="dbt_project_assets",
+    project_config=ProjectConfig("/usr/local/airflow/dags/dbt/my_project"),
+    profile_config=profile_config,                      # see ProfileConfig below
+    execution_config=ExecutionConfig(execution_mode=ExecutionMode.LOCAL),
+    render_config=RenderConfig(test_behavior=TestBehavior.AFTER_EACH),
+    schedule="@daily",
+    start_date=datetime(2024, 1, 1),
+    catchup=False,
+)
+```
+
+Use `DbtDag` when the dbt project is its own schedulable unit; use
+`DbtTaskGroup` when dbt is one stage inside a larger DAG with non-dbt tasks (the
+Python-assets case below). `dbt.cli(["build"])` maps to `test_behavior`, not a
+separate command. `DbtProject(project_dir=..., target=...)` splits into
+`ProjectConfig` (project dir / manifest) and `ProfileConfig` (the target);
+`DbtCliResource` disappears because Cosmos invokes dbt itself.
+
+Source-side gotcha for the baseline: a project using
+`DbtProject(...).prepare_if_dev()` needs `DAGSTER_IS_DEV_CLI=1` set (or a
+pre-generated dbt manifest via `dbt parse`) for ANY source-side command,
+including `dagster definitions validate` in the Phase 0 baseline. Without it the
+project fails with a manifest.json-not-found ImportError. `validation.md` owns the
+full baseline fix; this is the dbt-specific reason it happens.
+
+## Assembling requirements.txt (do this BEFORE the first image build)
+
+Translating the source's deps naively (the MECH `pyproject.toml` ->
+`requirements.txt` mapping) produces a **broken image** on current Runtime. Known
+class, hit in testing: `dbt-core` pins `mashumaro<3.15`, which cannot run on
+Runtime 3.3's Python 3.14, so dbt cannot even parse and both DAGs fail at DagBag
+import. The fix is an explicit override, `mashumaro>=3.16` (3.17 worked), in
+`requirements.txt`. dbt-on-Astro dependency sets need the playbook's version-check
+before you build the image; see the dbt dependency entry in
+`reference/troubleshooting.md` rather than guessing pins here. At minimum: do not
+treat the dbt requirements translation as mechanical, and run the playbook check
+before the first `astro dev start`.
+
+## ProfileConfig per environment (JUDG)
+
+Dagster projects switch dbt targets with an env var read at definition time.
+In a real example, `get_dbt_target()` returns `prod` / `branch_deployment` / `dev` /
+`personal` based on `DAGSTER_CLOUD_*` env vars, and `DbtProject(target=...)`
+picks the matching block in one shared `profiles.yml`.
+
+```python
+# BEFORE (Dagster): one profiles.yml, target chosen at runtime
+DbtProject(project_dir=..., target=get_dbt_target())   # "prod" | "branch_deployment" | ...
+```
+
+Airflow does NOT switch targets at parse time per run. The clean mapping is one
+Astro **Deployment per environment**, each pinning its own `ProfileConfig`. Two
+options:
+
+```python
+# Option A: reuse the existing profiles.yml, pick target by env var per Deployment
+profile_config = ProfileConfig(
+    profile_name="my_project",
+    target_name=os.environ["DBT_TARGET"],   # set per Astro Deployment
+    profiles_yml_filepath="/usr/local/airflow/dags/dbt/my_project/profiles.yml",
+)
+
+# Option B: map the warehouse onto an Airflow Connection (no profiles.yml)
+from cosmos.profiles import SnowflakeUserPasswordProfileMapping
+profile_config = ProfileConfig(
+    profile_name="my_project", target_name="prod",
+    profile_mapping=SnowflakeUserPasswordProfileMapping(
+        conn_id="snowflake_default", profile_args={"database": "PURINA", "schema": "analytics"},
+    ),
+)
+```
+
+Prefer Option A when the dbt repo already has a working `profiles.yml` (least
+churn). Prefer Option B to consolidate secrets into Airflow Connections. The
+per-`target` database/schema differences become per-Deployment Connection or
+`profile_args` differences.
+
+Not every dbt target is a Deployment. One real project's `get_dbt_target()` returns a
+fourth target, `personal`, a developer-laptop schema with no cloud counterpart.
+"One Deployment per environment" silently drops it. Map local/developer targets
+to `astro dev start` running against a local `profiles.yml` target, NOT a
+Deployment. Enumerate every value the target function can return and confirm each
+maps to either a Deployment or the local dev flow; a target that maps to neither
+is a gap to call out in the migration report.
+
+## Custom translator porting (JUDG)
+
+A `DagsterDbtTranslator` subclass is Python that runs while Dagster builds the
+asset graph. One real project's `CustomDagsterDbtTranslator` computes, per model:
+
+- **group name** from the dbt `fqn` path (snapshots → `"snapshots"`, else the directory path)
+- **asset key** as `[database, schema, name]`, or a custom key from `meta.dagster.asset_key`
+- **metadata**: a Snowflake Data Explorer URL
+- **automation condition** (covered separately below)
+
+Cosmos does not run your translator. Port each piece to its Cosmos equivalent, or
+accept a Cosmos default and record the loss:
+
+| Translator logic | Cosmos equivalent |
+|---|---|
+| group name from fqn | Airflow task grouping is by dbt folder already; custom grouping needs `RenderConfig(node_converters=...)` or dbt `+group` config. Often drop it |
+| asset key `[db, schema, name]` | Cosmos emits Airflow `Asset` URIs from model names; a custom key scheme means custom `node_converters`. Pick ONE URI convention and apply it everywhere (see `assets.md`) |
+| metadata URL | task `doc_md`, or drop |
+| `meta.dagster.asset_key` overrides | move the override into dbt `meta` and read it in a `node_converter`, or normalize keys in dbt |
+
+Do not try to reproduce a translator subclass one-to-one. Decide per project
+whether custom keys/groups are load-bearing (something downstream schedules on
+them) or cosmetic (UI only). Cosmetic ones get dropped in the migration report;
+load-bearing ones need `node_converters` and must be verified against the Cosmos
+docs, whose `node_converters` API is more limited than a Dagster translator.
+
+## Per-model automation conditions → cron + state-aware builds (JUDG)
+
+This is the sharpest edge. A real project's translator sets, per model:
+
+```python
+# BEFORE (Dagster): automation hangs on code_version_changed()
+asset_is_new_or_updated = ~AutomationCondition.in_progress() & (
+    AutomationCondition.code_version_changed() | AutomationCondition.missing()
+)
+# dwh_reporting models also add: | AutomationCondition.any_deps_updated()
+```
+
+`code_version_changed()` fires a rebuild when a model's compiled SQL changes.
+Airflow has no per-model code-change TRIGGER, but the dbt ecosystem now covers
+the effect from the other direction: **state-aware dbt builds** (the dbt Fusion
+engine's state-aware orchestration, and dbt State, which also works with dbt
+Core) rebuild only models whose code fingerprint or upstream data changed and
+skip the rest as "Reused". Cosmos supports the Fusion engine since 1.11
+(`ExecutionMode.LOCAL`). So the translation is a cron cadence whose runs are cheap
+because unchanged models skip:
+
+```python
+# AFTER: cron cadence + state-aware skipping; the run after a deploy rebuilds
+# exactly the changed models. Latency = the cadence, so size it accordingly.
+DbtDag(..., schedule="0 * * * *", catchup=False)
+```
+
+Document TWO deltas in the equivalence row: (1) latency semantics: Dagster
+rebuilds at deploy time (push); this rebuilds on the next tick (cadence-bounded;
+tighten the cron since skips are near-free). (2) Maturity: Fusion is public-beta
+era with Snowflake/Databricks adapters first, Cosmos Fusion support is newer
+(LOCAL mode), and dbt State is in preview: verify the versions available to the
+target before promising this, and fall back to CI-triggered `dbt build` on merge
+(PR-gated, the standard non-Dagster pattern) plus a coarser cron when the
+state-aware stack is not available.
+
+The `~in_progress()` part maps to `max_active_runs=1` (MECH). The
+`any_deps_updated()` part on `dwh_reporting` maps to an asset-aware schedule
+(`schedule=[upstream_asset]`, JUDG, success-only). Flag every model whose only
+automation was `code_version_changed()` so the cadence choice is deliberate.
+See `automation.md`.
+
+## Branch-deployment DB swaps in translator code (JUDG)
+
+Branch-deploy logic often lives IN the translator/resource code, not just in
+platform config. The test projects:
+
+```python
+# BEFORE (Dagster): DB name computed from Dagster Cloud env vars, in Python
+PURINA_DATABASE_NAME = (
+    f"PURINA_CLONE_{os.environ['DAGSTER_CLOUD_PULL_REQUEST_ID']}"
+    if os.getenv("DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT") == "1" else "PURINA"
+)
+```
+
+You MUST find and rewrite these. `DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT` and
+`DAGSTER_CLOUD_PULL_REQUEST_ID` do not exist on Astro. The clean landing is the
+dbt `branch_deployment` target with its own database, selected by the preview
+Deployment's `ProfileConfig` (Option A above), so the clone-DB name lives in
+`profiles.yml`, not Python. Grep the whole repo for `DAGSTER_CLOUD_` before
+declaring the dbt migration done; these strings also appear in metadata URLs.
+
+## dbt tests: `enable_asset_checks` → `TestBehavior` (MECH)
+
+`DagsterDbtTranslatorSettings(enable_asset_checks=True)` surfaces dbt tests as
+Dagster asset checks. **Check the project's dagster-dbt version before assuming
+blocking semantics:** the default flipped to `True` in dagster-dbt 0.23.0
+(dbt-core >= 1.6). Older in-the-wild projects defaulted to `False`, where dbt
+tests were observations that did NOT block downstream. If the source project ran
+with the old default, a faithful migration uses `AFTER_ALL` or `NONE`, not the
+blocking `AFTER_EACH`. Cosmos runs the same tests natively; choose where via
+`RenderConfig(test_behavior=...)`:
+
+| `TestBehavior` | Behavior | Use when |
+|---|---|---|
+| `AFTER_EACH` (default) | test task right after each model; a failing test blocks that model's children | closest to Dagster blocking checks |
+| `AFTER_ALL` | one test task after the whole run | tests are cheap and you want one gate |
+| `BUILD` | uses `dbt build` (interleaves run + test per node) | mirrors `dbt build` semantics |
+| `NONE` | skip tests entirely | tests run elsewhere |
+
+`AFTER_EACH` is the faithful default: it reproduces blocking-check semantics (a
+failed test stops downstream models). `should_detach_multiple_parents_tests=True`
+(Cosmos >= 1.8.2) splits a test spanning multiple parents into a standalone task.
+`enable_source_tests_as_checks` in Dagster maps to source tests being rendered by
+Cosmos; verify source-test rendering in your Cosmos version.
+
+## Selectors: `build_dbt_asset_selection` / `select`/`exclude` → `RenderConfig` (JUDG)
+
+`@dbt_assets(select=..., exclude=...)` and `build_dbt_asset_selection(...)` map
+to `RenderConfig(select=[...], exclude=[...])`. **Do NOT naively split the
+Dagster string into a list.** dbt selector combination is delimiter-sensitive and
+the test projects relies on it:
+
+- **comma = intersection (AND)**: `"tag:a,tag:b"` selects models matching BOTH.
+- **space = union (OR)**: `"tag:a tag:b"` selects models matching EITHER.
+
+The test projects deliberately uses both: `select=",".join([...])` (intersection) and
+`exclude=" ".join([INCREMENTAL_SELECTOR, SNAPSHOT_SELECTOR])` (union). Cosmos
+joins the elements of a `RenderConfig` list with **spaces** (union) when it builds
+the dbt command, so each list element is one union term. That means:
+
+```python
+# BEFORE (Dagster): comma-joined = INTERSECTION; space-joined = UNION
+@dbt_assets(select="config.materialized:incremental,tag:nightly",   # AND
+            exclude="config.materialized:incremental resource_type:snapshot")  # OR
+
+# AFTER (Cosmos): keep an intersection INSIDE one element; split a union across elements
+RenderConfig(
+    select=["config.materialized:incremental,tag:nightly"],   # one comma element = AND preserved
+    exclude=["config.materialized:incremental", "resource_type:snapshot"],  # two elements = OR
+)
+```
+
+Splitting a comma-joined `select` into separate list elements silently converts
+an intersection into a union and BROADENS the selected set (a real correctness
+bug in the emitted DAG). Verify Cosmos' list-join behavior against your Cosmos
+version before trusting the union assumption above. Selector syntax otherwise
+carries over: `tag:`, `path:`, `config.materialized:`, `config.meta.<key>:`, and
+graph operators. The test projects splits its project into three `@dbt_assets`
+(non-partitioned, incremental/partitioned, snapshots); each becomes its own
+`DbtDag`/`DbtTaskGroup` with the matching select/exclude. Dagster `AssetSelection`
+DSL that resolves against the graph (`.downstream()`, `.upstream()`) has no Cosmos
+runtime analog: resolve those to concrete dbt selectors at migration time.
+
+## Streaming post-processors: strip Insights, reroute metadata (NONE / JUDG)
+
+The test projects dbt bodies end in a chain that has NO Cosmos equivalent:
+
+```python
+# BEFORE (Dagster): dagster_open_platform dbt/assets.py
+yield from (
+    dbt.cli(_dbt_args("build", config), context=context)
+    .stream()
+    .fetch_column_metadata()   # column schema into asset metadata
+    .fetch_row_counts()        # row counts into asset metadata
+    .with_insights()           # Dagster+ Insights (cost/usage) hook
+)
+```
+
+Cosmos runs dbt directly, so `.stream()` and every post-processor on it vanish.
+Handle each:
+
+- `.fetch_column_metadata()` / `.fetch_row_counts()` (JUDG): these enriched the
+  Dagster asset catalog. On Astro the equivalent is **OpenLineage / Astro
+  lineage** (column schema, row facets), enabled per Deployment, NOT a hand-rolled
+  metadata call. Accept the reframing; do not try to reproduce the exact metadata
+  keys.
+- `.with_insights()` and the `InsightsBigQueryResource` / `InsightsSnowflakeResource`
+  / `create_snowflake_insights_asset_and_schedule` symbols (NONE): these are
+  Dagster+ Insights, a code-level product API. They **import-error on Astro** and
+  MUST be stripped, not translated. Astro Insights is UI-configured, no code.
+
+These symbols are in the `astro-deployment.md` grep checklist (alongside
+`DAGSTER_CLOUD_`); a build that still imports `dagster_cloud.dagster_insights`
+will fail at parse time. Grep and remove before declaring the dbt migration done.
+
+## Config-driven backfill routing (JUDG)
+
+The test projects routes backfills to a different warehouse via run config and run tags,
+in Python:
+
+```python
+# BEFORE (Dagster): op Config + run-tag conditional warehouse swap
+class DbtConfig(dg.Config):
+    full_refresh: bool = False
+    backfill: bool = False
+
+# on a backfill run, inject --vars and point at a bigger warehouse + longer timeout
+vars_arg = {"backfill": True,
+            "backfill_snowflake_warehouse": "BACKFILL_WH",
+            "backfill_statement_timeout_seconds": 24 * 60 * 60}
+```
+
+Map the pieces:
+
+- `dg.Config` fields (`full_refresh`, `backfill`) → **DAG `Params`** (typed),
+  read in the task and passed through to dbt `--vars` via `operator_args`.
+- run-tag-conditional warehouse (`DBT_BACKFILL_RUN_TAG` → `BACKFILL_WH` + longer
+  `statement_timeout`) → a **backfill-specific `ProfileConfig`** (or a
+  `profile_args` override selected when the `backfill` param is set), so backfill
+  runs bind the larger warehouse and timeout. There is no run-tag-reads-warehouse
+  indirection in Airflow; the branch becomes an explicit param check that picks
+  the profile or `--vars`.
+
+Keep the `--vars backfill=True` injection: it drives dbt macro behavior in the
+project and must still reach dbt. Only the *routing* mechanism (tags/config)
+changes, not the dbt-side contract.
+
+## Python assets up/downstream of dbt (JUDG)
+
+A Python `@asset` that reads a dbt model (or feeds one) is a cross-boundary edge.
+Two translations:
+
+- **Same DAG**: `DbtTaskGroup` inside a DAG, with Python `@task`s wired before/
+  after it via `>>`. Best when the Python step is tightly coupled to this dbt run.
+- **Cross-DAG**: the dbt DAG emits an `Asset` on completion; the Python asset-DAG
+  uses `schedule=[that_asset]`. Best when they run on different cadences.
+
+### Cosmos asset emission is a RUNTIME event, not parse-time (verified, eval 1)
+
+Do NOT assume a rendered Cosmos DAG carries model outlets. On Cosmos 1.15 /
+Airflow 3.3, dbt task `outlets` are **empty at parse time**. Cosmos attaches an
+`AssetAlias` and registers the model assets **during execution** ("Assigning
+outlets with DatasetAlias in Airflow 3"). Two consequences the migrator must
+handle:
+
+- **Gate 3 outlet assertions must exempt dbt tasks.** Assert outlets on Python
+  tasks only; a parse-time / DagBag inspection sees nothing on Cosmos tasks. Do
+  not fail the gate on "missing" dbt outlets.
+- **Cross-DAG `schedule=[Asset(uri)]` on a dbt model only resolves after the
+  first run.** The alias materializes at execution, so the consuming DAG cannot
+  bind the asset until one run has emitted it, and the URI must be captured from a
+  RUN (run log), not from a rendered DAG.
+
+The verified runtime URI form for a dbt-duckdb model (captured from a real run):
+
+```
+duckdb:/usr/local/airflow/include/data/example.duckdb/example/dbt_schema/<model>
+```
+
+That is scheme + profile-path + database + schema + model. Note the `//` after
+the scheme **collapses in `Asset.uri`** (`duckdb:/...`) but is **kept in
+`Asset.name`** (`duckdb:///...`); wire cross-DAG consumers against the exact
+`.uri` form from a run, not a hand-derived string. Pin your own convention for
+Python-asset URIs (see `assets.md`); `get_asset_key_for_model(...)` lookups from
+the source resolve to whatever Cosmos runtime URI you standardize on.
+
+## Partitioned dbt assets (JUDG)
+
+A real project runs an incremental `@dbt_assets` with `partitions_def=` and passes
+`min_date`/`max_date` dbt vars derived from `context.partition_time_window`. In
+Cosmos, pass run-scoped `--vars` via `operator_args`, computed from
+`dag_run.partition_key`. The partition-key → window derivation is the shared-recipe
+problem in `partitions.md`: producer and every consumer must derive identical
+`min_date`/`max_date` from the key. Do not reinvent it here.
+
+Watch the `BackfillPolicy.single_run()` interaction. The test projects pairs it with
+partitions, and on a single-run backfill `context.partition_time_window` spans the
+**whole** requested range, not one partition, so `min_date`/`max_date` become one
+dbt invocation covering the entire range (the test projects also pads: `min_date` shifts
+back 3 hours, `max_date` forward 1 day). There is NO single-run backfill in Airflow (verified in testing). The equivalent is one MANUALLY TRIGGERED run
+with explicit range params (the task ignores `partition_key` and reads the params),
+feeding the full-range `(start, end)` into `--vars`. Reproduce the same padding in
+the window helper, or the backfill query bounds shift. Do NOT emit one dbt run per
+partition when the source used `single_run`; that changes the query semantics and
+the row set.
+
+## Execution modes on Astro (JUDG)
+
+`ExecutionConfig(execution_mode=...)`. `ExecutionMode.LOCAL` runs dbt in the
+Airflow worker: simplest, and the default on Astro when dbt deps fit the image.
+Use `VIRTUALENV` to isolate dbt's Python deps from Airflow's; use `KUBERNETES` /
+`DOCKER` (or cloud-run modes `AWS_EKS`, `AWS_ECS`, `GCP_CLOUD_RUN_JOB`,
+`AZURE_CONTAINER_INSTANCE`) to run each model in its own pod/container. Start
+with `LOCAL`; escalate only when dependency conflicts or isolation demand it.
+
+## dbt Cloud (`dagster_dbt.cloud_v2`) → dbt Cloud provider (JUDG)
+
+If the source runs dbt in **dbt Cloud** (the `dagster_dbt.cloud_v2` surface:
+`DbtCloudWorkspace`, `@dbt_cloud_assets` / `dbt_cloud_assets`,
+`load_dbt_cloud_asset_specs`, `build_dbt_cloud_polling_sensor`), the target is
+`apache-airflow-providers-dbt-cloud`, NOT Cosmos. Cosmos runs dbt itself; the dbt
+Cloud provider triggers a job that dbt Cloud runs.
+
+Job triggering and polling map cleanly (MECH-ish): a `DbtCloudWorkspace` job run
+becomes a `DbtCloudRunJobOperator`, and `build_dbt_cloud_polling_sensor` becomes
+`DbtCloudJobRunSensor`. Verify these names against the provider docs before
+emitting (the provider evolves: the old `DbtCloudJobRunAsyncSensor` was removed in
+favor of `DbtCloudJobRunSensor(deferrable=True)`).
+
+```python
+# AFTER: trigger a dbt Cloud job and wait, in one task (deferrable)
+from airflow.providers.dbt.cloud.operators.dbt import DbtCloudRunJobOperator
+
+run_dbt = DbtCloudRunJobOperator(
+    task_id="run_dbt_cloud_job",
+    dbt_cloud_conn_id="dbt_cloud_default",   # a Connection backed by DbtCloudHook
+    job_id=12345,
+    deferrable=True,                          # defers to the triggerer instead of polling a worker
+)
+# Discovery: confirm the current operator/sensor/hook names and args against
+# airflow.apache.org/docs/apache-airflow-providers-dbt-cloud/stable/operators.html
+# A standalone wait uses DbtCloudJobRunSensor(deferrable=True); DbtCloudHook is the connection type.
+```
+
+The hard loss is granularity. `load_dbt_cloud_asset_specs` gives Dagster one asset
+PER MODEL inside a Cloud job; the provider has **no per-model analog**. To Airflow,
+the models inside a Cloud job are invisible: a job run is one opaque task. So any
+cross-DAG wiring that keyed on an individual dbt model must instead key on the
+**JOB** (JUDG). A downstream DAG waits on the whole job's completion, not on a
+specific model. Document this granularity loss in the report; per-model lineage
+inside dbt Cloud does not survive.
+
+Env-branched CLI-vs-Cloud definitions are common (the cold-eval project selected
+dbt Cloud vs local dbt at import time on an env var, one `Definitions` with both
+branches). Migrate the branch the deployment **actually uses** (Cosmos for the CLI
+branch, this provider for the Cloud branch), and record the other branch as a
+dispositioned alternate in the manifest, not silently dropped. If both branches
+genuinely ship, they are two target shapes, so say which Deployment uses which.
+
+## Legacy spellings to catch
+
+The scanner must also flag pre-`@dbt_assets` code, common in older projects:
+
+- `load_assets_from_dbt_project(...)` and `load_assets_from_dbt_manifest(...)`
+  (superseded by `@dbt_assets`) → same Cosmos `DbtDag`/`DbtTaskGroup` target.
+- `dbt_cli_resource` (snake_case, legacy) → `DbtCliResource` is already gone in
+  the Cosmos model; both map to Cosmos invoking dbt directly.
+- `DbtManifestAssetSelection.build(...)` (real projects' schedules use it) → resolve to
+  concrete dbt selectors for `RenderConfig`.
+
+## What could not be verified
+
+- Cosmos `node_converters` is the stated hook for custom asset keys/groups, but
+  its exact API surface was not doc-confirmed in this pass; verify before emitting
+  `node_converters` code. It is materially less expressive than a Dagster translator.
+- `enable_source_tests_as_checks` → Cosmos source-test rendering parity not
+  doc-confirmed; verify per Cosmos version.
+- Cross-DAG wiring against dbt-model assets is now RUNTIME-verified (verified in testing): the
+  asset is emitted via `AssetAlias` at execution, URI form above. What remains
+  unconfirmed is `should_detach_multiple_parents_tests` (>=1.8.2); verify per
+  Cosmos version.
+
+Sources: [Cosmos configuration](https://astronomer.github.io/astronomer-cosmos/configuration/index.html), [RenderConfig select/exclude](https://astronomer.github.io/astronomer-cosmos/configuration/selecting-excluding.html), [ProfileConfig / profiles_yml_filepath](https://astronomer.github.io/astronomer-cosmos/profiles/index.html).

--- a/skills/migrating-dagster-to-airflow/reference/io-and-data-passing.md
+++ b/skills/migrating-dagster-to-airflow/reference/io-and-data-passing.md
@@ -1,0 +1,117 @@
+# IO managers and data passing
+
+> **STATUS: reviewed; hardened through testing** (predicate-lift, key_format identity, and single-writer findings applied).
+
+The central hard problem of this migration direction. Dagster IO managers persist every asset/op output implicitly and load every input on demand; Airflow tasks share nothing unless code makes them. Dagster's own retired compiler (`dagster-airflow` 0.x) hit exactly this wall: it required configured shared storage for every intermediate value. There is no general translation. Instead, make an explicit decision **per edge** (producer output → consumer input), using the tree below.
+
+## The per-edge decision tree
+
+For every edge in the inventory, in order:
+
+1. **Fuse producer and consumer into one task** when the intermediate is pipeline-internal: nobody materializes it independently, no other consumer exists, no operational value in observing it. Fusing eliminates the handoff entirely. Do NOT fuse when the upstream is independently scheduled, has multiple consumers, is a real dataset someone queries, or carries its own checks/metadata; collapsing an independently-materializable chain loses per-asset observability.
+2. **Explicit storage read/write** for everything that is a real asset (the default). The producer task writes to the same storage the IO manager used; every consumer reads from it. Keep the storage layout the Dagster project already uses, at least through cutover, so side-by-side parity comparison stays trivial.
+3. **XCom** only for small control values (ids, counts, paths, flags) via TaskFlow returns. For medium payloads, configure the object-storage XCom backend and let it spill by size:
+
+```ini
+[core]
+xcom_backend = airflow.providers.common.io.xcom.backend.XComObjectStorageBackend
+
+[common.io]
+xcom_objectstorage_path = s3://conn_id@mybucket/xcom
+xcom_objectstorage_threshold = 1048576
+xcom_objectstorage_compression = gzip
+```
+
+Never pass dataframes or models through default XCom (metadata DB).
+
+## Inventory: what to collect per edge
+
+The scanner emits one record per edge: producer asset/op key, consumer key, `io_manager_key` (remember the implicit default is `fs_io_manager`), the Python type annotation of the output and of each consumer's input (they can differ, see heterogeneous inputs), any `AssetIn(metadata=...)` directives, partitioning of both sides, and whether producer/consumer land in the same generated DAG. Same-DAG edges may still need storage (parallel branches on separate workers); cross-DAG edges always do.
+
+## Recipes by IO manager class
+
+### Pickle IO managers (fs / S3 / GCS / ADLS2)
+
+Write a small helper in `include/io_helpers.py` exposing `write_pickle(key, obj)` / `read_pickle(key)` against the same bucket/prefix the IO manager used. Producer calls write at the end; consumers call read at the start. This is also the answer for **opaque Python objects** (sklearn models, scipy matrices, custom dataclasses): they stay pickles in object storage; XCom is not an option and fusing away an independently-materialized model asset is usually wrong.
+
+### Partitioned file IO managers: the path round-trip rule
+
+Real IO managers encode the partition **window** into the storage key. From a real project (`project_fully_featured/resources/parquet_io_manager.py`):
+
+```
+{prefix}/{asset_key}/{start:%Y%m%d%H%M%S}_{end:%Y%m%d%H%M%S}.pq
+```
+
+In Airflow the producer gets `dag_run.partition_key` (a single string), and a different consumer DAG gets a mapped key. Both must reconstruct the **identical** `(start, end)` window to hit the same file.
+
+**Rule: one shared derivation function, used by every producer and every consumer of that asset.**
+
+```python
+# include/partition_paths.py
+# THE strategy (proven testing, and what partitions.md prescribes): pass this same
+# string as key_format= on the producing timetable, so Airflow keys are byte-identical
+# to Dagster keys and paths round-trip as the identity. Only if you cannot override
+# key_format does conversion apply (Airflow's default is "%Y-%m-%dT%H:%M:%S").
+KEY_FMT = "%Y-%m-%d-%H:%M"   # = the SOURCE project's Dagster fmt (hourly default shown)
+
+def hourly_window(partition_key: str) -> tuple[datetime, datetime]:
+    start = datetime.strptime(partition_key, KEY_FMT)
+    return start, start + timedelta(hours=1)
+
+def parquet_path(prefix: str, asset_key: str, partition_key: str) -> str:
+    # reproduces the Dagster-era path exactly
+    start, end = hourly_window(partition_key)
+    return f"{prefix}/{asset_key}/{start:%Y%m%d%H%M%S}_{end:%Y%m%d%H%M%S}.pq"
+```
+
+Never inline the format string in a task body; a drifted copy produces silent misses (consumer reads nothing, no error). During side-by-side, assert the Airflow-derived path equals the path Dagster actually wrote.
+
+### Warehouse IO managers (Snowflake / BigQuery / DuckDB)
+
+**Non-partitioned**: this case genuinely simplifies. The table was always the real interface; producer runs its SQL/writes via the provider hook, consumers SELECT. Delete the abstraction happily.
+
+**Partitioned**: the IO manager was silently providing an idempotency contract. From a real project (`snowflake_io_manager.py`): on write, DELETE rows in the partition's time window, then append; on read, apply the same window WHERE clause. Reimplement BOTH sides or backfills stop being idempotent:
+
+- Producer: **lift the ORIGINAL delete predicate verbatim; do not re-derive a canonical one.** Real IO managers vary in operator inclusivity and column transforms: a real project uses `WHERE TO_TIMESTAMP(time::INT) BETWEEN '{start}' AND '{end}'`, a CLOSED interval over an epoch-int column. Rewriting that as `time >= :start AND time < :end` changes boundary rows at every partition edge (parity mismatch) and type-errors on the epoch column. Then insert. Wrapping delete+insert in one transaction where the warehouse allows is an improvement, not parity: Dagster issued them as separate statements with no atomicity guarantee.
+- Consumer (partitioned): apply the same original predicate, window derived from the shared helper above.
+- Checklist per table: what is the original predicate (column expression including transforms like `TO_TIMESTAMP(x::INT)`, closed vs half-open interval)? Does a suitable time column exist (the Dagster manager assumed one)? Are delete and read windows derived from the same function? Is a failed run safe to retry (delete-then-insert makes it so)?
+
+Two warehouse-proven amendments (verified in testing):
+
+- **Verbatim lifting preserves BUGS too.** A CLOSED interval (`BETWEEN`) is not partition-disjoint: the boundary row belongs to two windows, and re-running a partition after its neighbor silently DELETES the shared boundary row, identically on both the original Dagster manager and the faithful port (measured: 1689 -> 1688, both sides, degraded checksums equal). Surface this as a SOURCE defect in the migration report; rewriting to half-open (`>= start AND < end`) is the fix but is a deliberate behavior change, decided and documented, never silent.
+- **Bootstrap: the recipe cannot cold-start.** The first-ever materialization fails on the DELETE (`Object does not exist`); the original Dagster manager shares this flaw (it never ran against an empty schema). The port needs `CREATE TABLE IF NOT EXISTS` (or tolerate object-not-found on DELETE) before the first write.
+- **Session parameters change the predicate's meaning.** Under `TIMESTAMP_TYPE_MAPPING=TIMESTAMP_LTZ` with a non-UTC session, the same `TO_TIMESTAMP(...) BETWEEN` matches ZERO rows. Pin `session_parameters` (timezone, timestamp mapping) on the Airflow Connection to match what Dagster's connection used; see `astro-deployment.md`.
+
+**Column-projection metadata** (`AssetIn(metadata={"columns": [...]})`) becomes an explicit column list in the consumer's SELECT. It was never magic; it compiled to SQL anyway.
+
+### Env-swapped IO managers (local dev parity)
+
+Real-world pattern (`project_fully_featured/definitions.py`): the same asset code runs against DuckDB locally and Snowflake in prod because `DAGSTER_DEPLOYMENT` selects the IO manager. Inlining Snowflake SQL into task bodies destroys local dev. Preserve the indirection with a deployment-aware helper:
+
+```python
+# include/warehouse.py
+def warehouse_hook():
+    if os.environ.get("DEPLOYMENT", "local") == "local":
+        return DuckDBHook(...)          # local astro dev
+    return SnowflakeHook(snowflake_conn_id="warehouse")
+```
+
+and keep task bodies engine-neutral (or accept the loss explicitly in the migration report; never lose it silently). Airflow Connections per Astro Deployment carry the env-specific credentials.
+
+### Heterogeneous inputs
+
+One consumer may read N inputs from N different storage systems with different in-memory types; real projects have a single function reading two S3 pickles plus a column-projected Snowflake table, and assets written as pandas but read as Spark by a different consumer. There is no single "load inputs" translation: each input gets its own explicit read, and cross-engine edges (pandas out, Spark in) need an explicit conversion choice (read the parquet with Spark directly; don't round-trip through pandas).
+
+### Unbounded rollups
+
+A non-partitioned downstream of a partitioned upstream consumes **all partitions to date** (one real project's DuckDB manager only permits exactly this). No native Airflow mapper expresses it; windows and `RollupMapper` are bounded. Translate it as an explicit full scan (`SELECT ... FROM t` / glob over the asset's whole prefix) and document that its cost grows with history.
+
+## Single-writer stores under Airflow parallelism
+
+Dagster's default in-process execution serialized writes that Airflow's parallel tasks will not (verified in testing). DuckDB in particular is a single-writer store: two concurrent tasks writing the same file lock-conflict or corrupt. When the migrated DAG fans out writers to a single-writer store, either serialize them (an Airflow Pool with 1 slot on the writing tasks), write per-task outputs and consolidate in a downstream task, or move the store to a concurrent-writer backend as a documented change. Silent reliance on "it worked in Dagster" is exactly the class of parity failure that only appears under load.
+
+## Validation
+
+- Parity: run the same logical window through Dagster and the migrated DAGs; compare row counts + checksums per output table/file (rubric dimension 5).
+- Path drift: unit-test the shared derivation helpers against paths Dagster actually produced (pull real examples from the Dagster instance's materialization metadata before decommissioning it).
+- Idempotency: re-run a migrated partitioned producer for the same window twice; row counts must not grow.

--- a/skills/migrating-dagster-to-airflow/reference/mapping.md
+++ b/skills/migrating-dagster-to-airflow/reference/mapping.md
@@ -1,0 +1,213 @@
+# Dagster → Airflow 3 concept map (master)
+
+> **STATUS: reviewed; hardened through seven complete test migrations (incl. a real-warehouse execution), a live cutover rehearsal, and three adversarial review rounds.** Remaining `[VERIFY]` markers are individually flagged items.
+
+Target assumptions for every mapping in this file:
+
+- **Airflow 3.x on Astro Runtime**, authored TaskFlow-style with `airflow.sdk` assets as the flagship translation form.
+- **Asset-first**: a Dagster asset graph translates to multiple small asset-producing DAGs wired by asset-aware schedules, not one flattened DAG. Imperative job→DAG translation is the fallback for legacy ops/graphs/jobs.
+- **Cosmos** for dbt, provider packages for managed integrations.
+
+Classification legend (every row carries one):
+
+| Tag | Meaning |
+|---|---|
+| `MECH` | Mechanical translation; low risk; scriptable or near-scriptable |
+| `JUDG` | Needs per-instance judgment (granularity, boundaries, idioms) |
+| `REDESIGN` | Semantics differ enough that the pattern must be redesigned, not translated |
+| `NONE` | No Airflow equivalent; documented mitigation required |
+
+Deep-dive files are siblings in `reference/` (routing table in SKILL.md).
+
+---
+
+## 1. Project & definitions layer
+
+| Dagster | Airflow 3 / Astro target | Class | Notes |
+|---|---|---|---|
+| `Definitions` / code location | Astro project (`dags/` + `include/`) | JUDG | The `Definitions` object is the root the inventory scanner traverses |
+| `workspace.yaml` (multiple code locations) | Separate Astro Deployments, or one project with DAG bundles | JUDG | Team/isolation boundaries drive the call |
+| Asset loaders (`load_assets_from_modules`, `load_assets_from_package_module`, ...) | Nothing to migrate: loaders are assembly, not definitions; migrate what they LOAD | MECH | The inventory enumerates the loaded definitions themselves |
+| `get_asset_key_for_model` / `dbt_asset_key` helpers used outside dbt modules | Resolve the referenced model's Airflow asset URI at migration time | JUDG | Load-time dbt-manifest coupling; the scanner surfaces these (`dbt_manifest_coupling`), see `components.md` |
+| Components: library component instances (`defs.yaml` of shipped components) | Unwrap to the underlying integration's mapping row | JUDG | The YAML is config for a known component; map what it generates |
+| Components: custom `Component` subclasses (`build_defs` logic) | Port what `build_defs` PRODUCES, not the class | REDESIGN | Real subclasses are programs: dynamic discovery via live APIs, per-item automation conditions, config-file fan-out. Snapshot their output to a static manifest at migration time and translate that |
+| `setup.py` / `pyproject.toml` deps | `requirements.txt` + `Dockerfile` in Astro project | MECH | |
+| Definitions branched on env vars at import time (e.g. dbt CLI vs dbt Cloud selected by env) | Migrate the branch the deployment actually runs; disposition the alternate branch explicitly | JUDG | The scanner records BOTH branches with their conditions; neither may be silently absent from the report |
+| Third-party Dagster extension libraries (anything emitting definitions that isn't first-party `dagster-*`) | Classify the DEFINITIONS the library emits individually; the library's Dagster glue does not migrate, its core value usually survives as plain Python | JUDG | Read the extension's docs before assuming; flag heavy usage in the go/no-go conditions |
+| `dagster.yaml` (instance config) | `airflow.cfg` / Astro Deployment settings | JUDG | Concurrency, retention, retries live in different layers |
+
+## 2. Assets
+
+| Dagster | Airflow 3 / Astro target | Class | Notes |
+|---|---|---|---|
+| `@asset` | `airflow.sdk` `@asset` (auto DAG + single task + outlet), or `@task` with `Asset` outlet inside a domain DAG | JUDG | Granularity is the key decision: standalone asset-DAG vs task-in-DAG. See `assets.md` |
+| `@multi_asset` (`can_subset=False`) | `@asset.multi(outlets=[...])` | MECH | `@asset.multi` emits ALL outlets on success; fine when the Dagster asset also always emits all |
+| `@multi_asset` (`can_subset=True`) or with `internal_asset_deps` | Split into separate assets/tasks, or redesign | REDESIGN | Runtime subsetting via `context.selected_asset_keys` and internal dep graphs have no `@asset.multi` analog |
+| Asset deps (`deps=`) crossing DAG boundaries | Asset-aware schedule on downstream DAG (`schedule=[upstream]`) | MECH | The flagship Airflow 3 win; edges become schedule conditions |
+| Asset deps within one domain DAG | Task ordering (`>>` / TaskFlow returns) | MECH | Boundary choice (which deps become schedules vs edges) is JUDG |
+| `AssetIn` / managed input loading | None; explicit read in task body | NONE | IO-manager decision tree, see `io-and-data-passing.md` |
+| `MaterializeResult` / metadata | `yield Metadata(self, {...})` or `outlet_events[self].extra = {...}` | MECH | Consumer reads `inlet_events[upstream][-1].extra` |
+| External assets (`AssetSpec`) | `Asset` updated via `POST /api/v2/assets/events` (keys on integer `asset_id`) or `AssetWatcher` | JUDG | `partition_key` in the event body is verified in source (main branch); confirm it's in your deployed version before relying on it |
+| Observable source assets | `AssetWatcher` (event source) or polling sensor DAG | JUDG | |
+| `@graph_asset` / graph-backed assets | TaskGroup whose final task outlets the asset | JUDG | Inherits the intra-graph data-passing problem |
+| Asset groups / `key_prefix` | DAG naming + tags + asset name/URI conventions | MECH | Define one canonical URI convention; see `assets.md` |
+| `code_version` / `data_version` | None (DAG versioning tracks code, not data) | NONE | Document the loss |
+| `define_asset_job(selection=...)` | DAG materializing the selected asset set as tasks | JUDG | "Run this selection as one unit" is a first-class Dagster pattern; becomes a domain DAG whose boundary is the selection |
+| `AssetSelection` DSL (`.groups()`, `.upstream()`, `.downstream()`, `.key()`) | Explicit task/DAG enumeration at codegen time | JUDG | Queries resolve against the asset graph during migration, not at runtime |
+
+## 3. Data passing & IO managers
+
+The central hard problem of the whole migration. Dagster persists op/asset outputs implicitly via IO managers; Airflow tasks share nothing by default.
+
+| Dagster | Airflow 3 / Astro target | Class | Notes |
+|---|---|---|---|
+| IO manager (any) | None; per-edge explicit decision | NONE | Decision tree: (1) fuse producer+consumer into one task; (2) explicit storage write/read in task bodies; (3) XCom for small values, with `XComObjectStorageBackend` (`common-io`, size-threshold spillover to object storage) for medium |
+| Built-in fs/s3/gcs pickle IO managers | Explicit read/write against same storage | JUDG | Mechanical-ish once storage layout is chosen |
+| Opaque Python objects (ML models, matrices) via pickle IO managers | Explicit pickle to object storage | JUDG | XCom impossible (size/serialization); fusing collapses independently-materializable chains. Name the storage path convention explicitly |
+| Partitioned file IO managers (partition-window → path encoding) | Shared key-derivation helper used by producer AND consumers | JUDG | The storage key is a function of the partition window; both sides of every cross-DAG edge must derive the identical path from `partition_key`. Recipe in `partitions.md` |
+| Warehouse IO managers, non-partitioned | SQL executed via hooks/operators; table is the interface | JUDG | Often genuinely simplifies |
+| Warehouse IO managers, partitioned | Hooks/operators + reimplemented idempotency contract | JUDG | The IO manager silently provided delete-then-insert partition overwrite on write and time-window WHERE clauses on read. Every producer and consumer must reimplement both or backfills stop being idempotent |
+| Env-swapped IO managers (e.g. DuckDB locally, Snowflake in prod) | Env-switched connection/hook helper | REDESIGN | The IO-manager indirection is what made `dagster dev` run prod code locally; inlining SQL destroys it. Preserve with a deployment-aware helper or accept the local-dev loss explicitly |
+| One asset reading N inputs from different IO managers (+ `AssetIn(metadata=...)` directives like column projection) | Per-input explicit reads | JUDG | Each input names its own storage backend and read options; there is no single "input loading" translation |
+| Non-partitioned downstream consuming ALL partitions of an upstream | Explicit full-scan read | NONE | Unbounded rollup ("every partition to date") has no native mapper; windows/`RollupMapper` cover bounded ranges only |
+| `In`/`Out` between ops (small data) | XCom (TaskFlow return values) | MECH | Size guardrails apply |
+
+## 4. Partitions & backfills
+
+**CONFIRMED 2026-07-09**: Airflow shipped native asset partitions (AIP-76) in **3.2.0**, expanded in **3.3.0**. All under `airflow.sdk`. Version floors matter:
+
+- **3.2+**: `CronPartitionTimetable` (producer side), `PartitionedAssetTimetable` (consumer side), core mappers (`IdentityMapper`, `StartOfHourMapper` and other `StartOf*` mappers, `FixedKeyMapper`, `AllowedKeyMapper`, `ProductMapper`); tasks read `dag_run.partition_key`.
+- **3.3+ only**: runtime/dynamic partition emission via `outlet_events[self].add_partitions(...)`, `RollupMapper`, `FanOutMapper`, windows (`DayWindow`, `SegmentWindow`, ...), wait policies (`WaitForAll`, `MinimumCount`).
+
+Target Astro Runtime 3.3+ to get the full surface. Pre-3.2 fallback is logical-date mapping, documented in `partitions.md`.
+
+| Dagster | Airflow 3 / Astro target | Class | Notes |
+|---|---|---|---|
+| Time-window partitions (daily/hourly/...) | `CronPartitionTimetable` on the producing asset | MECH | Native mapping on Airflow >= 3.2 |
+| Downstream of partitioned asset | `PartitionedAssetTimetable` + wait policy | JUDG | Wait-policy choice (`WaitForAll` vs `MinimumCount`) encodes Dagster's implicit semantics |
+| Partition mappings (`TimeWindowPartitionMapping`, identity, fan-out...) | Partition mappers (`StartOfHourMapper`, `RollupMapper`, `FanOutMapper`, `IdentityMapper`, ...) | JUDG | Map each Dagster mapping to nearest mapper; document deltas |
+| Static partitions | `FixedKeyMapper` / `AllowedKeyMapper` key sets | JUDG | |
+| Dynamic partitions (`DynamicPartitionsDefinition`) | `outlet_events[self].add_partitions(...)` (3.3+); `PartitionedAtRuntime` timetable | JUDG | `add_partitions` is the doc-confirmed path; `PartitionedAtRuntime` spelling appears in core docs but not Astronomer's guide, re-verify against the 3.3 API ref before emitting. Retroactive-key semantics need verification |
+| Multi-partitions | `ProductMapper` composition, or key-encoding | REDESIGN | `ProductMapper` may cover two-dimensional cases; verify semantics before downgrading to JUDG |
+| Dagster backfill (asset partitions) | `airflow backfill create --from-date --to-date --reprocess-behavior ...` (also UI/REST) | JUDG | Partition-aware backfill is native since 3.2 |
+| `BackfillPolicy.single_run` | None: no single-run backfill exists (verified in testing) | NONE | Per-partition runs, or a manual run with explicit range params; see partitions.md |
+
+## 5. Automation: schedules, sensors, declarative automation
+
+| Dagster | Airflow 3 / Astro target | Class | Notes |
+|---|---|---|---|
+| `ScheduleDefinition` (cron) | DAG `schedule` cron string + timezone, `catchup` set explicitly | MECH | Catchup is the trap: Dagster non-partitioned schedules never catch up (Airflow 3 default `catchup=False` matches); Dagster partitioned schedules DO fill gaps (`catchup=True`, BUT an old start_date means a run storm at unpause: use `catchup=False` + bounded backfill, see automation.md). MECH only once catchup is set per source type |
+| `@schedule` with dynamic `RunConfig` | DAG params + templating, or leading config task | JUDG | Airflow schedules can't compute run config |
+| `@sensor` (polling, cursor) | Deferrable sensor / `@task.sensor` in a polling DAG; cursor state → Variable/XCom | REDESIGN | Dagster sensors are arbitrary Python with cursors; see `automation.md`. Scanner heuristic: a plain `@sensor` polling materialization events of multiple assets is a hand-rolled multi-asset sensor; MECH boolean asset schedule ONLY when its cursor is pure last-seen dedup (fire once per new materialization) with no counting/threshold/per-partition logic, which is the REDESIGN case below. And see automation.md's partitioned-upstream trap first |
+| Schedules/sensors targeting asset selections (`define_asset_job(selection=...)`, YAML `target:` queries) | One DAG per selection; overlapping selections need dedup rules | REDESIGN | In Airflow an asset has ONE producing DAG with ONE schedule. Two cadences over overlapping asset sets (e.g. @weekly everything + @daily subset) cannot both drive the same assets without restructuring |
+| `@asset_sensor` (bare: fire on materialization) | Asset-aware schedule (`schedule=[asset]`) | MECH | Airflow 3 makes this native. PARTITIONED upstream → must be `PartitionedAssetTimetable` instead (see automation.md's trap: a bare asset schedule silently never fires) |
+| `@asset_sensor` with evaluation logic | Asset schedule + guard task, or deferrable sensor | REDESIGN | `schedule=[asset]` fires unconditionally, passes no config. Metadata filtering, computed `run_config`, and cross-job triggering all need redesign |
+| `@multi_asset_sensor` | Boolean asset conditions (`(a & b)`, `(a \| b)`, nestable) for plain fan-in; otherwise redesign | REDESIGN | Cursor-based custom Python over materialization events (counting, per-partition logic) cannot be expressed as a boolean schedule. Partitioned upstreams → `PartitionedAssetTimetable`, per automation.md's trap |
+| `@run_status_sensor` / `@run_failure_sensor` | DAG/task callbacks, or listeners | JUDG | |
+| `AutomationCondition.eager()` | Asset-aware schedule on upstreams | JUDG | Approximation drops four guarantees: eager skips when (a) any upstream partition is missing, (b) any upstream is in progress, (c) the asset itself is in progress, and (d) restricts to the latest time window. A bare asset schedule fires anyway; migration report must say so |
+| `AutomationCondition.on_cron()` | No faithful native analog; `AssetOrTimeSchedule` is the nearest but has INVERTED semantics | REDESIGN | `on_cron` = cron tick THEN wait for ALL deps updated since that tick (AND). `AssetOrTimeSchedule` fires on time tick OR any asset update. Faithful version needs a gating pattern; see `automation.md` |
+| `cron_tick_passed(x) & ~in_progress()` (the DOMINANT idiom in real projects) | Plain DAG cron schedule + `max_active_runs=1` | MECH | Unlike `on_cron`, fires on the tick regardless of parent updates. Do not conflate with the on_cron row below |
+| `cron_tick_passed(x)` alone | DAG cron schedule | MECH | |
+| `~in_progress()` | `max_active_runs=1` | MECH | |
+| `any_deps_updated()` | Asset-aware schedule on deps | JUDG | Same success-only caveat as asset schedules |
+| `in_latest_time_window()` | Latest-window guard in task logic | JUDG | |
+| `code_version_changed()` | Cron + state-aware dbt builds (Fusion / dbt State skip unchanged models per run) | JUDG | Converges on rebuild-on-changed-models with cadence-bounded latency; the push-at-deploy semantics and non-dbt uses of code_version remain deltas. Maturity: Fusion public beta, Cosmos Fusion support since 1.11 (LOCAL mode); see `dbt.md` |
+| `any_deps_match(...)` / `.allow()` / `.ignore()` scoping | Partial decomposition at best | REDESIGN | Per-dep scoped conditions have no schedule analog |
+| Other complex `AutomationCondition` compositions | Partial via boolean asset schedules | REDESIGN | Decompose into the operator rows above; whatever remains goes to manual review |
+| `AutoMaterializePolicy.eager()` / eager-style `auto_materialize_policy=` [deprecated spelling] | Same targets as `AutomationCondition.eager()` | JUDG | Legacy spelling, still common; normalize then map |
+| `AutoMaterializePolicy.lazy()` [deprecated spelling] | Freshness/observability layer (see FreshnessPolicy row), NOT an asset schedule | JUDG | lazy was freshness/SLA-driven; routing it to an eager-style schedule is wrong (adversarial-review finding; matches automation.md) |
+| `FreshnessPolicy` / freshness checks | Deadline Alerts (`DeadlineAlert`, 3.1+, experimental) and/or Astro **DAG Timeliness** alerts | JUDG | Deadline references are DAG-run-oriented; Dagster freshness is asset-oriented. Document the reframing |
+
+## 6. Asset checks & data quality
+
+| Dagster | Airflow 3 / Astro target | Class | Notes |
+|---|---|---|---|
+| `@asset_check` | Downstream check task (`SQLColumnCheckOperator` / `SQLTableCheckOperator` from common-sql, or Python task) | JUDG | Blocking semantics are SCOPED in Dagster: a blocking check halts downstream assets in the SAME RUN only, and automation-driven (declarative) downstreams ignore blocking entirely |
+| Blocking check: WHO carries the asset outlet | Producer task by DEFAULT; check task only as a deliberate, documented upgrade | JUDG | For same-run imperative job downstreams, a check-task gate matches Dagster. For asset-schedule downstreams (the flagship translation form) Dagster did NOT block on checks, so putting the outlet on the check task INTRODUCES gating Dagster lacked: a behavior change, never the silent default (adversarial-review finding) |
+| Inline `check_specs=` / `AssetCheckSpec` on assets (incl. cross-system reconciliation checks) | Same translation as `@asset_check`: check task after the producing task | JUDG | Scanner must catch the inline spelling; cross-warehouse reconciliation checks need both connections. Blocking on inline specs is version-dependent (historically only `@asset_check` supported it); verify `AssetCheckSpec(blocking=True)` was actually set before assuming any gate |
+| Check severity / blocking | Task failure vs warning-only (callback + continue) | JUDG | |
+| dbt tests as checks | Cosmos-native dbt test execution | MECH | |
+| Freshness-check builders (`build_last_update_freshness_checks`, `build_time_partition_freshness_checks`, `build_sensor_for_freshness_checks`) | Astro DAG Timeliness alert / `DeadlineAlert`; **NEVER a downstream check task** | JUDG | Freshness checks run even when the asset fails or is stale, which is their whole purpose; a success-gated downstream task inverts that. Route to the observability layer, not the DAG |
+
+## 7. Legacy ops / graphs / jobs (imperative fallback)
+
+| Dagster | Airflow 3 / Astro target | Class | Notes |
+|---|---|---|---|
+| `@job` | DAG | MECH | |
+| `@op` | `@task` | MECH | |
+| `@graph` | TaskGroup | MECH | |
+| Op `In`/`Out` wiring | TaskFlow returns (XCom) or explicit storage | JUDG | Same IO decision tree; consider fusing ops |
+| `DynamicOut` / `DynamicOutput` | Dynamic task mapping (`expand`) | MECH | Runtime-verified (verified in testing). One trap: a collector task returning its mapped input re-pushes a `LazyXComSequence` and fails serialization; materialize with `list(...)` first (playbook entry) |
+| `Nothing` dependencies | Pure ordering edges (`>>`) | MECH | |
+| `@success_hook` / `@failure_hook` | `on_success_callback` / `on_failure_callback` | MECH | |
+| `RetryPolicy(max_retries, delay, backoff, jitter)` | `retries`, `retry_delay`, `retry_exponential_backoff` | JUDG | Only `max_retries` + constant delay are mechanical. `Backoff.LINEAR` and `Jitter` have no Airflow equivalent; the exponential curves differ (Dagster `(2^n - 1) * delay` vs Airflow `~2^try_number` sec capped by `max_retry_delay`) |
+| Executors (per-job) | Deployment-level executor choice | JUDG | Airflow executor is not per-DAG |
+
+## 8. Resources & configuration
+
+| Dagster | Airflow 3 / Astro target | Class | Notes |
+|---|---|---|---|
+| `ConfigurableResource` (connection-like) | Airflow Connection + provider Hook | JUDG | Inversion of control: injected → pulled. Run-scoped `setup_for_execution`/`teardown_after_execution` lifecycle is lost; resources relying on teardown (sessions, locks, leases) need context managers in task bodies or callbacks |
+| `ConfigurableResource` (client/service wrapper) | Plain Python construction in task body or `include/` helper | JUDG | Not everything should become a Connection |
+| `EnvVar` | Env vars / Astro Environment secrets | MECH | |
+| `Config` / `RunConfig` (Pydantic) | DAG `Params` (typed) + templating | JUDG | |
+| Resources on sensors/schedules | Hooks inside the corresponding DAG code | JUDG | |
+
+## 9. External execution (Pipes)
+
+| Dagster Pipes client | Airflow operator | Class | Notes |
+|---|---|---|---|
+| `PipesSubprocessClient` | `@task.bash` / `BashOperator` or `ExternalPythonOperator` | MECH | |
+| `PipesK8sClient` | `KubernetesPodOperator` | MECH | |
+| `PipesDatabricksClient` | Databricks provider operators | MECH | |
+| `PipesECSClient` / `PipesEMRClient` / `PipesGlueClient` / `PipesLambdaClient` | Matching AWS provider operators | MECH | |
+| Pipes report-back protocol (materializations, metadata, logs from external process) | None; OpenLineage or explicit post-hoc metadata | NONE | Document the loss; the launch mapping is easy, the feedback channel isn't |
+
+## 10. Integrations
+
+| Dagster | Airflow 3 / Astro target | Class | Notes |
+|---|---|---|---|
+| `dagster-dbt` (`@dbt_assets`, `DbtProject`, `DbtCliResource`) | Cosmos (`DbtDag` / `DbtTaskGroup`) | JUDG | Structure maps well, but: custom translators (grouping, automation) carry logic; automation via `code_version_changed()` has NO Cosmos equivalent (silently degrades to cron); branch-deploy DB swaps live in translator code |
+| dbt profiles/targets per environment | Cosmos `ProfileConfig` per Deployment | JUDG | Dagster projects switch dbt targets on env vars; map each to the right Astro Deployment's profile |
+| `dagster-fivetran` / `dagster-airbyte` | Fivetran/Airbyte provider operators | JUDG | Real projects discover connectors dynamically from the live API at definition time (`build_*_assets_definitions`); Airflow DAG parsing can't. Generate a static connector manifest at migration time. Custom workspace subclasses (e.g. skip-sync-on-reschedule) carry business logic provider operators lack |
+| `dagster-sling` / `dagster-dlt` (embedded ELT) | Plain tasks invoking sling/dlt, or provider operators `[VERIFY availability]` | JUDG | |
+| Plain-code dlt wrapped in a `ConfigurableResource` (the common real-world dlt shape, NOT `@dlt_assets`) | Vendor the dlt pipeline code unchanged; call it from `@task` bodies | MECH-ish | Execution-proven cold (verified in testing). The dlt DSL (`@dlt.resource`, `@dlt.source`) is dlt's, not Dagster's: it migrates as-is, and is NOT a Dagster resource needing a Connection |
+| Warehouse resources (snowflake/duckdb/bigquery) | Provider hooks + SQL operators | JUDG | |
+| `dagster-k8s` executor / ops | KubernetesPodOperator / K8s executor at deployment level | JUDG | |
+
+## 11. Runtime semantics
+
+| Dagster | Airflow 3 / Astro target | Class | Notes |
+|---|---|---|---|
+| Run tags | DAG tags + run conf/params | MECH | |
+| `dagster-k8s/config` tags (per-job pod resources) | Per-task `executor_config` / `pod_override` | JUDG | Container CPU/memory requests set via run tags must land on the translated tasks, not the deployment |
+| Tag-based concurrency limits / pools | Airflow Pools + `max_active_runs` / `max_active_tis_per_dag` | MECH | |
+| Run coordinator / queues | Pools + `priority_weight` | JUDG | |
+| Instance-level run retries | Default `retries` via `default_args` / config | MECH | |
+| `context.log` | Task logger (`logging`) | MECH | |
+| Definition metadata / descriptions | DAG/task `doc_md`, asset descriptions | MECH | |
+
+## 12. Platform: Dagster+ → Astro
+
+| Dagster+ | Astro | Class | Notes |
+|---|---|---|---|
+| Deployment | Astro Deployment (in a Workspace) | JUDG | |
+| `dagster_cloud.yaml` | Astro project + Deployment config + `astro deploy` CI/CD | JUDG | |
+| Branch deployments | Astro preview Deployments (per-branch ephemeral, via `deploy-action` CI sub-actions) | JUDG | Not just platform config: `DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT` / `DAGSTER_CLOUD_PULL_REQUEST_ID` env vars appear IN CODE (DB naming, URLs) and must be found and rewritten |
+| K8s `env_secrets` / agent env vars per code location | Astro Environment secrets + Connections | JUDG | Map each named secret; nothing does this automatically |
+| `agent_queue` routing (e.g. regional isolation) | Separate Astro Deployments (per region) + registry mapping | JUDG | Data-residency boundaries become deployment boundaries |
+| Run/materialization history | Not migrated | NONE | Keep Dagster readable for a grace period; Airflow starts with empty history |
+| Alert policies | Astro alerts (UI-configured, no DAG code): DAG Failure/Success/Timeliness/Duration, Task Failure/Duration; Slack/PagerDuty/Email/Opsgenie/DAG-Trigger channels | MECH | Map each Dagster alert policy to the nearest Astro alert type |
+| Insights | Astro Observe (GA): freshness/timeliness SLAs, data products, health dashboards, Snowflake cost at pipeline level. No per-asset credit accounting | JUDG | |
+| Serverless vs hybrid agents | Astro hosted vs dedicated/hybrid options | JUDG | |
+| Asset catalog & lineage UI | Airflow 3 asset views + Astro lineage (OpenLineage) | NONE | Partial coverage; column-level lineage loss must be documented honestly |
+
+## 13. Dev & testing workflow
+
+| Dagster | Airflow 3 / Astro target | Class | Notes |
+|---|---|---|---|
+| `dagster dev` | `astro dev start` | MECH | Different feel; set expectations |
+| `dagster definitions validate` | `astro dev parse` (DagBag import check) | MECH | First rung of the validation ladder |
+| `materialize()` in unit tests | `dag.test()` (in-file) / `astro dev pytest` | JUDG | See `validation.md` |
+| `build_asset_context()` etc. | Plain function tests of task callables | JUDG | |
+| `dagster asset materialize` CLI | `astro run <dag-id>` (single DAG, one worker container) | MECH | |

--- a/skills/migrating-dagster-to-airflow/reference/partitions.md
+++ b/skills/migrating-dagster-to-airflow/reference/partitions.md
@@ -1,0 +1,127 @@
+# Partitions and backfills
+
+> **STATUS: reviewed; runtime-probed in testing** (key_format, single_run, backfill semantics).
+
+Airflow 3.2 shipped native asset partitions (AIP-76), expanded in 3.3, so most Dagster partition patterns now translate natively instead of being redesigned onto logical dates. Version floors decide what you can use:
+
+| Airflow version | Available |
+|---|---|
+| 3.2+ | `CronPartitionTimetable` (producer), `PartitionedAssetTimetable` (consumer), core mappers (`IdentityMapper`, `StartOf*Mapper`, `FixedKeyMapper`, `AllowedKeyMapper`, `ProductMapper`), `dag_run.partition_key`, partition-aware backfill |
+| 3.3+ | Runtime emission `outlet_events[self].add_partitions(...)`, `RollupMapper`, `FanOutMapper`, windows (`HourWindow` ... `SegmentWindow`), wait policies (`WaitForAll`, `MinimumCount`) |
+
+**Target Astro Runtime 3.3+.** Migrating to anything older than 3.2 means the logical-date fallback (last section), a much worse mapping.
+
+## Producer side: time-window partitions
+
+Dagster `HourlyPartitionsDefinition` / `DailyPartitionsDefinition` / etc. become `CronPartitionTimetable` on the producing asset:
+
+```python
+# Dagster
+from dagster import HourlyPartitionsDefinition, asset
+@asset(partitions_def=HourlyPartitionsDefinition(start_date=datetime(2020, 12, 1)))
+def events(context):
+    start, end = context.partition_time_window
+    ...
+
+# Airflow 3
+from airflow.sdk import CronPartitionTimetable, asset
+@asset(uri="s3://lake/events", schedule=CronPartitionTimetable("0 * * * *", timezone="UTC"))
+def events(dag_run):
+    key = dag_run.partition_key
+    ...
+```
+
+Translation checklist per partitions definition (all fields are in the inventory):
+
+- Cadence → cron string: daily `0 0 * * *`, hourly `0 * * * *`, weekly/monthly per `day_offset`. Dagster's `minute_offset`/`hour_offset`/`day_offset` shift the cron fields.
+- Custom `TimeWindowPartitionsDefinition` sets `cron_schedule` and `fmt` INDEPENDENTLY and they can disagree (real example: daily cron with an hourly-looking `%Y-%m-%d-%H:%M` fmt). Take both from the definition; never infer the key format from the cadence.
+- `timezone` carries over directly. `[JUDG]` if the Dagster def relied on the instance default.
+- `start_date`: Airflow's DAG `start_date` bounds history for catchup/backfill.
+- `end_date` / `end_offset` (partitions beyond "now"): no direct field; flag `[JUDG]`.
+- `fmt` (the partition key format): see the key-format contract below. This is the field that silently breaks storage paths.
+
+**The key-format contract.** Dagster default key formats: daily `%Y-%m-%d` (`2026-07-09`), hourly `%Y-%m-%d-%H:%M` (`2026-07-09-14:00`). Airflow's default is different (verified in testing): `dag_run.partition_key` is a plain string in `key_format`, default `%Y-%m-%dT%H:%M:%S`; pass `key_format=` on the timetable to control it. **Best practice (proven eval 3): set `key_format` to the SOURCE project's Dagster fmt**, so Airflow partition keys equal Dagster partition keys and every key-derived storage path round-trips as the identity: `CronPartitionTimetable("0 0 * * *", key_format="%Y-%m-%d")` made the parquet path recipe pass with zero conversion. Also probed: `partition_key` is **None under `dags test`**; the local way to run a concrete partition is `airflow backfill create --from-date D --to-date D` for that single day/window. Every piece of code that turns a key into a time window or storage path must go through one shared helper that parses the Airflow key and reformats where Dagster-era paths must be reproduced (recipe in `io-and-data-passing.md`). Unit-test it against real paths pulled from Dagster's materialization metadata.
+
+**Per-edge window padding.** Producers commonly pad the derived window with business offsets before use, e.g. feeding dbt vars `min_date = start - 3h`, `max_date = end + 1d`. The padding lives in the producer's body, NOT in the partitions definition, so no key-derivation helper can recover it. Capture it during inventory (read the producer body) and reapply it explicitly in the translated task; assuming zero padding silently changes the data.
+
+## Consumer side: partition mappings
+
+**Rule (verified in testing): a partitioned producer forces the partition surface onto EVERY asset-scheduled consumer, partitioned-looking or not.** Partition-stamped asset events are dropped for non-partitioned consumers (silently: the consumer never fires), so any DAG scheduled on a partitioned asset must use `PartitionedAssetTimetable(assets=...)`, with a mapper choosing how keys map. Wait policies attach to the MAPPER (`RollupMapper(..., wait_policy=...)`), not the timetable. Version nuance: the drop behavior is the documented intent and holds on 3.3+; on Airflow 3.2.0 a bug (apache/airflow#63734) made such events WRONGLY fire non-partitioned consumers, the opposite failure. One more reason the 3.2 row in the version table above is a floor, not a recommendation.
+
+Downstream consumers use `PartitionedAssetTimetable(assets=..., default_partition_mapper=...)`. Mapping Dagster's partition mappings:
+
+| Dagster | Airflow 3 | Class | Notes |
+|---|---|---|---|
+| (default) same-partition dep, same cadence | `IdentityMapper` | MECH | |
+| Hourly upstream → daily downstream (coarser) | `StartOfDayMapper` + `RollupMapper`/windows (3.3+) | JUDG | Verify aggregation semantics match the Dagster window before trusting |
+| Daily upstream → hourly downstream (finer) | `FanOutMapper` (3.3+) | JUDG | |
+| `TimeWindowPartitionMapping(start_offset=-1)` | Window with `Window.Direction.BACKWARD` / `SegmentWindow` | JUDG | Note the Dagster semantics: start_offset=-1 with end_offset=0 depends on the prior AND current windows (an expanded set), not a shifted single window. Offset arithmetic differs; test with a concrete date table |
+| `TimeWindowPartitionMapping` on SELF (self-dependency) | `depends_on_past=True` on the task, plus explicit prev-window read | JUDG | Dagster's per-partition self-dep is stronger than depends_on_past (which is per-task-instance); document the delta |
+| `AllPartitionMapping` (consume all partitions) | None: explicit full scan | NONE | The unbounded-rollup case; see `io-and-data-passing.md` |
+| `LastPartitionMapping` | Read latest key explicitly in task logic | JUDG | |
+| `StaticPartitionMapping` (explicit key→key dict) | `FixedKeyMapper` | JUDG | |
+| `SpecificPartitionsPartitionMapping` | `AllowedKeyMapper` | JUDG | Spelling-level match; verify semantics |
+| `MultiToSingleDimensionPartitionMapping`, `MultiPartitionMapping` [Beta] | Composition or redesign | REDESIGN | See multi-partitions below |
+
+Wait policies: in Dagster, "wait for all upstream partitions" was never the partition mapping's job; it came from the automation condition (`~any_deps_missing()` inside eager) or a blocking check, and a manually triggered or non-eager downstream materializes with upstreams missing. So `WaitForAll` (the Airflow default) matches only when the Dagster side actually gated on all-present; check the asset's automation before assuming it. `MinimumCount(n)` has no Dagster analog (do not introduce it silently).
+
+## Static partitions
+
+`StaticPartitionsDefinition(["us", "eu", "apac"])` is usually not time at all; decide what it really is:
+
+1. **Fan-out within a run** (all regions processed every run): dynamic task mapping, `process.expand(region=["us", "eu", "apac"])`. Simplest and usually right.
+2. **Independently triggered/backfilled keys** (regions materialized separately, selectively): partitioned asset with fixed keys (`FixedKeyMapper`/`AllowedKeyMapper` on consumers) or one DAG per key when the list is tiny and stable.
+
+The inventory should record how the Dagster project actually used it (were single-partition runs launched? per-key backfills?) and choose accordingly.
+
+## Dynamic partitions
+
+`DynamicPartitionsDefinition(name=...)` plus `AddDynamicPartitionsRequest` from a sensor translates to runtime partition emission (3.3+):
+
+```python
+@asset(uri="s3://lake/live", schedule=PartitionedAtRuntime())
+def live(self, outlet_events):
+    outlet_events[self].add_partitions(discovered_keys)
+```
+
+Caveats, both flagged in the map review:
+
+- `PartitionedAtRuntime` is CONFIRMED importable from `airflow.sdk` on Runtime 3.3 (verified in testing)` but imports fine). `add_partitions` remains the doc-confirmed emission path.
+- Retroactive-key semantics (Dagster lets a sensor add keys and separately request runs for them) are unverified on the Airflow side. If the Dagster project adds keys without immediately materializing them, flag for manual design.
+
+The event-driven alternative often fits better: if dynamic partitions modeled "a new file/tenant arrived," an `AssetWatcher` on a queue, or an external `POST /api/v2/assets/events` with `partition_key`, is closer to intent than replicating the sensor.
+
+## Multi-partitions
+
+`MultiPartitionsDefinition({"date": daily, "region": static})` is REDESIGN. Options in preference order:
+
+1. **Time partition on the DAG, dynamic task mapping over the static dimension.** Date stays a real partition (backfillable); regions become mapped tasks within each run. Covers the common date×category case well. Loses per-(date, region) selective materialization; say so in the report.
+2. **`ProductMapper`** exists (3.2+) and may express two-dimensional consumption; semantics unverified against Dagster's `MultiPartitionKey`. Verify before use; do not emit blind.
+3. **Key encoding** (`2026-07-09|eu` as a runtime-emitted key): preserves per-pair granularity, costs all native time-window tooling. Last resort.
+
+## Backfills
+
+| Dagster | Airflow 3 |
+|---|---|
+| Backfill selected asset partitions (UI/CLI) | `airflow backfill create --dag-id X --from-date A --to-date B` (also UI and REST); partition-aware since 3.2. from/to is the partition-date range, no off-by-one (verified in testing). DAGs with `depends_on_past=True` REFUSE backfills unless `--reprocess-behavior` is passed explicitly |
+| Re-materialize only failed partitions | `--reprocess-behavior failed` (also `none`, `completed`) |
+| `BackfillPolicy.single_run()` (one run spans the range) | None: no single-run backfill exists (verified in testing). Emit per-partition runs, or a manually triggered run with explicit range params whose task ignores `partition_key`; document the change |
+| `BackfillPolicy.multi_run(max_partitions_per_run=n)` | Batching has no direct knob; `max_active_runs` bounds concurrency, not batch size. `[JUDG]` |
+| Asset-selection backfill across the graph | Per-DAG backfills, ordered by dependency; no native graph-wide backfill. Document the operational difference |
+
+Three rehearsal-verified realities (verified in testing), plus one from eval 5: unpausing a partition-timetable DAG fires the CURRENT partition immediately, so pause-and-clear that noise run (or accept it knowingly) before starting a historical backfill.
+
+(1) `backfill create` on a PartitionedAssetTimetable CONSUMER is refused outright (`DagNonPeriodicScheduleException`); the recipe is to backfill the PRODUCER with the consumer UNPAUSED, and the consumer fires once per upstream key in order. (2) A backfill against a paused DAG queues runs that never execute, silently. Unpause first. (3) Under asset-triggered runs, `depends_on_past` enforces run-CREATION order, not partition order; if ordering by partition matters, verify the producer emits in order.
+
+Idempotency is the prerequisite for any of this: partitioned producers must be safe to re-run per window (the delete-then-insert contract in `io-and-data-passing.md`). Verify with the double-run test before running a real backfill.
+
+## Pre-3.2 fallback (logical dates)
+
+If the target is stuck below 3.2: time partitions become `schedule` + `data_interval_start/end` with `catchup=True` for history; every other partition type degrades to params or mapped tasks; per-partition lineage and selective re-materialization are lost. This fallback is documented for completeness; prefer upgrading the target Runtime over using it.
+
+## Validation
+
+- Key-format round-trip: unit-test the shared key/window helper against real keys and paths from the Dagster instance.
+- Partition-count parity: for a fixed window, the set of Airflow partition keys materialized must equal Dagster's partition set (compare against `dagster asset list`/materialization events before decommissioning).
+- Mapper spot-check: for each consumer, pick one concrete key and assert the mapped upstream key set matches what Dagster's partition mapping produced for the same date.
+- Idempotency double-run per partitioned producer.

--- a/skills/migrating-dagster-to-airflow/reference/quickstart.md
+++ b/skills/migrating-dagster-to-airflow/reference/quickstart.md
@@ -1,0 +1,62 @@
+# Quickstart: your first hour
+
+For the human driving the migration (with Claude Code running the skill). Everything in your first hour is read-only and reversible, with one caveat: runtime-mode inventory of a dagster-dbt project runs `prepare_if_dev`, which writes dbt's `target/` directory inside the source repo (build artifacts only, gitignored in typical projects). Nothing touches your Dagster deployment or its schedules until the cutover phase, many steps from now.
+
+## Terms you'll meet immediately
+
+| Term | Meaning |
+|---|---|
+| **unit** | One migratable definition from your Dagster repo (an asset, schedule, sensor, resource, ...). The manifest has one record per unit |
+| **manifest** | The JSON file the scanner emits: every unit, its classification, and its migration state. The single source of truth for progress |
+| **MECH / JUDG / REDESIGN / NONE** | Classification per unit: mechanical translation / needs judgment / semantics differ, redesign / no Airflow equivalent, documented mitigation. The manifest embeds this legend too |
+| **disposition** | How a unit ended: `complete` (migrated, gates passed) or `deferred` (not migrated, with a written reason). Every unit must end as one or the other |
+| **translation** | Turning a Dagster construct into its Airflow form (an asset becomes a DAG task with an asset outlet) |
+| **equivalence row** | One line per schedule/sensor/trigger in the migration report: what it was, what it became, and the behavioral difference in one sentence |
+| **gate / ladder** | The six validation steps each unit climbs (lint → import → structure → execution → data parity → idempotency), cheapest first |
+
+## Prerequisites
+
+- `python3` (commands in these docs say `python3`; bare `python` may not exist on macOS)
+- `astro` CLI + Docker (needed from Phase 2 onward, not for the first hour)
+- Read access to the Dagster repo; ideally the Dagster instance stays running (its outputs become your parity fixtures)
+
+## Hour one, literally
+
+```bash
+# 1. Make a working directory for the migration run (NOT inside either project)
+mkdir dagster-migration && cd dagster-migration
+
+# 2. Scan the Dagster repo. Read-only; touches nothing.
+python3 <path-to-skill>/scripts/inventory.py <path-to-dagster-repo> --out manifest.json
+
+# 3. Better: rerun with the PROJECT's venv for runtime enrichment. Activate the
+# venv (or put its bin on PATH) rather than calling its python directly: dbt
+# projects need the venv's `dbt` executable resolvable, and dagster-dbt projects
+# also need DAGSTER_IS_DEV_CLI=1 to prepare their manifest.
+source <dagster-repo-venv>/bin/activate
+DAGSTER_IS_DEV_CLI=1 python <path-to-skill>/scripts/inventory.py <path-to-dagster-repo> --runtime --out manifest.json
+# (if runtime mode can't run, you get a loud STATIC-ONLY banner; the static manifest still stands)
+# If the project's lockfile won't install (monorepo-relative sources), create a fresh
+# venv and `pip install -e <path-to-dagster-repo>` instead; runtime mode only needs imports to resolve.
+
+# 4. Look at what you have
+python3 <path-to-skill>/scripts/status.py --manifest manifest.json summary
+```
+
+Open `manifest.json` and skim: `counts` tells you what kinds of definitions you have, and anything `spelling: "deprecated"` deserves a close look. Classifications start `pending`; the driving agent assigns MECH/JUDG/REDESIGN/NONE per record from the concept map during Phase 1 (a high MECH share afterward means an easier migration). The `legend` field decodes the tags.
+
+The manifest lives HERE in your run directory for now. Later (Phase 2, once `astro dev init` has created the Astro project) you copy it to the project's `include/inventory/manifest.json` so the structural tests can find it; the run-dir copy stays canonical.
+
+A `<unit-id>` in any `status.py` command is a key of the manifest's `units` map (shaped `kind:name`, e.g. `asset:daily_sales`); `status.py show` lists them. One editing rule, worth learning before it bites: the PLAN fields on a unit (`dag_id`, `task_count`, `edges`, `schedule`, `asset_outlets`, `target`) are yours to fill during planning. The STATE field (`status`) is never hand-edited; it only moves via `status.py advance / defer / reopen`.
+
+## What to do with the skill itself
+
+Point Claude Code at the skill (`SKILL.md`) with your Dagster repo and the manifest; it drives the workflow phase by phase and routes itself to the reference files. Your job is the judgment calls it surfaces: reviewing classifications, choosing DAG boundaries, approving per-edge IO decisions, and reading the migration report skeptically.
+
+## When to pull in a senior engineer
+
+Self-serve: reading the manifest, the reference routing table, running gates 1-3, MECH units. Escalate: any REDESIGN/NONE row on a pipeline you don't fully understand, the per-edge IO decisions on partitioned warehouse tables (`reference/io-and-data-passing.md` explains why they're the sharp edge), anything in the playbook you hit twice, and everything in the cutover phase.
+
+## What can this break?
+
+Until cutover: nothing. The scanner is read-only; the generated Astro project is a separate directory; gates 1-4 run against local/dev environments; Dagster remains the system of record and keeps running. The first action with production consequences is flipping a schedule in the cutover phase, and that has its own checklist (`reference/astro-deployment.md`) with rollback as step one's mirror.

--- a/skills/migrating-dagster-to-airflow/reference/troubleshooting.md
+++ b/skills/migrating-dagster-to-airflow/reference/troubleshooting.md
@@ -1,0 +1,136 @@
+# Playbook: failure classes and their fixes
+
+Living catalog. Every validation failure that gets diagnosed lands here as a class with its fix, so the next occurrence is a lookup, not an investigation. Entries are added by the migration loop (SKILL.md rule 4) and by eval runs.
+
+Format per entry: symptom (the error or misbehavior as observed), class (what is actually wrong), fix (what to change, in the pattern not the instance), origin (which project/eval surfaced it).
+
+---
+
+## dbt-core unimportable on Astro Runtime (Python 3.14): mashumaro UnserializableField
+
+- **Symptom**: every DAG file touching Cosmos fails DagBag import (and `dbt parse` fails in the container) with `mashumaro.exceptions.UnserializableField: Field "schema" of type Optional[str] in JSONObjectSchema is not serializable`.
+- **Class**: dependency resolution, not migration code. Astro Runtime 3.3-1 ships Python 3.14 (PEP 649 lazy annotations); dbt-core (<= 1.11.x) pins `mashumaro[msgpack]<3.15`, and mashumaro < 3.16 cannot build (de)serializers under Python 3.14.
+- **Fix (pattern)**: version-dependent. Runtime 3.3-1 (pip installer): add `mashumaro==3.17` (any >= 3.16) to `requirements.txt`; pip warns about dbt-core's pin but installs. Runtime **3.3-2+ installs requirements with uv's STRICT resolver**, which refuses the conflicting pin outright (`No solution found when resolving dependencies` at image build) — leave requirements.txt resolvable and force the override post-resolve in the Dockerfile: `USER root` / `RUN uv pip install --system --no-deps 'mashumaro>=3.16'` / `USER astro`. Remove once dbt-core lifts the pin.
+- **Origin**: test migration (`assets_dbt_python`), Runtime 3.3-1; uv-resolver variant from testing (`project_fully_featured`), Runtime 3.3-2.
+
+## Partition-stamped asset events never trigger plain asset-scheduled consumers
+
+- **Symptom**: a DAG with `schedule=[a, b]` / `schedule=(a & b)` downstream of a PARTITIONED producer parses clean, passes structural gates, and never runs; `asset_dag_run_queue` stays empty; no error anywhere.
+- **Class**: Airflow 3.3 asset-trigger semantics. Outlet events of a partitioned DAG run are automatically partition-stamped, and `airflow/assets/manager.py::_queue_dagruns` skips non-partitioned consumer DAGs whenever the event carries a `partition_key` (`if not non_partitioned_dags or partition_key is not None: return None`).
+- **Fix (pattern)**: every asset-scheduled consumer of a partitioned producer uses `PartitionedAssetTimetable(assets=<condition>)` even when the consumer is conceptually non-partitioned. Default `IdentityMapper` fires one consumer run per upstream key once ALL condition members have that key's event (AND respected; re-materialization re-fires). Add a behavioral trigger check to validation (emit upstream events, assert the consumer run appears): no parse-time gate catches this.
+- **Origin**: test migration (`project_fully_featured`), Runtime 3.3-2, hn_tables_updated sensor translation.
+
+## DuckDB (single-writer local warehouse) vs parallel Airflow tasks / Cosmos dbt processes
+
+- **Symptom**: intermittent `IOException: Could not set lock on file "....duckdb": Conflicting lock is held in airflow worker (PID ...)` on tasks that write to a shared DuckDB file; may pass on lucky timing.
+- **Class**: concurrency contract change. Dagster ran sibling asset writes through one process pool where collisions were rare, and dbt was ONE `dbt build` process; Airflow runs sibling tasks in parallel workers and Cosmos runs one dbt process per model, so a single-writer database gets concurrent writers.
+- **Fix (pattern)**: a 1-slot Airflow pool on every task that opens the file — `pool=` on @task, `operator_args={"pool": ...}` on DbtTaskGroup. Declare it in `airflow_settings.yaml` (astro dev applies pools on start) and create the same pool on the Deployment.
+- **Origin**: test migration (`project_fully_featured`), comments/stories view creation race; independently hit and pool-pattern-verified in testing (gauntlet) under parallel asset-triggered DAGs. Applies to any single-writer local store (DuckDB, SQLite); keep connections short-lived (open-write-close per task). Reference home: io-and-data-passing.md, "Single-writer stores under Airflow parallelism".
+
+## `astro dev parse` fails from the CLI's own bundled integrity test on Airflow 3.3
+
+- **Symptom**: `astro dev parse` exits nonzero with `TypeError: DagBag.__init__() got an unexpected keyword argument 'include_examples'` in `.astro/test_dag_integrity_default.py`, regardless of your DAGs.
+- **Class**: tooling incompatibility. Airflow 3.3 removed `include_examples` from `DagBag.__init__`; astro CLI (<= 1.43.1) scaffolds an integrity test that still passes it.
+- **Fix (pattern)**: run Gate 2 via an in-process DagBag inside the container (`DagBag(dag_folder=...)`, no kwargs) or patch `.astro/test_dag_integrity_default.py`. Do not treat the parse failure as a DAG error. validate_dag.py's TypeError fallback already handles the in-process path.
+- **Origin**: test migration (`assets_dbt_python`), astro CLI 1.43.1, Runtime 3.3-1.
+- **Version scope (testing, empirical)**: `astro dev parse` passes cleanly on Runtime 3.3-2 + CLI 1.43.1. The mechanism of the fix was NOT isolated (the CLI version is unchanged and Airflow 3.3 still lacks the kwarg, so presumably the 3.3-2 image or its scaffold handling changed); treat the scope as observed-not-explained, and re-test parse before assuming either behavior on a new Runtime.
+
+## Gate 3 fails with "unexpected" edges on every unit that got a dag_id
+
+- **Symptom**: after planning fills `dag_id` into scanner-produced units, Gate 3 reports the DAG's real task edges as `unexpected` and expects none (or expects scanner dicts like `upstream->io_manager`).
+- **Class**: manifest field collision. `inventory.py` writes SOURCE dependency edges under `edges`; `validate_dag.py` reads the same key as expected TARGET task edges on any unit with a `dag_id`.
+- **Fix (pattern)**: during Phase-2 enrichment, move scanner values to `source_edges` and write planned task edges under `edges` only on the one canonical unit per DAG. Long-term fix belongs in the scripts (rename one side).
+- **Origin**: test migration (gauntlet), 24 spurious unit failures.
+
+## Task crashes on manual runs: missing keyword-only argument 'logical_date'
+
+- **Symptom**: `TypeError: <fn>() missing 1 required keyword-only argument: 'logical_date'` only on `airflow dags trigger` runs; scheduled runs fine.
+- **Class**: Airflow 3 manual runs have `logical_date=None` and the sdk does not inject the context key. Hits the recommended translation of `@schedule`-computed run_config (tick-time date arithmetic in the task) and any tick-derived guard.
+- **Fix (pattern)**: accept `dag_run` instead and derive `tick = dag_run.logical_date or dag_run.run_after`. Apply to every task doing tick arithmetic, not the one that failed.
+- **Origin**: test migration (gauntlet), Runtime 3.3-2 (threshold DAG + am_on_cron guard).
+
+## Backfill refused on DAGs with depends_on_past (self-dependency translation)
+
+- **Symptom**: `airflow backfill create` exits with `InvalidReprocessBehavior: Dag has tasks for which depends_on_past=True...`.
+- **Class**: CLI validation. Any Dagster self-dependency translated to `depends_on_past=True` (partitions.md recipe) hits it on the DAG's first backfill.
+- **Fix (pattern)**: pass `--reprocess-behavior completed` (or `failed`) on every backfill of such DAGs; record it in the unit's runbook line. `--run-backwards` is unsupported for these DAGs.
+- **Origin**: test migration (gauntlet), Airflow 3.3.
+
+## Fresh-venv DagBag load fails: sqlite OperationalError "no such table: dag"
+
+- **Symptom**: `validate_dag.py` (or any in-process `DagBag(dag_folder=...)`) in a clean venv/AIRFLOW_HOME dies with `sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such table: dag` on Airflow 3.3.0.
+- **Class**: environment, not DAG code. DagBag population on 3.3 touches the metadata DB even without `get_dag()`; a fresh AIRFLOW_HOME has no schema.
+- **Fix (pattern)**: run `airflow db migrate` once in the AIRFLOW_HOME used for gates, before any DagBag-based gate. Containers built by `astro dev` already have a migrated DB; this bites only local-venv gate runs.
+- **Origin**: test migration (dagster-open-platform), Airflow 3.3.0 / py3.12 venv.
+
+## Migration input artifact ungenerable from the source repo (public mirror strips content)
+
+- **Symptom**: a translation needs an artifact built FROM the source repo (dbt manifest, connector list, config file) and the repo cannot produce it — e.g. a public mirror strips `models/` so `dbt parse` fails in the SOURCE itself; or component discovery needs live-API credentials that don't exist at migration time.
+- **Class**: blocked-at-source, pre-existing. Not a translation failure; never "fix" it by fabricating placeholder models, mocking discovery, or shipping a conditional factory that silently renders zero DAGs.
+- **Fix (pattern)**: (a) baseline the source failure as Phase-0 evidence; (b) write the COMPLETE translation under a non-parsed directory (e.g. `deferred/<domain>/`) with an activation runbook in the file header (generate artifact in the real repo → move file into `dags/` → run gates); (c) defer the units with the baseline log as the reason; (d) for live-API discovery without creds, ship a PARTIAL static manifest derived from source config, flagged (`tables_complete: false`) plus a committed refresh script, and gate cutover on the first refresh+diff.
+- **Origin**: test migration (dagster-open-platform): stripped dbt models/ (Cosmos blocked) and credential-less Fivetran discovery.
+
+## DuckDB read_only connection refused inside `airflow dags test` (single-process runs)
+
+- **Symptom**: a consumer task fails with `_duckdb.ConnectionException: Can't open a connection to same database file with a different configuration than existing connections` under `airflow dags test`, while the same DAG's writer tasks succeed; real executor runs may not hit it.
+- **Class**: process-sharing artifact. `dags test` runs every task in ONE process; Cosmos LOCAL-mode dbt (dbt-duckdb) leaves a read-write DuckDB handle in that process, so a later task opening the same file with `read_only=True` is a config-mismatch, which DuckDB rejects per process. In production each task is its own process and the mismatch never materializes, so this bites exactly at Gate 4.
+- **Fix (pattern)**: open every DuckDB connection in the shared `include/` IO helper with ONE config (plain `duckdb.connect(path)`, no `read_only`). Cross-process safety comes from the 1-slot pool (see single-writer entries above), not from read-only flags; do not scatter per-task connect calls with differing configs.
+- **Origin**: test migration (`assets_dbt_python`), Runtime 3.3-2, forecast_daily order_forecast_model task.
+
+## Gate 5 checksum mismatch from float summation order (aggregate models)
+
+- **Symptom**: side-by-side/seeded parity shows a handful of tables "MISMATCH" under exact `EXCEPT` comparison while row counts match; diffs are ~1 ulp (e.g. 9.3e-10 on ~6.4e6 SUM() results); affected tables are exactly the ones with float aggregates over aggregates (SUM of SUMs, ratios of SUMs).
+- **Class**: not a migration delta. Floating-point aggregation order differs between one `dbt build` process (Dagster) and per-model dbt invocations (Cosmos), and between parallel hash-aggregate schedules generally; associativity does not hold for float SUM.
+- **Fix (pattern)**: compare float columns with a relative tolerance (rtol 1e-9 catches ulp noise, still fails real logic deltas by many orders of magnitude) and everything else exactly; record which tables passed exact vs tolerance in the parity evidence. Do not chase bit-exactness on float aggregates and do not widen tolerance beyond ~1e-6 without diagnosis.
+- **Origin**: test migration (`assets_dbt_python`), company_perf/top_users, DuckDB 1.5.x both sides.
+
+## macOS local-venv gates: fork-safety SIGABRT (empty import_error table)
+
+- **Symptom**: on a macOS host venv, every DAG shows parse "# Errors 1" with an EMPTY import_error table; scheduler-launched tasks die with empty logs; processes abort with `objc +[NSNumber initialize] ... fork()`.
+- **Class**: macOS Objective-C fork-safety killing the dag-processor's forked children and LocalExecutor workers.
+- **Fix (pattern)**: `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` before any local-venv gate run. Container gates are unaffected.
+- **Origin**: test migration (gauntlet), macOS host.
+
+## Non-default API port: scheduler-run tasks fail `Not Found` with empty logs
+
+- **Symptom**: CLI works (DB-backed) but every scheduler-launched task fails `ServerResponseError: Not Found`, task logs empty, `run_start_date=None`. May also appear to work on ports 8793/8794 (those are the component log servers, whose FastAPI even serves /openapi.json).
+- **Class**: split config. Tasks talk to the Execution API at `AIRFLOW__CORE__EXECUTION_API_SERVER_URL` (default 8080), which does NOT follow `AIRFLOW__API__PORT`.
+- **Fix (pattern)**: set `API__PORT`, `API__BASE_URL`, and `CORE__EXECUTION_API_SERVER_URL` together; never pick 8793/8794. Read "empty task log + Not Found in scheduler log" as this class.
+- **Origin**: test migration (gauntlet), Airflow 3.3 standalone.
+
+## Mapped-task collector: LazyXComSequence cannot be re-pushed to XCom
+
+- **Symptom**: the downstream task aggregating a mapped fan-out (`DynamicOut.collect()` translation) dies with `TypeError: cannot serialize object of type BaseOperatorMeta` when it returns its input.
+- **Class**: mapped results arrive as a lazy `LazyXComSequence`; returning or storing it re-pushes an unserializable proxy.
+- **Fix (pattern)**: materialize before returning: `values = list(values)` at the top of any collector that returns or stores its input.
+- **Origin**: test migration (gauntlet), Airflow 3.3.
+
+## Backfill refused on PartitionedAssetTimetable consumers (non-periodic schedule)
+
+- **Symptom**: `airflow backfill create` on an asset/partition-timetable consumer fails `DagNonPeriodicScheduleException: ... does not support backfills` (before depends_on_past is even considered; the existing --reprocess-behavior entry does not apply here).
+- **Class**: backfills drive time-based schedules only; asset-triggered consumers have no periodic timetable.
+- **Fix (pattern)**: backfill the PRODUCER while the consumer is UNPAUSED; the consumer fires once per upstream key (IdentityMapper), in order under depends_on_past. Verified testing.
+- **Origin**: test migration (gauntlet).
+
+## Backfill against a paused DAG queues runs that never execute
+
+- **Symptom**: backfill runs sit `queued` forever, task instances state-NULL, zero warnings.
+- **Class**: paused DAGs accept but never schedule backfill runs; classic cutover trap (backfilling history before flipping the DAG on).
+- **Fix (pattern)**: unpause first, or check `is_paused` before `backfill create`. "Backfill runs queued + zero TIs started" reads as this class.
+- **Origin**: test migration (gauntlet).
+
+
+## Vendored dbt profiles invalid on modern dbt-snowflake ('schema' is a required property)
+
+- **Symptom**: `dbt build` against the source project's own snowflake profile fails schema validation before connecting: `'schema' is a required property`.
+- **Class**: dbt-snowflake tightened profile validation; older Dagster-era profiles omitted fields that defaulted implicitly.
+- **Fix (pattern)**: generate a fresh profile for the migration (Cosmos ProfileConfig or a written profiles.yml) with database/schema/warehouse explicit, rather than reusing the vendored profile verbatim.
+- **Origin**: test migration (project_fully_featured on real Snowflake), dbt-snowflake current.
+
+
+## dlt filesystem destination fails on a pre-created dataset directory
+
+- **Symptom**: the first dlt pipeline run in the migrated task fails with `FileExistsError` from the filesystem destination's makedirs.
+- **Class**: dlt's filesystem destination creates its dataset directory without exist_ok; scaffolding that pre-creates the output tree (a natural Astro `include/` habit) breaks the first run.
+- **Fix (pattern)**: do not pre-create dlt dataset directories; let dlt own its output tree. If scaffolding must exist, create only the parent.
+- **Origin**: test migration (dbt_duckdb_demo_public), dlt filesystem destination.

--- a/skills/migrating-dagster-to-airflow/reference/validation.md
+++ b/skills/migrating-dagster-to-airflow/reference/validation.md
@@ -1,0 +1,243 @@
+> **STATUS: reviewed; runtime-verified in testing** (Runtime 3.3); gates exercised across the test migrations.
+
+# Validation ladder (Dagster to Airflow 3 on Astro)
+
+How a migrating agent (or human) proves each migrated unit works. The ladder runs cheap-to-expensive: fail fast on the cheapest check, never run an expensive gate before the cheap ones pass. A unit is a translated DAG (asset-DAG, domain DAG, or job-DAG) plus its `include/` helpers.
+
+Two rules govern every gate:
+
+- **Advance only on gate pass.** A unit moves to the next state only when the current gate is green. See the per-unit state machine at the bottom.
+- **Baseline before you migrate.** Run the source project's own tests first and record what already fails (section 0). A gate failure that matches the baseline is not caused by the migration.
+
+---
+
+## 0. Baseline pre-existing failures (before touching anything)
+
+Run the Dagster project's suite and its validate command, capture the output, and store it as the baseline:
+
+```bash
+# in the source Dagster project
+dagster definitions validate 2>&1 | tee baseline/dagster-validate.log
+pytest -q 2>&1 | tee baseline/dagster-pytest.log
+```
+
+Any test or asset already red here is quarantined: list it in the migration report under "pre-existing, not migration-caused" and exclude it from every gate below. This feeds rubric dimension 7 (no test regressions attributable to the migration). Skipping this step means every latent bug in the source gets blamed on the migration.
+
+dagster-dbt projects using `DbtProject(...).prepare_if_dev()` need `DAGSTER_IS_DEV_CLI=1` in the environment (or a pre-run `dbt parse`) or both baseline commands fail with a confusing manifest-not-found ImportError.
+
+---
+
+## Gate 1: Python import + lint (cheapest)
+
+The file is valid Python and passes lint. No Airflow machinery yet.
+
+```bash
+python3 -c "import ast, sys; ast.parse(open(sys.argv[1]).read())" dags/<unit>.py
+ruff check dags/<unit>.py include/
+```
+
+**Pass:** `ast.parse` raises nothing; `ruff check` exits 0. Feeds rubric dimension 2. This is the floor: nothing below it matters if this fails.
+
+Ported source code can violate the target lint even though Dagster shipped it fine. Policy: prefer a behavior-identical fix; when a fix would change semantics, `# noqa` with a comment and keep source behavior. Faithful porting outranks lint aesthetics.
+
+---
+
+## Gate 2: DagBag import check (does Airflow load it?)
+
+A file can be valid Python and still fail to produce a DAG (bad imports, top-level exceptions, duplicate DAG ids). Two equivalent checks; run both, they catch different things.
+
+The `astro dev parse` CLI check (whole project, no running env):
+
+```bash
+astro dev parse
+```
+
+The pytest DagBag snippet. Note the Airflow 3.x import path is `airflow.dag_processing.dagbag`, **not** `airflow.models`:
+
+```python
+import pytest
+from airflow.dag_processing.dagbag import DagBag
+
+@pytest.fixture()
+def dagbag():
+    return DagBag()
+
+def test_no_import_errors(dagbag):
+    assert dagbag.import_errors == {}
+
+def test_dag_present(dagbag):
+    assert dagbag.get_dag(dag_id="<expected_dag_id>") is not None
+```
+
+**Pass:** zero import errors and every expected DAG id resolves. CI helper for a machine-readable list: `airflow dags list-import-errors -o json`. Feeds rubric dimension 2 (threshold 100%).
+
+Known breakage on Runtime 3.3 / astro CLI <= 1.43.1 (playbook entries exist for both): `astro dev parse` fails on the CLI's OWN scaffolded integrity test (`DagBag.__init__() got an unexpected keyword argument 'include_examples'`, removed in Airflow 3.3) regardless of DAG health, and any DagBag call passing `include_examples=` breaks the same way. The Gate 2 source of truth is an in-process `DagBag(dag_folder=...)` (no extra kwargs) inside the scheduler container; treat `astro dev parse` as advisory until the CLI catches up, and patch `.astro/test_dag_integrity_default.py` if it blocks CI.
+
+---
+
+## Gate 3: Structural asserts (does it match the inventory?)
+
+(Canonical attribute spellings for everything asserted here live in the "Runtime-verified spellings" table at the bottom of this file; the snippets below already use them.)
+
+The DAG loads, but does its shape match what the inventory manifest says it should be? Assert task count, dependency edges, schedule string, and asset outlets against the manifest emitted by the inventory scanner. This is where rubric dimension 3 (structural equivalence) is proven per unit.
+
+```python
+import json, pytest
+from airflow.dag_processing.dagbag import DagBag
+
+MANIFEST = json.load(open("include/inventory/manifest.json"))
+
+@pytest.fixture()
+def dagbag():
+    return DagBag()
+
+def test_structure_matches_manifest(dagbag):
+    spec = MANIFEST["units"]["<unit_id>"]
+    # dagbag.dags (in-memory dict), NOT get_dag(): get_dag() reads SERIALIZED
+    # DAGs from the metadata DB. Note Gate 3 needs a migrated AIRFLOW_HOME
+    # either way (run `airflow db migrate` first in bare envs); astro-dev
+    # containers ship one. See the playbook's metadata-DB entry.
+    dag = dagbag.dags[spec["dag_id"]]
+
+    # task count
+    assert len(dag.tasks) == spec["task_count"]
+
+    # dependency edges (each edge is [upstream_task_id, downstream_task_id])
+    edges = {(t.task_id, d) for t in dag.tasks for d in t.downstream_task_ids}
+    assert edges == {tuple(e) for e in spec["edges"]}
+
+    # schedule. Three expectation forms, matching validate_dag.py:
+    #   spec["schedule"]       cron/string forms; dag.schedule round-trips '@daily'
+    #   spec["asset_schedule"] asset-driven DAGs; each URI/name must appear in the condition
+    #   spec["timetable_type"] partition timetables; class-name substring
+    # (schedule_interval is removed; sdk timetables have no .summary. Eval-1 probe.)
+    if "schedule" in spec:
+        assert dag.schedule == spec["schedule"]
+    if "asset_schedule" in spec:
+        cond = repr(dag.schedule) + repr(dag.timetable)
+        assert all(a in cond for a in spec["asset_schedule"])
+    if "timetable_type" in spec:
+        assert spec["timetable_type"] in type(dag.timetable).__name__
+
+    # asset outlets produced by this DAG's tasks. Assert PYTHON tasks only:
+    # Cosmos dbt tasks have empty outlets at parse time (assets are registered
+    # at execution via AssetAlias); see dbt.md.
+    outlets = {a.uri for t in dag.tasks for a in getattr(t, "outlets", [])}
+    assert outlets == set(spec["asset_outlets"])
+```
+
+**Pass:** every assert green. A mismatch is either a translation bug or an intentional boundary choice (an edge became a cross-DAG asset schedule instead of a task edge); the latter must be reflected in the manifest and noted in the report, not silently asserted away. Cross-DAG asset-schedule edges are verified by inspecting `dag.timetable` / the asset conditions, not `downstream_task_ids`.
+
+---
+
+## Gate 4: Single-DAG execution (does it run?)
+
+Execute the unit end-to-end against dev fixtures. Four ways, roughly cheapest-first:
+
+```python
+# in-file, fastest: append to the DAG module and run it directly
+if __name__ == "__main__":
+    dag.test()          # single serialized process; supports use_executor=True
+```
+
+```bash
+airflow dags test <dag_id> [logical_date]     # CLI, same single-process engine
+astro dev pytest                              # runs the tests/ suite in the Astro env
+astro run <dag_id>                            # single DAG in one worker container
+```
+
+**Pass:** the run completes with all tasks in `success`. Feeds rubric dimension 5 (every generated DAG test-runs clean). For a partitioned unit, run at least one concrete `partition_key` and confirm the task read `dag_run.partition_key` as expected. Note: `partition_key` is None under `dags test`; the local way to exercise a concrete partition is `airflow backfill create --from-date D --to-date D` (see partitions.md).
+
+**Fused-pipeline pass (single-writer stores).** Per-stage Gate 4 green does not imply the FUSED pipeline is green: standalone DAGs each own their process, so read_only/single-writer conflicts (DuckDB) only surface when the full pipeline runs in one `dags test` process (verified in testing). Before the fused-DAG gate, de-flag read_only on single-writer helper connections and apply the pool pattern, then run the fused DAG explicitly.
+
+**Behavioral trigger check (asset-scheduled DAGs, mandatory when any upstream is partitioned).** `dags test` proves the DAG runs when forced; it does NOT prove the schedule ever fires. A boolean asset schedule downstream of a partitioned producer silently never triggers on Airflow 3.3 (verified in testing). So for every asset-scheduled DAG: materialize one upstream for real (backfill one partition or POST an asset event) and verify a downstream run is actually created before marking the unit complete.
+
+Local-venv gate runs have two environment traps with playbook entries (macOS fork-safety SIGABRT needing `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`, and the split API-port config where `CORE__EXECUTION_API_SERVER_URL` does not follow `API__PORT`); check the playbook before debugging empty task logs.
+
+Fresh-container caveats for `astro dev pytest` (verified in testing): Cosmos's dbt-ls cache reads Airflow Variables at parse time and dies in a fresh container (`no such table: variable`); set `AIRFLOW__COSMOS__ENABLE_CACHE=False` in `.env` for test runs. And use `dagbag.dags[...]`, never `get_dag()` (DB-backed).
+
+---
+
+## Gate 5: Data parity side-by-side (does it produce the same data?)
+
+The strongest gate: run Airflow and the still-running Dagster instance over the **same logical window**, then compare outputs. This is the ground-truth backbone, deterministic and independent of the migration itself.
+
+1. Pick a window with known Dagster output. Do NOT assume `MaterializeResult` metadata carries fixtures: real projects often record no row counts or checksums (some deliberately removed them for performance). Default to recomputing expected values from the Dagster-produced output itself; use recorded metadata opportunistically when it exists.
+2. Run the Airflow unit over the identical window (`airflow dags test <dag_id> <logical_date>`, or a concrete `partition_key`).
+3. Compare per output table/file:
+
+```bash
+# row count parity
+dagster_rows=$(psql -tA -c "select count(*) from <table> where <window-filter>")
+airflow_rows=$(psql -tA -c "select count(*) from <table> where <window-filter>")
+[ "$dagster_rows" = "$airflow_rows" ] || echo "ROW COUNT MISMATCH"
+
+# content parity: order-independent checksum of the window
+md5 <(psql -tA -c "select * from <table> where <window-filter> order by 1")
+```
+
+**Pass:** row counts equal and checksums match on every comparable output. Feeds rubric dimension 5 (parity). Float-tolerance policy (testing finding): exact checksums apply to counts, keys, strings, and integer columns; float columns computed through different summation orders can differ by 1 ulp, so compare numeric frames with a tight relative tolerance (rtol 1e-9) and record in the report which tables passed exact vs tolerance, with the rtol used. A tolerance wider than 1e-6 is not parity; investigate instead. Where side-by-side is infeasible (external services, non-deterministic outputs), substitute mocked-run assertions and say so explicitly in the report; do not claim parity you did not measure.
+
+**Incremental / overlapping-window variant.** Incremental-merge models with padded windows (e.g. dbt vars spanning `start - 3h` to `end + 1d`) have no discrete partition column, and adjacent windows overlap, so per-window row counts double-count boundary rows. For these: run a bounded backfill over a fixed range in BOTH systems, then compare a full-table ordered checksum plus total count. The same applies to Gate 6 below (there is no `where partition=<key>` column to filter on; use the full-table comparison after re-running the same range).
+
+**Cross-engine canonicalization (verified in testing).** Byte checksums do not transfer across engines (numpy array vs JSON VARCHAR, TIMESTAMPTZ vs NTZ): compare within one engine where possible (both schemas checksummed by the same in-warehouse SQL), and across engines canonicalize first (stable column order, id-sorted rows, normalized timestamps/nulls) in one shared pandas routine, documenting the exact method beside the numbers.
+
+**Seeded-inputs stage parity variant (nondeterministic sources).** When source assets are unseeded generators or live-API reads, same-window reruns can never match, but full mock-out is unnecessarily weak. The recipe that works (verified in testing): snapshot the Dagster-produced storage; seed the Airflow side with the identical raw inputs; re-run everything DOWNSTREAM of the source assets task-by-task (`airflow tasks test <dag> <task>` skips the source-regeneration tasks); checksum-compare all downstream outputs. Parity then covers every transformation while exempting only the genuinely nondeterministic sources, which the report lists explicitly.
+
+---
+
+## Gate 6: Idempotency re-run (partitioned producers only)
+
+A partitioned producer must be safe to re-run: a second run over the same partition must leave the output identical, not doubled. The Dagster IO manager often provided delete-then-insert partition overwrite for free; the translated task must reimplement it (see mapping.md section 3).
+
+```bash
+# run the same partition twice, expect identical output
+airflow dags test <dag_id> <logical_date>   # or the concrete partition_key
+rows_after_first=$(psql -tA -c "select count(*) from <table> where partition=<key>")
+airflow dags test <dag_id> <logical_date>
+rows_after_second=$(psql -tA -c "select count(*) from <table> where partition=<key>")
+[ "$rows_after_first" = "$rows_after_second" ] || echo "NOT IDEMPOTENT: rows changed on re-run"
+```
+
+**Pass:** row count and checksum are unchanged after the second run, AND the FULL-TABLE checksum equals the pre-re-run baseline. The second condition is load-bearing (verified in testing): a non-disjoint window predicate deletes a NEIGHBOR partition's boundary row on re-run, after which first==second compares clean while data is lost. Baseline the whole table before the re-run; a doubling means the overwrite contract was dropped, a shrink means the windows overlap. Fix the task, do not relax the gate.
+
+---
+
+## Per-unit state machine
+
+Each unit walks these states. It advances only when the named gate passes:
+
+```
+Translate  ->  Fix-Import  ->  Fix-Lint  ->  Fix-Tests  ->  Verify-Parity  ->  Complete
+              (Gate 2)       (Gate 1)      (Gates 3,4)     (Gates 5,6)
+```
+
+(Gate 1 lint and Gate 2 import are cheap enough to run together at the top; the state names follow the Airbnb per-file machine. Order the actual gate runs cheapest-first: 1, 2, 3, 4, 5, 6.)
+
+Track state per unit (a JSON status file or an in-band comment block) so runs are resumable and selective re-runs target only the failed state.
+
+### Retry-with-latest-error loop
+
+At any gate, on failure: feed the **latest** error text back to the translator and retry the same unit. This brute-force loop (retry with the last validation error in context) beats prompt engineering; most units pass in under 10 attempts, with a tail of 50 to 100. Cap attempts (suggested 15), then escalate rather than grind.
+
+### On persistent failure at any gate
+
+When a unit will not pass after the retry cap:
+
+- **Mark it `deferred` with a concrete reason** in the migration report (which gate, the failing assertion or error, what a human needs to resolve it). A deferred item with a reason is honest and passes the completeness gate; a silently omitted item is an automatic run failure (rubric dimension 1).
+- **Never stub to fake a pass.** A task body that returns success without doing the work fails rubric dimension 6 automatically. Borrowing Bun's reviewer rule: if a workaround needs a paragraph of justification, it is wrong.
+- **Fix the class, not the instance.** If several units fail the same way, record the pattern in `troubleshooting.md` and re-sweep, rather than hand-patching each unit.
+
+---
+
+## Runtime-verified spellings (settled by testing, Runtime 3.3-1 / Airflow 3.3.0)
+
+Full probe transcript: `example-migrations/assets-dbt-python/runtime-probes.md`.
+
+- `dag.schedule_interval` is **removed** (attribute and argument), confirmed at runtime.
+- **`dag.timetable.summary` does NOT exist** on `airflow.sdk` timetables; the Gate 3 snippet above must assert on **`dag.schedule`**, which exists on sdk DAGs and round-trips the authored value (`'@daily'`, asset list, timetable object). `validate_dag.py` probes `schedule` first for this reason.
+- Timetable classes: cron -> `airflow.sdk...trigger.CronTriggerTimetable`; `schedule=[asset]` -> `airflow.sdk...assets.AssetTriggeredTimetable` with `asset_condition=AssetAll(...)` (list = AND); `(a | b)` -> `AssetAny(...)`.
+- `downstream_task_ids`, `task.outlets`, `Asset.name`, `Asset.uri` all exist with those spellings on `airflow.sdk` objects.
+- **URI normalization trap**: a host-only URI (`scheme://one_part`) is stored with a trailing slash (`'dagster://order_forecast_model/'`); assert against the normalized form.
+- `DagBag.__init__` no longer accepts `include_examples` (Airflow 3.3); `astro dev parse` on CLI <= 1.43.1 fails on its own scaffolded integrity test because of this (see troubleshooting.md). The import path `airflow.dag_processing.dagbag` is confirmed.
+- Partitions: `dag_run.partition_key` is a plain string in the timetable's `key_format` (default `'%Y-%m-%dT%H:%M:%S'`, e.g. `'2026-07-07T00:00:00'` — NOT Dagster's `'2026-07-07'`); it is **None on `airflow dags test` / manual runs**. To execute one concrete partition locally (Gate 4), use `airflow backfill create --from-date D --to-date D`; `dags test`/`trigger` have no partition-key flag. `PartitionedAtRuntime` and the full mapper/window surface import from `airflow.sdk` (lazily; not in `dir()`).

--- a/skills/migrating-dagster-to-airflow/scripts/inventory.py
+++ b/skills/migrating-dagster-to-airflow/scripts/inventory.py
@@ -78,8 +78,13 @@ DEPRECATED_SYMBOLS = {
 # class names are stable API (they do not rotate like the full symbol surface),
 # so this small set is safe to keep; transitive subclasses resolve via the
 # package-wide inheritance map.
-IO_MANAGER_BASES = {"IOManager", "ConfigurableIOManager", "ConfigurableIOManagerFactory",
-                    "UPathIOManager", "InputManager"}
+IO_MANAGER_BASES = {
+    "IOManager",
+    "ConfigurableIOManager",
+    "ConfigurableIOManagerFactory",
+    "UPathIOManager",
+    "InputManager",
+}
 RESOURCE_BASES = {"ConfigurableResource", "ConfigurableResourceFactory"}
 
 # Library builder helpers recorded even inside a factory body (every other call
@@ -93,9 +98,15 @@ FACTORY_HELPER_SYMBOLS = {"make_slack_on_run_failure_sensor", "make_values_resou
 # names do not rotate, and excluding them keeps the import-based net from
 # recording `logger = get_dagster_logger()` and friends as phantom units.
 DAGSTER_NON_DEFINITIONS = {
-    "get_dagster_logger", "get_current_context", "build_op_context",
-    "build_asset_context", "build_resources", "build_init_resource_context",
-    "materialize", "materialize_to_memory", "instance_for_test",
+    "get_dagster_logger",
+    "get_current_context",
+    "build_op_context",
+    "build_asset_context",
+    "build_resources",
+    "build_init_resource_context",
+    "materialize",
+    "materialize_to_memory",
+    "instance_for_test",
 }
 
 _DEFAULT_IO_MANAGER_KEY = "io_manager"  # Dagster's default IO manager resource key
@@ -111,6 +122,7 @@ LEGEND = {
 
 
 # ---------------------------------------------------------------- AST helpers
+
 
 def _callee_name(node):
     """Bare symbol name of a decorator or call target, or None."""
@@ -231,9 +243,11 @@ def _record_name(node, kind, fallback):
 
 # --------------------------------------------------- dagster import resolution
 
+
 def _is_dagster_module(mod):
-    return bool(mod) and (mod == "dagster" or mod.startswith("dagster.")
-                          or mod.startswith("dagster_"))
+    return bool(mod) and (
+        mod == "dagster" or mod.startswith("dagster.") or mod.startswith("dagster_")
+    )
 
 
 def _resolve_dagster_symbol(func_node, mod_aliases, sym_imports):
@@ -249,16 +263,17 @@ def _resolve_dagster_symbol(func_node, mod_aliases, sym_imports):
         n = n.value
     if not isinstance(n, ast.Name):
         return None
-    origin = sym_imports.get(n.id)          # from dagster[_x] import SYM [as n]
+    origin = sym_imports.get(n.id)  # from dagster[_x] import SYM [as n]
     if origin and _is_dagster_module(origin[0]):
-        return origin[1]                    # ignore builder attrs after the symbol
-    mod = mod_aliases.get(n.id)             # import dagster[_x] [as n]
+        return origin[1]  # ignore builder attrs after the symbol
+    mod = mod_aliases.get(n.id)  # import dagster[_x] [as n]
     if mod and _is_dagster_module(mod):
         return attrs[-1] if attrs else None
     return None
 
 
 # --------------------------------------------------------------- coarse family
+
 
 def _coarse_family(kind):
     """Group a raw dagster symbol name into a stable structural family for merge
@@ -310,6 +325,7 @@ def _resolves_to(class_name, targets, imap, seen=None):
 
 # --------------------------------------------------------------- static scanner
 
+
 def _tag_assignments(tree):
     for stmt in ast.walk(tree):
         if isinstance(stmt, ast.Assign) and isinstance(stmt.value, ast.Call):
@@ -321,8 +337,11 @@ def _tag_dict_keys(tree):
     for node in ast.walk(tree):
         if isinstance(node, ast.Dict):
             for k, v in zip(node.keys, node.values):
-                if (isinstance(k, ast.Constant) and isinstance(k.value, str)
-                        and isinstance(v, ast.Call)):
+                if (
+                    isinstance(k, ast.Constant)
+                    and isinstance(k.value, str)
+                    and isinstance(v, ast.Call)
+                ):
                     v._dagster_dict_key = k.value
 
 
@@ -344,8 +363,8 @@ class Scanner(ast.NodeVisitor):
         self.source = source
         self.records = []
         self.imap = imap or {}
-        self.mod_aliases = {}   # local alias -> module (import X as Y)
-        self.sym_imports = {}   # local name -> (module, symbol) (from X import S)
+        self.mod_aliases = {}  # local alias -> module (import X as Y)
+        self.sym_imports = {}  # local name -> (module, symbol) (from X import S)
         self._factory_stack = []
         self._cond_stack = []
 
@@ -402,8 +421,14 @@ class Scanner(ast.NodeVisitor):
                 continue
             kwargs = _kwargs_present(dec) if isinstance(dec, ast.Call) else {}
             extra = self._asset_extra(kind, kwargs, func_node=node)
-            self._add(kind, _declared_name(kwargs, dec, kind, node.name),
-                      dec, kwargs, extra, deprecated=dep)
+            self._add(
+                kind,
+                _declared_name(kwargs, dec, kind, node.name),
+                dec,
+                kwargs,
+                extra,
+                deprecated=dep,
+            )
         # descend into the body: factories define decorated defs (and call builder
         # helpers) inside a function; tag records with the enclosing function.
         self._factory_stack.append(node.name)
@@ -418,11 +443,19 @@ class Scanner(ast.NodeVisitor):
         """Custom IO managers / resources defined as subclasses (transitive)."""
         direct = [_callee_name(b) for b in node.bases]
         if _resolves_to(node.name, IO_MANAGER_BASES, self.imap):
-            self._add("io_manager", node.name, node,
-                      extra={"subclass_of": next((b for b in direct if b), None)})
+            self._add(
+                "io_manager",
+                node.name,
+                node,
+                extra={"subclass_of": next((b for b in direct if b), None)},
+            )
         elif _resolves_to(node.name, RESOURCE_BASES, self.imap):
-            self._add("resource", node.name, node,
-                      extra={"subclass_of": next((b for b in direct if b), None)})
+            self._add(
+                "resource",
+                node.name,
+                node,
+                extra={"subclass_of": next((b for b in direct if b), None)},
+            )
         # class bodies hold fields/methods (EnvVar defaults etc.), not definitions
 
     def visit_Call(self, node):
@@ -486,7 +519,9 @@ class Scanner(ast.NodeVisitor):
             edges.append({"upstream_ins": ins, "io_manager": None})
         if not deps and not ins and func_node is not None:
             for pname in _signature_deps(func_node):
-                edges.append({"upstream": pname, "io_manager": None, "from": "signature"})
+                edges.append(
+                    {"upstream": pname, "io_manager": None, "from": "signature"}
+                )
         if edges:
             extra["source_edges"] = edges
         outputs = _multi_asset_outputs(kwargs)
@@ -501,10 +536,19 @@ def scan_python_file(path, root, imap=None):
         source = path.read_text(encoding="utf-8")
         tree = ast.parse(source, filename=str(path))
     except (SyntaxError, UnicodeDecodeError) as exc:
-        return [{"kind": "parse_error", "name": path.name, "location": f"{rel}:0",
-                 "params": {"error": str(exc)}, "spelling": "unknown",
-                 "classification": "pending", "note": "file did not parse; inspect manually",
-                 "source_edges": [], "status": "pending"}]
+        return [
+            {
+                "kind": "parse_error",
+                "name": path.name,
+                "location": f"{rel}:0",
+                "params": {"error": str(exc)},
+                "spelling": "unknown",
+                "classification": "pending",
+                "note": "file did not parse; inspect manually",
+                "source_edges": [],
+                "status": "pending",
+            }
+        ]
     _tag_assignments(tree)
     _tag_dict_keys(tree)
     _tag_nested_calls(tree)
@@ -517,12 +561,23 @@ def scan_python_file(path, root, imap=None):
 # --------------------------------------------------- structural text tells
 
 TEXT_PATTERNS = [
-    (re.compile(r"DAGSTER_CLOUD_(?:IS_BRANCH_DEPLOYMENT|PULL_REQUEST_ID|DEPLOYMENT_NAME)"),
-     "branch_env_ref", "branch-deploy env var IN CODE (DB naming/URLs); find and rewrite for Astro"),
-    (re.compile(r"dagster-k8s/config"),
-     "k8s_config_tag", "per-job pod resources; map to per-task executor_config / pod_override"),
-    (re.compile(r"dagster/concurrency_key"),
-     "concurrency_tag", "tag-based op concurrency; map to Airflow Pools"),
+    (
+        re.compile(
+            r"DAGSTER_CLOUD_(?:IS_BRANCH_DEPLOYMENT|PULL_REQUEST_ID|DEPLOYMENT_NAME)"
+        ),
+        "branch_env_ref",
+        "branch-deploy env var IN CODE (DB naming/URLs); find and rewrite for Astro",
+    ),
+    (
+        re.compile(r"dagster-k8s/config"),
+        "k8s_config_tag",
+        "per-job pod resources; map to per-task executor_config / pod_override",
+    ),
+    (
+        re.compile(r"dagster/concurrency_key"),
+        "concurrency_tag",
+        "tag-based op concurrency; map to Airflow Pools",
+    ),
 ]
 
 
@@ -534,11 +589,19 @@ def text_findings(source, rel, records):
             if not match or (kind, match.group(0)) in seen:
                 continue
             seen.add((kind, match.group(0)))
-            records.append({
-                "kind": kind, "name": match.group(0), "location": f"{rel}:{line_no}",
-                "params": {}, "spelling": "current", "classification": "pending",
-                "note": note, "source_edges": [], "status": "pending",
-            })
+            records.append(
+                {
+                    "kind": kind,
+                    "name": match.group(0),
+                    "location": f"{rel}:{line_no}",
+                    "params": {},
+                    "spelling": "current",
+                    "classification": "pending",
+                    "note": note,
+                    "source_edges": [],
+                    "status": "pending",
+                }
+            )
 
 
 def _split_yaml_docs(text):
@@ -546,14 +609,14 @@ def _split_yaml_docs(text):
     docs, cur, start = [], [], 1
     for i, line in enumerate(text.splitlines(), start=1):
         if re.match(r"^---(\s|$)", line):
-            if any(l.strip() for l in cur):
+            if any(ln.strip() for ln in cur):
                 docs.append(("\n".join(cur), start))
             cur, start = [], i + 1
         else:
             if not cur:
                 start = i
             cur.append(line)
-    if any(l.strip() for l in cur):
+    if any(ln.strip() for ln in cur):
         docs.append(("\n".join(cur), start))
     return docs
 
@@ -583,6 +646,7 @@ def _parse_component_doc(doc_text):
     type_val, attributes = None, None
     try:
         import yaml  # optional; the scanner must run without it
+
         data = yaml.safe_load(doc_text)
         if isinstance(data, dict):
             type_val, attributes = data.get("type"), data.get("attributes")
@@ -608,17 +672,24 @@ def scan_component_yaml(path, root):
         params = {"type": type_val}
         if attributes is not None:
             params["attributes"] = attributes
-        records.append({
-            "kind": "component_instance", "name": type_val,
-            "location": f"{rel}:{start_line}", "params": params, "spelling": "current",
-            "classification": "pending",
-            "note": "unwrap YAML to the integration's mapping row; custom Component subclass ports build_defs output",
-            "source_edges": [], "status": "pending",
-        })
+        records.append(
+            {
+                "kind": "component_instance",
+                "name": type_val,
+                "location": f"{rel}:{start_line}",
+                "params": params,
+                "spelling": "current",
+                "classification": "pending",
+                "note": "unwrap YAML to the integration's mapping row; custom Component subclass ports build_defs output",
+                "source_edges": [],
+                "status": "pending",
+            }
+        )
     return records
 
 
 # --------------------------------------------------------- file discovery
+
 
 def _is_test_path(rel):
     """A test file or a file under a test package (relative to the project root)."""
@@ -626,11 +697,16 @@ def _is_test_path(rel):
         if part == "tests" or part.endswith("_tests") or part.startswith("test_"):
             return True
     name = rel.name
-    return name.startswith("test_") or name.endswith("_test.py") or name == "conftest.py"
+    return (
+        name.startswith("test_") or name.endswith("_test.py") or name == "conftest.py"
+    )
 
 
 def _skip_dir(path):
-    return any(p in (".venv", "venv", "__pycache__", ".tox", "node_modules") for p in path.parts)
+    return any(
+        p in (".venv", "venv", "__pycache__", ".tox", "node_modules")
+        for p in path.parts
+    )
 
 
 def _scannable_files(root):
@@ -657,7 +733,9 @@ def _build_inheritance_map(files):
             continue
         for node in ast.walk(tree):
             if isinstance(node, ast.ClassDef):
-                imap[node.name] = [b for b in (_callee_name(base) for base in node.bases) if b]
+                imap[node.name] = [
+                    b for b in (_callee_name(base) for base in node.bases) if b
+                ]
     return imap
 
 
@@ -675,7 +753,8 @@ def run_static(root):
 # Cross-domain dbt-manifest coupling (load-time). Hits OUTSIDE the dbt domain
 # dictate migration order (dbt first, or those edges get deferred).
 DBT_COUPLING_PATTERN = re.compile(
-    r"\b(get_asset_key_for_model|dbt_asset_key|DbtManifestAssetSelection)\b")
+    r"\b(get_asset_key_for_model|dbt_asset_key|DbtManifestAssetSelection)\b"
+)
 
 
 def _is_dbt_domain(path):
@@ -699,6 +778,7 @@ def _dbt_coupling_scan(root):
 
 # ------------------------------------------------------- runtime (primary)
 
+
 def run_runtime(root):
     """Import the project and enumerate resolved Definitions. Returns
     (records, error); on any failure returns ([], reason)."""
@@ -712,13 +792,17 @@ def run_runtime(root):
     except Exception as exc:
         return [], f"dagster not importable in this interpreter: {exc}"
     if not module_name:
-        return [], ("could not locate a Definitions entrypoint module "
-                    "(checked dagster_cloud.yaml, workspace.yaml, pyproject, definitions.py)")
+        return [], (
+            "could not locate a Definitions entrypoint module "
+            "(checked dagster_cloud.yaml, workspace.yaml, pyproject, definitions.py)"
+        )
     try:
         mod = importlib.import_module(module_name)
     except Exception as exc:
         return [], f"import of {module_name} failed: {exc}"
-    defs = next((a for a in vars(mod).values() if type(a).__name__ == "Definitions"), None)
+    defs = next(
+        (a for a in vars(mod).values() if type(a).__name__ == "Definitions"), None
+    )
     if defs is None:
         return [], f"no Definitions object found in {module_name}"
     records = []
@@ -762,7 +846,10 @@ def _resolve_entrypoint(root):
 def _discover_module(root):
     pyproject = root / "pyproject.toml"
     if pyproject.exists():
-        m = re.search(r"root_module\s*=\s*[\"']([^\"']+)[\"']", pyproject.read_text(encoding="utf-8"))
+        m = re.search(
+            r"root_module\s*=\s*[\"']([^\"']+)[\"']",
+            pyproject.read_text(encoding="utf-8"),
+        )
         if m:
             return m.group(1) + ".definitions"
     for candidate in root.rglob("definitions.py"):
@@ -786,13 +873,19 @@ def _runtime_obj_name(obj):
 
 def _runtime_check_pairs(obj):
     """(check_name, normalized_asset_key) per check in an AssetChecksDefinition."""
-    items = list(getattr(obj, "check_specs", None) or getattr(obj, "check_keys", None) or [])
+    items = list(
+        getattr(obj, "check_specs", None) or getattr(obj, "check_keys", None) or []
+    )
     pairs = []
     for it in items:
         cname = getattr(it, "name", None)
         akey = getattr(it, "asset_key", None)
-        pairs.append((str(cname).strip() if cname else None,
-                      _normalize_name(str(akey)) if akey is not None else None))
+        pairs.append(
+            (
+                str(cname).strip() if cname else None,
+                _normalize_name(str(akey)) if akey is not None else None,
+            )
+        )
     return pairs
 
 
@@ -800,12 +893,22 @@ def _enumerate(defs, module_name, records):
     """Enumerate resolved objects via dagster's public APIs. Captures structural
     facts (deps, partitions/automation presence, io_manager_key); classification
     stays pending for the agent."""
+
     def emit(kind, name, params=None):
-        records.append({
-            "kind": kind, "name": str(name).strip(), "location": f"{module_name} (runtime)",
-            "params": params or {}, "spelling": "current", "classification": "pending",
-            "note": "", "source_edges": [], "status": "pending", "source": "runtime",
-        })
+        records.append(
+            {
+                "kind": kind,
+                "name": str(name).strip(),
+                "location": f"{module_name} (runtime)",
+                "params": params or {},
+                "spelling": "current",
+                "classification": "pending",
+                "note": "",
+                "source_edges": [],
+                "status": "pending",
+                "source": "runtime",
+            }
+        )
 
     try:
         for spec in defs.resolve_all_asset_specs():
@@ -841,10 +944,16 @@ def _enumerate(defs, module_name, records):
                 io_key = io_by_out.get(out_name)
                 rec = by_name.get(str(akey))
                 if rec is not None and io_key and io_key != "io_manager":
-                    rec.setdefault("params", {}).setdefault("io_manager_key", str(io_key))
+                    rec.setdefault("params", {}).setdefault(
+                        "io_manager_key", str(io_key)
+                    )
     except Exception:
         pass
-    for attr, kind in (("jobs", "job"), ("schedules", "schedule"), ("sensors", "sensor")):
+    for attr, kind in (
+        ("jobs", "job"),
+        ("schedules", "schedule"),
+        ("sensors", "sensor"),
+    ):
         try:
             for obj in getattr(defs, attr, None) or []:
                 params = {}
@@ -859,20 +968,24 @@ def _enumerate(defs, module_name, records):
             pairs = _runtime_check_pairs(obj)
             if pairs:
                 for cname, akey in pairs:
-                    emit("asset_check", cname or _runtime_obj_name(obj),
-                         {"asset": akey} if akey else None)
+                    emit(
+                        "asset_check",
+                        cname or _runtime_obj_name(obj),
+                        {"asset": akey} if akey else None,
+                    )
             else:
                 emit("asset_check", _runtime_obj_name(obj))
     except Exception:
         pass
     try:
-        for key in (defs.resources or {}):
+        for key in defs.resources or {}:
             emit("resource", key)
     except Exception:
         pass
 
 
 # ---------------------------------------------------------- manifest assembly
+
 
 def _best_static_match(candidates, rt):
     """Which static record a runtime record aligns with; disambiguate checks by
@@ -881,7 +994,9 @@ def _best_static_match(candidates, rt):
     if rt_asset:
         for c in candidates:
             c_asset = (c.get("params") or {}).get("asset")
-            if c_asset is not None and _normalize_name(c_asset) == _normalize_name(rt_asset):
+            if c_asset is not None and _normalize_name(c_asset) == _normalize_name(
+                rt_asset
+            ):
                 return c
     for c in candidates:
         if c["kind"] == rt["kind"]:
@@ -897,7 +1012,9 @@ def _merge_runtime_first(runtime_records, static_records):
     `not_in_runtime` so the completeness net never drops them."""
     index = {}
     for s in static_records:
-        index.setdefault((_coarse_family(s["kind"]), _normalize_name(s["name"])), []).append(s)
+        index.setdefault(
+            (_coarse_family(s["kind"]), _normalize_name(s["name"])), []
+        ).append(s)
     used = set()
     combined = []
     for rt in runtime_records:
@@ -907,8 +1024,14 @@ def _merge_runtime_first(runtime_records, static_records):
         if cands:
             s = _best_static_match(cands, rt)
             used.add(id(s))
-            for f in ("source_edges", "spelling", "conditional", "factory",
-                      "deprecated_reason", "outputs"):
+            for f in (
+                "source_edges",
+                "spelling",
+                "conditional",
+                "factory",
+                "deprecated_reason",
+                "outputs",
+            ):
                 if s.get(f) and not rt.get(f):
                     rt[f] = s[f]
             rt["static_location"] = s.get("location")
@@ -939,9 +1062,11 @@ def _resolve_edge_io_managers(records):
     for r in records:
         consumer_key = (r.get("params") or {}).get("io_manager_key")
         for edge in r.get("source_edges", []):
-            keys = [producer[_normalize_name(n)] or _DEFAULT_IO_MANAGER_KEY
-                    for n in _edge_upstream_names(edge)
-                    if _normalize_name(n) in producer]
+            keys = [
+                producer[_normalize_name(n)] or _DEFAULT_IO_MANAGER_KEY
+                for n in _edge_upstream_names(edge)
+                if _normalize_name(n) in producer
+            ]
             edge["consumer_io_manager"] = consumer_key
             if keys:
                 uniq = sorted(set(keys))
@@ -974,7 +1099,7 @@ def build_manifest(root, use_runtime):
     counts = {}
     for rec in records:
         counts[rec["kind"]] = counts.get(rec["kind"], 0) + 1
-    manifest["counts"] = counts          # counts per KIND (classification is pending)
+    manifest["counts"] = counts  # counts per KIND (classification is pending)
     manifest["total"] = len(records)
     manifest["dbt_manifest_coupling"] = _dbt_coupling_scan(root)
 
@@ -994,11 +1119,23 @@ def build_manifest(root, use_runtime):
 
 
 def main(argv=None):
-    parser = argparse.ArgumentParser(description="Read-only Dagster project inventory scanner.")
-    parser.add_argument("project_root", type=Path, help="path to the Dagster project root")
-    parser.add_argument("--runtime", action="store_true",
-                        help="runtime-first: import the project and enumerate Definitions")
-    parser.add_argument("--out", type=Path, default=None, help="write manifest JSON here (default: stdout)")
+    parser = argparse.ArgumentParser(
+        description="Read-only Dagster project inventory scanner."
+    )
+    parser.add_argument(
+        "project_root", type=Path, help="path to the Dagster project root"
+    )
+    parser.add_argument(
+        "--runtime",
+        action="store_true",
+        help="runtime-first: import the project and enumerate Definitions",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="write manifest JSON here (default: stdout)",
+    )
     args = parser.parse_args(argv)
 
     root = args.project_root.resolve()
@@ -1014,8 +1151,12 @@ def main(argv=None):
             "    runtime inventory). Runtime mode imports the project in THIS\n"
             "    interpreter, so run the scanner with the project's own venv python:\n"
             "      <project-venv>/bin/python scripts/inventory.py "
-            + str(args.project_root) + " --runtime\n"
-            "      uv run python scripts/inventory.py " + str(args.project_root) + " --runtime\n\n")
+            + str(args.project_root)
+            + " --runtime\n"
+            "      uv run python scripts/inventory.py "
+            + str(args.project_root)
+            + " --runtime\n\n"
+        )
 
     text = json.dumps(manifest, indent=2, default=str)
     if args.out:

--- a/skills/migrating-dagster-to-airflow/scripts/inventory.py
+++ b/skills/migrating-dagster-to-airflow/scripts/inventory.py
@@ -1,0 +1,1029 @@
+#!/usr/bin/env python3
+"""Read-only inventory scanner for a Dagster project.
+
+First step of every Dagster to Airflow 3 migration. Emits one JSON manifest, one
+record per definition. Architecture (redesigned to stop tracking Dagster's
+fast-rotating API surface by hand):
+
+  RUNTIME-FIRST (primary): with `--runtime`, import the project's Definitions in
+  the project's own interpreter and enumerate the RESOLVED objects (assets with
+  keys/deps/partitions/automation/io_manager_key, jobs, schedules, sensors,
+  checks, resources) via dagster's own public APIs. This tracks any Dagster
+  version automatically. Run the scanner WITH the project's venv python, e.g.
+    <project-venv>/bin/python scripts/inventory.py <root> --runtime
+    uv run python scripts/inventory.py <root> --runtime
+  On failure the static manifest still stands and a loud STATIC-ONLY banner plus
+  a top-level `runtime_error` field are emitted.
+
+  STATIC (completeness net): a thin, import-based scan. Per file it tracks what
+  is imported from dagster* modules (including aliases: `import dagster as dg`,
+  `from dagster import asset as a`) and records any decorator/call whose origin
+  resolves to a dagster* module as a definition site, kind = the original dagster
+  symbol name. No curated symbol table, so aliased decorators and new APIs are
+  caught for free. Integration packages (dagster_dbt etc.) resolve the same way.
+
+CLASSIFICATION is the AGENT's job, not the scanner's: every record ships
+`classification: "pending"`; the driving agent classifies each against
+reference/mapping.md during Phase 1 and writes MECH/JUDG/REDESIGN/NONE back.
+
+Usage: inventory.py <project_root> [--runtime] [--out manifest.json]
+"""
+
+import argparse
+import ast
+import json
+import re
+import sys
+from pathlib import Path
+
+# The stable, non-rotting past: legacy spellings never change. Used only to flag
+# spelling=deprecated and attach a note; NOT to decide what is a definition.
+DEPRECATED_SYMBOLS = {
+    "solid": "legacy solid; modern @op",
+    "pipeline": "legacy pipeline; modern @job",
+    "composite_solid": "legacy composite_solid; modern @graph",
+    "lambda_solid": "legacy lambda_solid; modern @op",
+    "repository": "classic @repository; modern Definitions",
+    "ModeDefinition": "legacy mode; modern resources",
+    "PresetDefinition": "legacy preset; modern config on job",
+    "hourly_schedule": "legacy partitioned schedule decorator",
+    "daily_schedule": "legacy partitioned schedule decorator",
+    "weekly_schedule": "legacy partitioned schedule decorator",
+    "monthly_schedule": "legacy partitioned schedule decorator",
+    "SourceAsset": "SourceAsset; modern AssetSpec external asset",
+    "load_assets_from_dbt_project": "legacy dbt loader; modern @dbt_assets",
+    "load_assets_from_dbt_manifest": "legacy dbt loader; modern @dbt_assets",
+    "dbt_cli_resource": "legacy dbt_cli_resource; modern DbtCliResource",
+    "fivetran_resource": "legacy op-based fivetran",
+    "FivetranResource": "legacy fivetran resource",
+    "airbyte_resource": "legacy op-based airbyte",
+    "AirbyteResource": "legacy airbyte resource",
+    "build_fivetran_assets": "legacy op-based; modern _definitions",
+    "build_airbyte_assets": "legacy op-based; modern _definitions",
+    "databricks_pyspark_step_launcher": "step launcher superseded by Pipes",
+    "emr_pyspark_step_launcher": "step launcher superseded by Pipes",
+    "build_snowflake_io_manager": "legacy builder; modern SnowflakeIOManager class",
+    "build_duckdb_io_manager": "legacy builder; modern DuckDBIOManager class",
+    "build_bigquery_io_manager": "legacy builder; modern BigQueryIOManager class",
+    "snowflake_pandas_io_manager": "deprecated fn; modern SnowflakePandasIOManager",
+    "duckdb_pandas_io_manager": "deprecated fn; modern DuckDBPandasIOManager",
+    "bigquery_pandas_io_manager": "deprecated fn; modern BigQueryPandasIOManager",
+    "AutoMaterializePolicy": "deprecated; normalize to AutomationCondition",
+    "auto_materialize_policy": "deprecated kwarg spelling",
+    "static_partitioned_config": "partitioned-config era",
+    "dynamic_partitioned_config": "partitioned-config era",
+}
+
+# Base classes that make a user `class X(...)` a resource / IO manager. Base
+# class names are stable API (they do not rotate like the full symbol surface),
+# so this small set is safe to keep; transitive subclasses resolve via the
+# package-wide inheritance map.
+IO_MANAGER_BASES = {"IOManager", "ConfigurableIOManager", "ConfigurableIOManagerFactory",
+                    "UPathIOManager", "InputManager"}
+RESOURCE_BASES = {"ConfigurableResource", "ConfigurableResourceFactory"}
+
+# Library builder helpers recorded even inside a factory body (every other call
+# inside a `def defs(): return Definitions(...)` factory is skipped, so DOP's
+# per-module container pattern does not mint phantom units).
+FACTORY_HELPER_SYMBOLS = {"make_slack_on_run_failure_sensor", "make_values_resource"}
+
+# Well-known dagster UTILITIES that resolve from a dagster* module but never
+# produce a definition (loggers, context/test builders, value wrappers). This is
+# a short DENYLIST of stable helpers, not the old definition allowlist: these
+# names do not rotate, and excluding them keeps the import-based net from
+# recording `logger = get_dagster_logger()` and friends as phantom units.
+DAGSTER_NON_DEFINITIONS = {
+    "get_dagster_logger", "get_current_context", "build_op_context",
+    "build_asset_context", "build_resources", "build_init_resource_context",
+    "materialize", "materialize_to_memory", "instance_for_test",
+}
+
+_DEFAULT_IO_MANAGER_KEY = "io_manager"  # Dagster's default IO manager resource key
+
+LEGEND = {
+    "MECH": "mechanical translation, low risk",
+    "JUDG": "needs per-instance judgment",
+    "REDESIGN": "semantics differ; redesign, not translate",
+    "NONE": "no Airflow equivalent; documented mitigation required",
+    "pending": "not yet classified; the driving agent fills this from mapping.md",
+    "status": "migration state; owned by status.py, never hand-edited",
+}
+
+
+# ---------------------------------------------------------------- AST helpers
+
+def _callee_name(node):
+    """Bare symbol name of a decorator or call target, or None."""
+    if isinstance(node, ast.Call):
+        node = node.func
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _kwargs_present(call):
+    """Map keyword-name -> rendered value for a Call node's keyword args."""
+    out = {}
+    if not isinstance(call, ast.Call):
+        return out
+    for kw in call.keywords:
+        if kw.arg is not None:
+            out[kw.arg] = _render(kw.value)
+    return out
+
+
+def _render(node, limit=120):
+    """Best-effort short rendering: literal value if simple, else source text."""
+    try:
+        val = ast.literal_eval(node)
+        if isinstance(val, (int, float, bool, str, type(None))):
+            return val
+    except Exception:
+        pass
+    return _safe_unparse(node, limit)
+
+
+def _safe_unparse(node, limit=120):
+    """Short source text for a node, never raising."""
+    try:
+        text = ast.unparse(node)
+    except Exception:
+        return "<expr>"
+    return text if len(text) <= limit else text[:limit] + "..."
+
+
+def _annotation_name(ann):
+    """Bare name of a parameter annotation (Name, Attribute, or subscript base)."""
+    if isinstance(ann, ast.Subscript):
+        ann = ann.value
+    if isinstance(ann, ast.Name):
+        return ann.id
+    if isinstance(ann, ast.Attribute):
+        return ann.attr
+    return None
+
+
+_NON_ASSET_PARAMS = {"self", "context", "config"}
+# Annotation suffixes that mark a param as an injected resource/client, not an
+# upstream asset. Tight on purpose: a false resource-edge is pruned at planning
+# (visible), but dropping a real asset edge is a silent omission.
+_RESOURCE_ANN_SUFFIXES = ("Resource", "Client", "Config", "Connection", "Session")
+
+
+def _signature_deps(func_node):
+    """Upstream asset names inferred from an asset function's parameters (syntax,
+    not API): non-context/config/resource params name upstream assets."""
+    args = func_node.args
+    deps = []
+    for a in list(args.posonlyargs) + list(args.args) + list(args.kwonlyargs):
+        if a.arg in _NON_ASSET_PARAMS:
+            continue
+        ann = _annotation_name(a.annotation)
+        if ann and ann.endswith(_RESOURCE_ANN_SUFFIXES):
+            continue
+        deps.append(a.arg)
+    return deps
+
+
+def _multi_asset_outputs(kwargs):
+    """Output names declared by @multi_asset (outs dict keys + AssetSpec names)."""
+    names = []
+    outs = kwargs.get("outs")
+    if isinstance(outs, str):
+        names += re.findall(r"['\"]([A-Za-z_]\w*)['\"]\s*:", outs)
+    specs = kwargs.get("specs")
+    if isinstance(specs, str):
+        names += re.findall(r"AssetSpec\(\s*['\"]([A-Za-z_]\w*)['\"]", specs)
+    seen, out = set(), []
+    for n in names:
+        if n not in seen:
+            seen.add(n)
+            out.append(n)
+    return out
+
+
+def _declared_name(kwargs, node, kind, fallback):
+    """The definition's DECLARED name (name= kwarg, then a name-positional for
+    define_asset_job), so static and runtime keys align. Else the fallback."""
+    n = kwargs.get("name")
+    if isinstance(n, str) and n.strip():
+        return n.strip()
+    if kind == "define_asset_job" and isinstance(node, ast.Call) and node.args:
+        first = node.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            return first.value
+    return fallback
+
+
+def _record_name(node, kind, fallback):
+    """Name for a call-constructed record: assigned var, then resource dict key."""
+    assigned = getattr(node, "_dagster_assign_target", None)
+    if assigned:
+        return assigned
+    if _coarse_family(kind) == "resource":
+        key = getattr(node, "_dagster_dict_key", None)
+        if key:
+            return key
+    return fallback
+
+
+# --------------------------------------------------- dagster import resolution
+
+def _is_dagster_module(mod):
+    return bool(mod) and (mod == "dagster" or mod.startswith("dagster.")
+                          or mod.startswith("dagster_"))
+
+
+def _resolve_dagster_symbol(func_node, mod_aliases, sym_imports):
+    """The original dagster symbol name a decorator/call resolves to, or None.
+
+    Handles `@asset` (from-import), `@a` (aliased from-import), `@dg.asset`
+    (module alias), and builder forms `dg.FreshnessPolicy.cron(...)` (the symbol
+    is the attribute nearest the module base, not the builder method)."""
+    n = func_node.func if isinstance(func_node, ast.Call) else func_node
+    attrs = []
+    while isinstance(n, ast.Attribute):
+        attrs.append(n.attr)
+        n = n.value
+    if not isinstance(n, ast.Name):
+        return None
+    origin = sym_imports.get(n.id)          # from dagster[_x] import SYM [as n]
+    if origin and _is_dagster_module(origin[0]):
+        return origin[1]                    # ignore builder attrs after the symbol
+    mod = mod_aliases.get(n.id)             # import dagster[_x] [as n]
+    if mod and _is_dagster_module(mod):
+        return attrs[-1] if attrs else None
+    return None
+
+
+# --------------------------------------------------------------- coarse family
+
+def _coarse_family(kind):
+    """Group a raw dagster symbol name into a stable structural family for merge
+    dedup. Keys on role words Dagster does not rename, not a curated symbol list.
+    Order matters: asset_check -> check, asset_job -> job."""
+    k = str(kind).lower()
+    if "check" in k:
+        return "check"
+    if "sensor" in k:
+        return "sensor"
+    if "schedule" in k:
+        return "schedule"
+    if "job" in k:
+        return "job"
+    if "iomanager" in k or "io_manager" in k:
+        return "resource"
+    if "resource" in k or "workspace" in k:
+        return "resource"
+    if "asset" in k:
+        return "asset"
+    return k
+
+
+def _normalize_name(name):
+    """Collapse a name or asset key to a comparable slug (terminal component)."""
+    s = str(name).strip()
+    m = re.search(r"AssetKey\(\[([^\]]*)\]\)", s)
+    if m:
+        parts = re.findall(r"['\"]([^'\"]+)['\"]", m.group(1))
+        if parts:
+            s = parts[-1]
+    if "/" in s:
+        s = s.rsplit("/", 1)[-1]
+    return s.strip().lower()
+
+
+def _resolves_to(class_name, targets, imap, seen=None):
+    """True if class_name transitively inherits from any base in `targets`."""
+    if seen is None:
+        seen = set()
+    if class_name in seen:
+        return False
+    seen.add(class_name)
+    for base in imap.get(class_name, []):
+        if base in targets or _resolves_to(base, targets, imap, seen):
+            return True
+    return False
+
+
+# --------------------------------------------------------------- static scanner
+
+def _tag_assignments(tree):
+    for stmt in ast.walk(tree):
+        if isinstance(stmt, ast.Assign) and isinstance(stmt.value, ast.Call):
+            if stmt.targets and isinstance(stmt.targets[0], ast.Name):
+                stmt.value._dagster_assign_target = stmt.targets[0].id
+
+
+def _tag_dict_keys(tree):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Dict):
+            for k, v in zip(node.keys, node.values):
+                if (isinstance(k, ast.Constant) and isinstance(k.value, str)
+                        and isinstance(v, ast.Call)):
+                    v._dagster_dict_key = k.value
+
+
+def _tag_nested_calls(tree):
+    """Mark Call nodes that are ARGUMENTS to another call, so helper calls used
+    as arguments (AssetOut inside outs=, EnvVar in a default) are not recorded as
+    their own definition sites."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            for arg in list(node.args) + [kw.value for kw in node.keywords]:
+                for sub in ast.walk(arg):
+                    if isinstance(sub, ast.Call):
+                        sub._dagster_nested_call = True
+
+
+class Scanner(ast.NodeVisitor):
+    def __init__(self, path, source, imap=None):
+        self.path = path
+        self.source = source
+        self.records = []
+        self.imap = imap or {}
+        self.mod_aliases = {}   # local alias -> module (import X as Y)
+        self.sym_imports = {}   # local name -> (module, symbol) (from X import S)
+        self._factory_stack = []
+        self._cond_stack = []
+
+    # -- imports ------------------------------------------------------------
+    def visit_Import(self, node):
+        for alias in node.names:
+            self.mod_aliases[alias.asname or alias.name] = alias.name
+
+    def visit_ImportFrom(self, node):
+        if node.module:
+            for alias in node.names:
+                self.sym_imports[alias.asname or alias.name] = (node.module, alias.name)
+
+    # -- resolution helpers -------------------------------------------------
+    def _symbol_for(self, node):
+        return _resolve_dagster_symbol(node, self.mod_aliases, self.sym_imports)
+
+    def _ctx_fields(self):
+        out = {}
+        if self._factory_stack:
+            out["factory"] = self._factory_stack[-1]
+        if self._cond_stack:
+            out["conditional"] = " and ".join(self._cond_stack)
+        return out
+
+    def _add(self, kind, name, node, kwargs=None, extra=None, deprecated=None):
+        kwargs = kwargs or {}
+        rec = {
+            "kind": kind,
+            "name": str(name).strip(),
+            "location": f"{self.path}:{getattr(node, 'lineno', 0)}",
+            "params": kwargs,
+            "spelling": "deprecated" if deprecated else "current",
+            "classification": "pending",
+            "note": deprecated or "",
+            "source_edges": extra.get("source_edges", []) if extra else [],
+            "status": "pending",
+        }
+        if deprecated:
+            rec["deprecated_reason"] = deprecated
+        if extra:
+            rec.update({k: v for k, v in extra.items() if k != "source_edges"})
+        rec.update(self._ctx_fields())
+        self.records.append(rec)
+
+    # -- definitions --------------------------------------------------------
+    def _visit_def(self, node):
+        for dec in node.decorator_list:
+            sym = self._symbol_for(dec)
+            bare = _callee_name(dec)
+            dep = DEPRECATED_SYMBOLS.get(bare)
+            kind = sym or (bare if dep else None)
+            if kind is None or kind in DAGSTER_NON_DEFINITIONS:
+                continue
+            kwargs = _kwargs_present(dec) if isinstance(dec, ast.Call) else {}
+            extra = self._asset_extra(kind, kwargs, func_node=node)
+            self._add(kind, _declared_name(kwargs, dec, kind, node.name),
+                      dec, kwargs, extra, deprecated=dep)
+        # descend into the body: factories define decorated defs (and call builder
+        # helpers) inside a function; tag records with the enclosing function.
+        self._factory_stack.append(node.name)
+        for stmt in node.body:
+            self.visit(stmt)
+        self._factory_stack.pop()
+
+    visit_FunctionDef = _visit_def
+    visit_AsyncFunctionDef = _visit_def
+
+    def visit_ClassDef(self, node):
+        """Custom IO managers / resources defined as subclasses (transitive)."""
+        direct = [_callee_name(b) for b in node.bases]
+        if _resolves_to(node.name, IO_MANAGER_BASES, self.imap):
+            self._add("io_manager", node.name, node,
+                      extra={"subclass_of": next((b for b in direct if b), None)})
+        elif _resolves_to(node.name, RESOURCE_BASES, self.imap):
+            self._add("resource", node.name, node,
+                      extra={"subclass_of": next((b for b in direct if b), None)})
+        # class bodies hold fields/methods (EnvVar defaults etc.), not definitions
+
+    def visit_Call(self, node):
+        # arguments-of-a-call helper constructs are not definition sites
+        if getattr(node, "_dagster_nested_call", False):
+            self.generic_visit(node)
+            return
+        sym = self._symbol_for(node)
+        bare = _callee_name(node)
+        dep = DEPRECATED_SYMBOLS.get(bare)
+        kind = sym or (bare if dep else None)
+        if kind is not None and kind not in DAGSTER_NON_DEFINITIONS:
+            # inside a factory body only record explicit builder helpers; generic
+            # container calls (Definitions, define_asset_job) there just assemble
+            # module-level objects and would double-count.
+            if self._factory_stack and bare not in FACTORY_HELPER_SYMBOLS:
+                pass
+            else:
+                kw = _kwargs_present(node)
+                name = _declared_name(kw, node, kind, _record_name(node, kind, bare))
+                self._add(kind, name, node, kw, deprecated=dep)
+        self.generic_visit(node)
+
+    def visit_If(self, node):
+        # visit BOTH branches, each flagged with its condition, so an alternate
+        # integration branch (dbt Cloud vs local) is never silently absent.
+        test = _safe_unparse(node.test)
+        self._cond_stack.append(test)
+        for stmt in node.body:
+            self.visit(stmt)
+        self._cond_stack.pop()
+        if node.orelse:
+            self._cond_stack.append("not (%s)" % test)
+            for stmt in node.orelse:
+                self.visit(stmt)
+            self._cond_stack.pop()
+
+    def visit_Try(self, node):
+        self._cond_stack.append("try")
+        for stmt in node.body:
+            self.visit(stmt)
+        self._cond_stack.pop()
+        for handler in node.handlers:
+            for stmt in handler.body:
+                self.visit(stmt)
+        for stmt in list(node.orelse) + list(node.finalbody):
+            self.visit(stmt)
+
+    def _asset_extra(self, kind, kwargs, func_node=None):
+        """Syntactic extras for asset-family definitions: source_edges (from
+        deps/ins/signature) and multi_asset outputs. Generic kwarg capture is in
+        `params`; nothing here interprets them (that is the agent's job)."""
+        extra = {}
+        if _coarse_family(kind) != "asset":
+            return extra
+        edges = []
+        deps, ins = kwargs.get("deps"), kwargs.get("ins")
+        if deps:
+            edges.append({"upstream": deps, "io_manager": None})
+        if ins:
+            edges.append({"upstream_ins": ins, "io_manager": None})
+        if not deps and not ins and func_node is not None:
+            for pname in _signature_deps(func_node):
+                edges.append({"upstream": pname, "io_manager": None, "from": "signature"})
+        if edges:
+            extra["source_edges"] = edges
+        outputs = _multi_asset_outputs(kwargs)
+        if outputs:
+            extra["outputs"] = [{"name": n} for n in outputs]
+        return extra
+
+
+def scan_python_file(path, root, imap=None):
+    rel = path.relative_to(root)
+    try:
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+    except (SyntaxError, UnicodeDecodeError) as exc:
+        return [{"kind": "parse_error", "name": path.name, "location": f"{rel}:0",
+                 "params": {"error": str(exc)}, "spelling": "unknown",
+                 "classification": "pending", "note": "file did not parse; inspect manually",
+                 "source_edges": [], "status": "pending"}]
+    _tag_assignments(tree)
+    _tag_dict_keys(tree)
+    _tag_nested_calls(tree)
+    scanner = Scanner(rel, source, imap=imap)
+    scanner.visit(tree)
+    text_findings(source, rel, scanner.records)
+    return scanner.records
+
+
+# --------------------------------------------------- structural text tells
+
+TEXT_PATTERNS = [
+    (re.compile(r"DAGSTER_CLOUD_(?:IS_BRANCH_DEPLOYMENT|PULL_REQUEST_ID|DEPLOYMENT_NAME)"),
+     "branch_env_ref", "branch-deploy env var IN CODE (DB naming/URLs); find and rewrite for Astro"),
+    (re.compile(r"dagster-k8s/config"),
+     "k8s_config_tag", "per-job pod resources; map to per-task executor_config / pod_override"),
+    (re.compile(r"dagster/concurrency_key"),
+     "concurrency_tag", "tag-based op concurrency; map to Airflow Pools"),
+]
+
+
+def text_findings(source, rel, records):
+    seen = set()
+    for line_no, line in enumerate(source.splitlines(), start=1):
+        for pattern, kind, note in TEXT_PATTERNS:
+            match = pattern.search(line)
+            if not match or (kind, match.group(0)) in seen:
+                continue
+            seen.add((kind, match.group(0)))
+            records.append({
+                "kind": kind, "name": match.group(0), "location": f"{rel}:{line_no}",
+                "params": {}, "spelling": "current", "classification": "pending",
+                "note": note, "source_edges": [], "status": "pending",
+            })
+
+
+def _split_yaml_docs(text):
+    """Split a YAML file into (doc_text, start_line) on `---` document markers."""
+    docs, cur, start = [], [], 1
+    for i, line in enumerate(text.splitlines(), start=1):
+        if re.match(r"^---(\s|$)", line):
+            if any(l.strip() for l in cur):
+                docs.append(("\n".join(cur), start))
+            cur, start = [], i + 1
+        else:
+            if not cur:
+                start = i
+            cur.append(line)
+    if any(l.strip() for l in cur):
+        docs.append(("\n".join(cur), start))
+    return docs
+
+
+def _raw_attributes_block(doc_text):
+    out, capturing, base_indent = [], False, 0
+    for line in doc_text.splitlines():
+        if not capturing:
+            m = re.match(r"^(\s*)attributes:\s*(.*)$", line)
+            if m:
+                capturing = True
+                base_indent = len(m.group(1))
+                if m.group(2).strip():
+                    out.append(m.group(2).strip())
+            continue
+        if line.strip() == "":
+            out.append("")
+            continue
+        if len(line) - len(line.lstrip()) <= base_indent:
+            break
+        out.append(line)
+    block = "\n".join(out).strip()
+    return block[:2000] if block else None
+
+
+def _parse_component_doc(doc_text):
+    type_val, attributes = None, None
+    try:
+        import yaml  # optional; the scanner must run without it
+        data = yaml.safe_load(doc_text)
+        if isinstance(data, dict):
+            type_val, attributes = data.get("type"), data.get("attributes")
+    except Exception:
+        pass
+    if type_val is None:
+        m = re.search(r"^\s*type:\s*(\S+)", doc_text, re.M)
+        if m:
+            type_val = m.group(1).strip().strip("\"'")
+    if attributes is None:
+        attributes = _raw_attributes_block(doc_text)
+    return type_val, attributes
+
+
+def scan_component_yaml(path, root):
+    """Parse a Components defs.yaml / component.yaml: one record per document."""
+    rel = path.relative_to(root)
+    records = []
+    for doc_text, start_line in _split_yaml_docs(path.read_text(encoding="utf-8")):
+        type_val, attributes = _parse_component_doc(doc_text)
+        if type_val is None:
+            continue
+        params = {"type": type_val}
+        if attributes is not None:
+            params["attributes"] = attributes
+        records.append({
+            "kind": "component_instance", "name": type_val,
+            "location": f"{rel}:{start_line}", "params": params, "spelling": "current",
+            "classification": "pending",
+            "note": "unwrap YAML to the integration's mapping row; custom Component subclass ports build_defs output",
+            "source_edges": [], "status": "pending",
+        })
+    return records
+
+
+# --------------------------------------------------------- file discovery
+
+def _is_test_path(rel):
+    """A test file or a file under a test package (relative to the project root)."""
+    for part in rel.parts[:-1]:
+        if part == "tests" or part.endswith("_tests") or part.startswith("test_"):
+            return True
+    name = rel.name
+    return name.startswith("test_") or name.endswith("_test.py") or name == "conftest.py"
+
+
+def _skip_dir(path):
+    return any(p in (".venv", "venv", "__pycache__", ".tox", "node_modules") for p in path.parts)
+
+
+def _scannable_files(root):
+    for path in sorted(root.rglob("*.py")):
+        if _skip_dir(path) or _is_test_path(path.relative_to(root)):
+            continue
+        yield path
+
+
+def _component_yaml_files(root):
+    for pattern in ("defs.yaml", "component.yaml"):
+        for path in sorted(root.rglob(pattern)):
+            if not _skip_dir(path):
+                yield path
+
+
+def _build_inheritance_map(files):
+    """Package-wide `class name -> [direct base bare-names]`, across all files."""
+    imap = {}
+    for path in files:
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                imap[node.name] = [b for b in (_callee_name(base) for base in node.bases) if b]
+    return imap
+
+
+def run_static(root):
+    records = []
+    files = list(_scannable_files(root))
+    imap = _build_inheritance_map(files)
+    for path in files:
+        records.extend(scan_python_file(path, root, imap=imap))
+    for path in _component_yaml_files(root):
+        records.extend(scan_component_yaml(path, root))
+    return records
+
+
+# Cross-domain dbt-manifest coupling (load-time). Hits OUTSIDE the dbt domain
+# dictate migration order (dbt first, or those edges get deferred).
+DBT_COUPLING_PATTERN = re.compile(
+    r"\b(get_asset_key_for_model|dbt_asset_key|DbtManifestAssetSelection)\b")
+
+
+def _is_dbt_domain(path):
+    return any("dbt" in part.lower() for part in path.parts)
+
+
+def _dbt_coupling_scan(root):
+    hits = []
+    for path in list(_scannable_files(root)) + list(_component_yaml_files(root)):
+        if _is_dbt_domain(path):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if DBT_COUPLING_PATTERN.search(line):
+                hits.append(f"{path.relative_to(root)}:{lineno}")
+    return sorted(set(hits))
+
+
+# ------------------------------------------------------- runtime (primary)
+
+def run_runtime(root):
+    """Import the project and enumerate resolved Definitions. Returns
+    (records, error); on any failure returns ([], reason)."""
+    module_name, syspaths = _resolve_entrypoint(root)
+    for d in syspaths:
+        if d not in sys.path:
+            sys.path.insert(0, d)
+    try:
+        import importlib
+        import dagster as dg  # noqa: F401  guarded project-venv import
+    except Exception as exc:
+        return [], f"dagster not importable in this interpreter: {exc}"
+    if not module_name:
+        return [], ("could not locate a Definitions entrypoint module "
+                    "(checked dagster_cloud.yaml, workspace.yaml, pyproject, definitions.py)")
+    try:
+        mod = importlib.import_module(module_name)
+    except Exception as exc:
+        return [], f"import of {module_name} failed: {exc}"
+    defs = next((a for a in vars(mod).values() if type(a).__name__ == "Definitions"), None)
+    if defs is None:
+        return [], f"no Definitions object found in {module_name}"
+    records = []
+    _enumerate(defs, module_name, records)
+    return records, None
+
+
+def _resolve_entrypoint(root):
+    """(module_name, [sys.path dirs]) honoring dagster_cloud.yaml / workspace.yaml
+    code_source + working_directory and src-layout uv packages."""
+    syspaths = [str(root)]
+    if (root / "src").is_dir():
+        syspaths.append(str(root / "src"))
+    module_name = None
+    for cfg in ("dagster_cloud.yaml", "workspace.yaml"):
+        p = root / cfg
+        if not p.exists():
+            continue
+        text = p.read_text(encoding="utf-8")
+        m = re.search(r"module_name:\s*['\"]?([A-Za-z0-9_.]+)", text)
+        if m and module_name is None:
+            module_name = m.group(1)
+        w = re.search(r"working_directory:\s*['\"]?([^\s'\"#]+)", text)
+        if w:
+            wdir = (root / w.group(1)).resolve()
+            for d in (wdir, wdir / "src"):
+                if d.is_dir() and str(d) not in syspaths:
+                    syspaths.append(str(d))
+    if module_name is None:
+        module_name = _discover_module(root)
+    else:
+        top = module_name.split(".")[0]
+        for cand in root.rglob(top):
+            if cand.is_dir() and (cand / "__init__.py").exists():
+                if str(cand.parent) not in syspaths:
+                    syspaths.append(str(cand.parent))
+                break
+    return module_name, syspaths
+
+
+def _discover_module(root):
+    pyproject = root / "pyproject.toml"
+    if pyproject.exists():
+        m = re.search(r"root_module\s*=\s*[\"']([^\"']+)[\"']", pyproject.read_text(encoding="utf-8"))
+        if m:
+            return m.group(1) + ".definitions"
+    for candidate in root.rglob("definitions.py"):
+        if not any(p in (".venv", "venv", "__pycache__") for p in candidate.parts):
+            return ".".join(candidate.relative_to(root).with_suffix("").parts)
+    return None
+
+
+def _runtime_obj_name(obj):
+    name = getattr(obj, "name", None)
+    if name:
+        return str(name).strip()
+    for attr in ("check_keys", "keys", "check_specs"):
+        val = getattr(obj, attr, None)
+        if val:
+            first = next(iter(val), None)
+            if first is not None:
+                return _normalize_name(str(first))
+    return type(obj).__name__.strip()
+
+
+def _runtime_check_pairs(obj):
+    """(check_name, normalized_asset_key) per check in an AssetChecksDefinition."""
+    items = list(getattr(obj, "check_specs", None) or getattr(obj, "check_keys", None) or [])
+    pairs = []
+    for it in items:
+        cname = getattr(it, "name", None)
+        akey = getattr(it, "asset_key", None)
+        pairs.append((str(cname).strip() if cname else None,
+                      _normalize_name(str(akey)) if akey is not None else None))
+    return pairs
+
+
+def _enumerate(defs, module_name, records):
+    """Enumerate resolved objects via dagster's public APIs. Captures structural
+    facts (deps, partitions/automation presence, io_manager_key); classification
+    stays pending for the agent."""
+    def emit(kind, name, params=None):
+        records.append({
+            "kind": kind, "name": str(name).strip(), "location": f"{module_name} (runtime)",
+            "params": params or {}, "spelling": "current", "classification": "pending",
+            "note": "", "source_edges": [], "status": "pending", "source": "runtime",
+        })
+
+    try:
+        for spec in defs.resolve_all_asset_specs():
+            params = {}
+            deps = getattr(spec, "deps", None)
+            if deps:
+                params["deps"] = [str(getattr(d, "asset_key", d)) for d in deps]
+            if getattr(spec, "partitions_def", None) is not None:
+                params["partitioned"] = True
+            if getattr(spec, "automation_condition", None) is not None:
+                params["automation_condition"] = True
+            md = getattr(spec, "metadata", None) or {}
+            if isinstance(md, dict) and md.get("dagster/io_manager_key"):
+                params["io_manager_key"] = str(md["dagster/io_manager_key"])
+            emit("asset", getattr(spec, "key", spec), params)
+    except Exception:
+        pass
+    # io_manager_key BINDINGS live on the assets definitions, not the specs;
+    # walk defs.assets and stamp each key's binding onto its record (G1).
+    try:
+        by_name = {}
+        for r in records:
+            if r["kind"] == "asset":
+                by_name[r["name"]] = r
+        for adef in getattr(defs, "assets", None) or []:
+            keys_by_out = getattr(adef, "keys_by_output_name", None)
+            node = getattr(adef, "node_def", None)
+            outs = getattr(node, "output_defs", None) if node is not None else None
+            if not keys_by_out or not outs:
+                continue
+            io_by_out = {o.name: getattr(o, "io_manager_key", None) for o in outs}
+            for out_name, akey in keys_by_out.items():
+                io_key = io_by_out.get(out_name)
+                rec = by_name.get(str(akey))
+                if rec is not None and io_key and io_key != "io_manager":
+                    rec.setdefault("params", {}).setdefault("io_manager_key", str(io_key))
+    except Exception:
+        pass
+    for attr, kind in (("jobs", "job"), ("schedules", "schedule"), ("sensors", "sensor")):
+        try:
+            for obj in getattr(defs, attr, None) or []:
+                params = {}
+                cron = getattr(obj, "cron_schedule", None)
+                if cron:
+                    params["cron_schedule"] = str(cron)
+                emit(kind, _runtime_obj_name(obj), params or None)
+        except Exception:
+            pass
+    try:
+        for obj in getattr(defs, "asset_checks", None) or []:
+            pairs = _runtime_check_pairs(obj)
+            if pairs:
+                for cname, akey in pairs:
+                    emit("asset_check", cname or _runtime_obj_name(obj),
+                         {"asset": akey} if akey else None)
+            else:
+                emit("asset_check", _runtime_obj_name(obj))
+    except Exception:
+        pass
+    try:
+        for key in (defs.resources or {}):
+            emit("resource", key)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------- manifest assembly
+
+def _best_static_match(candidates, rt):
+    """Which static record a runtime record aligns with; disambiguate checks by
+    target asset when names collide."""
+    rt_asset = (rt.get("params") or {}).get("asset")
+    if rt_asset:
+        for c in candidates:
+            c_asset = (c.get("params") or {}).get("asset")
+            if c_asset is not None and _normalize_name(c_asset) == _normalize_name(rt_asset):
+                return c
+    for c in candidates:
+        if c["kind"] == rt["kind"]:
+            return c
+    return candidates[0]
+
+
+def _merge_runtime_first(runtime_records, static_records):
+    """RUNTIME-FIRST reconciliation. Runtime records are the primary inventory;
+    each is grafted with the matching static site's syntactic extras (source
+    edges, spelling, conditional/factory context). Static-only sites (dead code,
+    an alternate conditional branch, a runtime miss) are appended flagged
+    `not_in_runtime` so the completeness net never drops them."""
+    index = {}
+    for s in static_records:
+        index.setdefault((_coarse_family(s["kind"]), _normalize_name(s["name"])), []).append(s)
+    used = set()
+    combined = []
+    for rt in runtime_records:
+        rt = dict(rt)
+        key = (_coarse_family(rt["kind"]), _normalize_name(rt["name"]))
+        cands = [s for s in index.get(key, []) if id(s) not in used]
+        if cands:
+            s = _best_static_match(cands, rt)
+            used.add(id(s))
+            for f in ("source_edges", "spelling", "conditional", "factory",
+                      "deprecated_reason", "outputs"):
+                if s.get(f) and not rt.get(f):
+                    rt[f] = s[f]
+            rt["static_location"] = s.get("location")
+        combined.append(rt)
+    for s in static_records:
+        if id(s) not in used:
+            s = dict(s)
+            s["not_in_runtime"] = True
+            combined.append(s)
+    return combined
+
+
+def _edge_upstream_names(edge):
+    raw = edge.get("upstream") or edge.get("upstream_ins")
+    return re.findall(r"[A-Za-z_]\w*", str(raw)) if raw is not None else []
+
+
+def _resolve_edge_io_managers(records):
+    """Attribute each source-edge's io_manager to the PRODUCER (default key when
+    unset); fall back to the consumer's key marked `consumer-side guess`."""
+    producer = {}
+    for r in records:
+        if _coarse_family(r["kind"]) == "asset":
+            key = (r.get("params") or {}).get("io_manager_key")
+            producer[_normalize_name(r["name"])] = key
+            for o in r.get("outputs", []):
+                producer.setdefault(_normalize_name(o["name"]), key)
+    for r in records:
+        consumer_key = (r.get("params") or {}).get("io_manager_key")
+        for edge in r.get("source_edges", []):
+            keys = [producer[_normalize_name(n)] or _DEFAULT_IO_MANAGER_KEY
+                    for n in _edge_upstream_names(edge)
+                    if _normalize_name(n) in producer]
+            edge["consumer_io_manager"] = consumer_key
+            if keys:
+                uniq = sorted(set(keys))
+                edge["io_manager"] = uniq[0] if len(uniq) == 1 else uniq
+                edge["io_manager_source"] = "producer"
+            else:
+                edge["io_manager"] = consumer_key or _DEFAULT_IO_MANAGER_KEY
+                edge["io_manager_source"] = "consumer-side guess"
+
+
+def build_manifest(root, use_runtime):
+    static_records = run_static(root)
+    for rec in static_records:
+        rec["name"] = str(rec["name"]).strip()
+
+    manifest = {"project_root": str(root), "modes": ["static"], "legend": LEGEND}
+    records = static_records
+    if use_runtime:
+        runtime_records, error = run_runtime(root)
+        if error:
+            manifest["runtime_error"] = error
+        else:
+            # runtime-first: runtime is the primary inventory, static is the net
+            manifest["modes"] = ["runtime", "static"]
+            records = _merge_runtime_first(runtime_records, static_records)
+            manifest["runtime_records"] = len(runtime_records)
+            manifest["static_only"] = sum(1 for r in records if r.get("not_in_runtime"))
+
+    _resolve_edge_io_managers(records)
+    counts = {}
+    for rec in records:
+        counts[rec["kind"]] = counts.get(rec["kind"], 0) + 1
+    manifest["counts"] = counts          # counts per KIND (classification is pending)
+    manifest["total"] = len(records)
+    manifest["dbt_manifest_coupling"] = _dbt_coupling_scan(root)
+
+    # units: the records keyed by a stable unit id, the shape status.py and
+    # validate_dag.py consume. The planner later adds TARGET expectations under
+    # DISTINCT keys (dag_id, edges, schedule, asset_schedule, timetable_type,
+    # asset_outlets); source_edges stays scanner-owned so the two never collide.
+    units = {}
+    for rec in records:
+        base = "{0}:{1}".format(rec["kind"], rec["name"])
+        unit_id, n = base, 2
+        while unit_id in units:
+            unit_id, n = "{0}#{1}".format(base, n), n + 1
+        units[unit_id] = rec
+    manifest["units"] = units
+    return manifest
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Read-only Dagster project inventory scanner.")
+    parser.add_argument("project_root", type=Path, help="path to the Dagster project root")
+    parser.add_argument("--runtime", action="store_true",
+                        help="runtime-first: import the project and enumerate Definitions")
+    parser.add_argument("--out", type=Path, default=None, help="write manifest JSON here (default: stdout)")
+    args = parser.parse_args(argv)
+
+    root = args.project_root.resolve()
+    if not root.exists():
+        parser.error(f"project root does not exist: {root}")
+
+    manifest = build_manifest(root, args.runtime)
+
+    if args.runtime and manifest.get("runtime_error"):
+        sys.stderr.write(
+            "\n!!! runtime mode did not run: " + manifest["runtime_error"] + "\n"
+            "    The manifest is STATIC-ONLY (the completeness net, not the primary\n"
+            "    runtime inventory). Runtime mode imports the project in THIS\n"
+            "    interpreter, so run the scanner with the project's own venv python:\n"
+            "      <project-venv>/bin/python scripts/inventory.py "
+            + str(args.project_root) + " --runtime\n"
+            "      uv run python scripts/inventory.py " + str(args.project_root) + " --runtime\n\n")
+
+    text = json.dumps(manifest, indent=2, default=str)
+    if args.out:
+        args.out.write_text(text, encoding="utf-8")
+        print(f"wrote {manifest['total']} records to {args.out}", file=sys.stderr)
+    else:
+        print(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/migrating-dagster-to-airflow/scripts/pyproject.toml
+++ b/skills/migrating-dagster-to-airflow/scripts/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "migrating-dagster-to-airflow-scripts"
+version = "0.0.0"
+description = "Inventory, validation, and status scripts for the Dagster to Airflow 3 migration skill."
+requires-python = ">=3.9"
+# The scripts are stdlib-only; validate_dag shells out to ruff/astro/airflow when
+# present but imports none of them. No runtime dependencies.
+dependencies = []
+
+[project.optional-dependencies]
+test = ["pytest>=7"]
+
+[tool.uv]
+# Not an installable package (flat scripts + tests); uv provisions the test env
+# without trying to build the project. Tests import the scripts via conftest.
+package = false
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/skills/migrating-dagster-to-airflow/scripts/status.py
+++ b/skills/migrating-dagster-to-airflow/scripts/status.py
@@ -135,6 +135,7 @@ def cmd_show(manifest, by_state):
 # Transition planners: given a unit, return (target_state, current_state, error).
 # error is a human phrase when the transition is illegal (target is then None).
 
+
 def _plan_advance(unit):
     current = unit_state(unit)
     if current == "complete":
@@ -214,7 +215,11 @@ def _matches(unit, where, from_state):
 
 
 def _selected(units, where, from_state):
-    return [(uid, units[uid]) for uid in sorted(units) if _matches(units[uid], where, from_state)]
+    return [
+        (uid, units[uid])
+        for uid in sorted(units)
+        if _matches(units[uid], where, from_state)
+    ]
 
 
 def _filter_desc(where, from_state):
@@ -246,7 +251,9 @@ def run_transition(manifest, path, op, args):
 
     if args.unit_id is not None:
         if where or from_state is not None:
-            sys.stderr.write("error: pass a unit id OR --where/--from-state, not both\n")
+            sys.stderr.write(
+                "error: pass a unit id OR --where/--from-state, not both\n"
+            )
             return 2
         if args.unit_id not in units:
             sys.stderr.write("error: no such unit: " + args.unit_id + "\n")
@@ -254,7 +261,9 @@ def run_transition(manifest, path, op, args):
         targets, single = [(args.unit_id, units[args.unit_id])], True
     else:
         if not where and from_state is None:
-            sys.stderr.write("error: bulk mode needs at least one --where or --from-state filter\n")
+            sys.stderr.write(
+                "error: bulk mode needs at least one --where or --from-state filter\n"
+            )
             return 2
         targets, single = _selected(units, where, from_state), False
         if not targets:
@@ -267,7 +276,11 @@ def run_transition(manifest, path, op, args):
         target, current, err = planner(unit)
         if err is not None:
             if single:
-                sys.stderr.write("error: cannot {0} {1}: {2} (state={3})\n".format(op, uid, err, current))
+                sys.stderr.write(
+                    "error: cannot {0} {1}: {2} (state={3})\n".format(
+                        op, uid, err, current
+                    )
+                )
                 return 1
             print("  skip  {0}: {1} ({2})".format(uid, err, current))
             skipped += 1
@@ -276,8 +289,11 @@ def run_transition(manifest, path, op, args):
             print("  would-{0}  {1}: {2} -> {3}".format(op, uid, current, target))
         else:
             _commit(unit, target, current, op, evidence, reason)
-            print(_single_line(op, uid, current, target, evidence, reason) if single
-                  else "  {0}: {1} -> {2}".format(uid, current, target))
+            print(
+                _single_line(op, uid, current, target, evidence, reason)
+                if single
+                else "  {0}: {1} -> {2}".format(uid, current, target)
+            )
         applied += 1
 
     if not args.dry_run and applied:
@@ -300,8 +316,11 @@ def cmd_summary(manifest):
     # Surface a static-only manifest so a summary is never mistaken for a full
     # inventory (GAP-1): runtime mode was requested but did not run.
     if manifest.get("runtime_error"):
-        print("NOTE: manifest is STATIC-ONLY (runtime mode did not run: {0})".format(
-            manifest["runtime_error"]))
+        print(
+            "NOTE: manifest is STATIC-ONLY (runtime mode did not run: {0})".format(
+                manifest["runtime_error"]
+            )
+        )
     counts = {s: 0 for s in ALL_STATES}
     unknown = []
 
@@ -323,7 +342,9 @@ def cmd_summary(manifest):
     print("in flight: {0}".format(in_flight))
 
     if unknown:
-        print("SILENT OMISSION: {0} unit(s) with no recognized state".format(len(unknown)))
+        print(
+            "SILENT OMISSION: {0} unit(s) with no recognized state".format(len(unknown))
+        )
         for unit_id, state in unknown:
             print("  {0}  (state={1!r})".format(unit_id, state))
         return 1
@@ -336,36 +357,64 @@ def cmd_summary(manifest):
 
 def main(argv=None):
     parser = argparse.ArgumentParser(description="Per-unit migration state machine.")
-    parser.add_argument("--manifest", default=DEFAULT_MANIFEST,
-                        help="inventory manifest JSON (default: " + DEFAULT_MANIFEST + ")")
+    parser.add_argument(
+        "--manifest",
+        default=DEFAULT_MANIFEST,
+        help="inventory manifest JSON (default: " + DEFAULT_MANIFEST + ")",
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     def _add_filters(p):
         # bulk selection, shared by advance/defer/reopen (unit_id optional)
-        p.add_argument("unit_id", nargs="?", default=None,
-                       help="single unit id; omit and use --where/--from-state for bulk")
-        p.add_argument("--where", action="append", default=[], metavar="KEY=VALUE",
-                       help="bulk filter on a record field (e.g. kind=op); repeatable, ANDed")
-        p.add_argument("--from-state", dest="from_state", default=None,
-                       help="bulk filter: only units currently in this state")
-        p.add_argument("--dry-run", action="store_true",
-                       help="print the matches and planned transitions without writing")
+        p.add_argument(
+            "unit_id",
+            nargs="?",
+            default=None,
+            help="single unit id; omit and use --where/--from-state for bulk",
+        )
+        p.add_argument(
+            "--where",
+            action="append",
+            default=[],
+            metavar="KEY=VALUE",
+            help="bulk filter on a record field (e.g. kind=op); repeatable, ANDed",
+        )
+        p.add_argument(
+            "--from-state",
+            dest="from_state",
+            default=None,
+            help="bulk filter: only units currently in this state",
+        )
+        p.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="print the matches and planned transitions without writing",
+        )
 
     p_show = sub.add_parser("show", help="list units and their states")
     p_show.add_argument("--by-state", action="store_true", help="group by state")
 
     p_adv = sub.add_parser("advance", help="advance a unit (or a --where set) one step")
     _add_filters(p_adv)
-    p_adv.add_argument("--evidence", required=True,
-                       help="path or command-output reference proving the gate passed")
+    p_adv.add_argument(
+        "--evidence",
+        required=True,
+        help="path or command-output reference proving the gate passed",
+    )
 
-    p_def = sub.add_parser("defer", help="mark a unit (or a --where set) deferred with a reason")
+    p_def = sub.add_parser(
+        "defer", help="mark a unit (or a --where set) deferred with a reason"
+    )
     _add_filters(p_def)
     p_def.add_argument("--reason", required=True, help="why the unit(s) are deferred")
 
-    p_reopen = sub.add_parser("reopen", help="move complete/deferred unit(s) back to translate")
+    p_reopen = sub.add_parser(
+        "reopen", help="move complete/deferred unit(s) back to translate"
+    )
     _add_filters(p_reopen)
-    p_reopen.add_argument("--reason", required=True, help="why the unit(s) are being reopened")
+    p_reopen.add_argument(
+        "--reason", required=True, help="why the unit(s) are being reopened"
+    )
 
     sub.add_parser("summary", help="counts per state and completeness check")
 

--- a/skills/migrating-dagster-to-airflow/scripts/status.py
+++ b/skills/migrating-dagster-to-airflow/scripts/status.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Per-unit migration state machine, backed by the inventory manifest.
+
+Tracks where each migrated unit sits on the validation ladder from
+reference/validation.md. State lives in the manifest under each unit's
+"status" key, so inventory.py, validate_dag.py, and this script share one file.
+
+States (exactly these, in ladder order):
+
+  pending        not started
+  translate      lowering Dagster to Airflow in progress
+  fix-import     making it pass gate 2 (DagBag import)
+  fix-lint       making it pass gate 1 (ruff) and gate 3 (structure)
+  fix-tests      making it pass gate 4 (execution)
+  verify-parity  making it pass gates 5 and 6 (data parity, idempotency)
+  complete       every gate green
+  deferred       cannot pass after the retry cap; REQUIRES a reason
+
+Legal transitions: forward one step along the ladder order above, and into
+`deferred` from any non-complete state. A deferred unit may be reopened by
+advancing it, which moves it back to `translate`.
+
+Advancing requires --evidence: a path or command-output reference that names the
+gate proof (for example "reports/orders_daily.gate3.json" or the parity checksum
+line). Deferring requires --reason.
+
+A unit the planner marked target:"none" (it lowers into another unit or the
+platform layer, so it has no DAG and no gate ladder) is dispositioned by a single
+`advance` straight to complete, with --evidence naming where it went.
+
+Manifest shape consumed and written:
+
+  { "units": { "<unit_id>": { ..., "status": {
+        "state": "translate",
+        "reason": null,
+        "history": [ {"to": "translate", "evidence": "..."} ]
+  } } } }
+
+Commands (advance/defer/reopen take a single <unit-id> OR a --where/--from-state
+filter for bulk; the two forms are mutually exclusive):
+  status.py [--manifest M] show [--by-state]
+  status.py [--manifest M] advance <unit-id> --evidence "..."
+  status.py [--manifest M] advance --where kind=op [--where classification=MECH]
+            [--from-state pending] --evidence "..." [--dry-run]
+  status.py [--manifest M] defer  (<unit-id> | --where KEY=VALUE ...) --reason "..." [--dry-run]
+  status.py [--manifest M] reopen (<unit-id> | --where KEY=VALUE ...) --reason "..." [--dry-run]
+  status.py [--manifest M] summary
+
+Bulk semantics: every matched unit gets the transition under the normal legality
+rules; illegal transitions are reported per-unit and skipped, not fatal. --where
+KEY=VALUE matches a top-level record field (kind, classification, ...); repeatable
+and ANDed. --from-state matches the unit's current state. --dry-run prints the
+match list and planned transitions without writing. Single-unit mode is unchanged:
+a missing unit exits 2, an illegal move exits 1.
+
+Stdlib only.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+DEFAULT_MANIFEST = os.path.join("include", "inventory", "manifest.json")
+
+# Ladder order. `deferred` sits outside the linear chain.
+LADDER = [
+    "pending",
+    "translate",
+    "fix-import",
+    "fix-lint",
+    "fix-tests",
+    "verify-parity",
+    "complete",
+]
+ALL_STATES = LADDER + ["deferred"]
+
+# States that count as a final disposition for the completeness check.
+TERMINAL = {"complete", "deferred"}
+
+
+def load_manifest(path):
+    if not os.path.isfile(path):
+        sys.stderr.write("error: manifest not found: " + path + "\n")
+        sys.exit(2)
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def save_manifest(path, manifest):
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+
+
+def unit_state(unit):
+    """Current state of a unit, defaulting to pending when untracked."""
+    status = unit.get("status")
+    if not isinstance(status, dict):
+        return "pending"
+    return status.get("state", "pending")
+
+
+def get_units(manifest):
+    units = manifest.get("units")
+    if not isinstance(units, dict):
+        sys.stderr.write("error: manifest has no 'units' object\n")
+        sys.exit(2)
+    return units
+
+
+def cmd_show(manifest, by_state):
+    units = get_units(manifest)
+    if by_state:
+        buckets = {s: [] for s in ALL_STATES}
+        for unit_id, unit in units.items():
+            buckets.setdefault(unit_state(unit), []).append(unit_id)
+        for state in ALL_STATES:
+            ids = sorted(buckets.get(state, []))
+            print("{0:<14} {1}".format(state, len(ids)))
+            for unit_id in ids:
+                print("    " + unit_id)
+    else:
+        for unit_id in sorted(units):
+            unit = units[unit_id]
+            state = unit_state(unit)
+            reason = ""
+            status = unit.get("status")
+            if isinstance(status, dict) and status.get("reason"):
+                reason = "  (" + status["reason"] + ")"
+            print("{0:<40} {1}{2}".format(unit_id, state, reason))
+    return 0
+
+
+# Transition planners: given a unit, return (target_state, current_state, error).
+# error is a human phrase when the transition is illegal (target is then None).
+
+def _plan_advance(unit):
+    current = unit_state(unit)
+    if current == "complete":
+        return None, current, "already complete"
+    if unit.get("target") == "none":
+        # Deliberately DAG-less units (lower into another unit or the platform
+        # layer) have no gate ladder to walk. Advance dispositions them in one
+        # step; the required --evidence names where the unit went (G13).
+        return "complete", current, None
+    if current == "deferred":
+        return "translate", current, None  # reopen a deferred unit at the chain start
+    return LADDER[LADDER.index(current) + 1], current, None
+
+
+def _plan_defer(unit):
+    current = unit_state(unit)
+    if current == "complete":
+        return None, current, "cannot defer a complete unit"
+    return "deferred", current, None
+
+
+def _plan_reopen(unit):
+    current = unit_state(unit)
+    if current not in ("complete", "deferred"):
+        return None, current, "reopen only applies to complete or deferred units"
+    return "translate", current, None
+
+
+_PLANNERS = {"advance": _plan_advance, "defer": _plan_defer, "reopen": _plan_reopen}
+
+
+def _commit(unit, target, current, op, evidence, reason):
+    """Write the transition onto a unit's status (no save)."""
+    status = unit.get("status")
+    if not isinstance(status, dict):  # inventory.py emits status as a plain string
+        status = unit["status"] = {}
+    status["state"] = target
+    status["reason"] = None if op == "advance" else reason
+    entry = {"to": target}
+    if op == "advance":
+        entry["evidence"] = evidence
+    elif op == "defer":
+        entry["reason"] = reason
+    else:  # reopen
+        entry["reopened_from"] = current
+        entry["reason"] = reason
+    status.setdefault("history", []).append(entry)
+
+
+def _single_line(op, uid, current, target, evidence, reason):
+    """The one-line result for single-unit mode, unchanged from before."""
+    if op == "advance":
+        return "{0}: {1} -> {2}  ({3})".format(uid, current, target, evidence)
+    if op == "defer":
+        return "{0}: {1} -> deferred  ({2})".format(uid, current, reason)
+    return "{0}: {1} -> translate (reopened)  ({2})".format(uid, current, reason)
+
+
+def _parse_where(where_args):
+    pairs = []
+    for w in where_args or []:
+        if "=" not in w:
+            sys.stderr.write("error: --where expects key=value, got: " + w + "\n")
+            sys.exit(2)
+        k, v = w.split("=", 1)
+        pairs.append((k.strip(), v.strip()))
+    return pairs
+
+
+def _matches(unit, where, from_state):
+    for k, v in where:
+        if str(unit.get(k)) != v:
+            return False
+    if from_state is not None and unit_state(unit) != from_state:
+        return False
+    return True
+
+
+def _selected(units, where, from_state):
+    return [(uid, units[uid]) for uid in sorted(units) if _matches(units[uid], where, from_state)]
+
+
+def _filter_desc(where, from_state):
+    parts = ["{0}={1}".format(k, v) for k, v in where]
+    if from_state is not None:
+        parts.append("from-state=" + from_state)
+    return ", ".join(parts) or "(no filter)"
+
+
+def run_transition(manifest, path, op, args):
+    """Apply advance/defer/reopen to one unit (positional) or many (--where).
+
+    Single-unit mode is unchanged: missing unit -> exit 2, illegal move -> exit 1.
+    Bulk mode applies to every matched unit under the same legality rules;
+    illegal transitions are reported per-unit and skipped, not fatal.
+    """
+    units = get_units(manifest)
+
+    reason = getattr(args, "reason", None)
+    if op in ("defer", "reopen"):
+        if not reason or not reason.strip():
+            sys.stderr.write("error: " + op + " requires a non-empty --reason\n")
+            return 2
+        reason = reason.strip()
+    evidence = getattr(args, "evidence", None)
+
+    where = _parse_where(args.where)
+    from_state = args.from_state
+
+    if args.unit_id is not None:
+        if where or from_state is not None:
+            sys.stderr.write("error: pass a unit id OR --where/--from-state, not both\n")
+            return 2
+        if args.unit_id not in units:
+            sys.stderr.write("error: no such unit: " + args.unit_id + "\n")
+            return 2
+        targets, single = [(args.unit_id, units[args.unit_id])], True
+    else:
+        if not where and from_state is None:
+            sys.stderr.write("error: bulk mode needs at least one --where or --from-state filter\n")
+            return 2
+        targets, single = _selected(units, where, from_state), False
+        if not targets:
+            print("no units matched " + _filter_desc(where, from_state))
+            return 0
+
+    planner = _PLANNERS[op]
+    applied = skipped = 0
+    for uid, unit in targets:
+        target, current, err = planner(unit)
+        if err is not None:
+            if single:
+                sys.stderr.write("error: cannot {0} {1}: {2} (state={3})\n".format(op, uid, err, current))
+                return 1
+            print("  skip  {0}: {1} ({2})".format(uid, err, current))
+            skipped += 1
+            continue
+        if args.dry_run:
+            print("  would-{0}  {1}: {2} -> {3}".format(op, uid, current, target))
+        else:
+            _commit(unit, target, current, op, evidence, reason)
+            print(_single_line(op, uid, current, target, evidence, reason) if single
+                  else "  {0}: {1} -> {2}".format(uid, current, target))
+        applied += 1
+
+    if not args.dry_run and applied:
+        save_manifest(path, manifest)
+    if not single:
+        verb = "would apply" if args.dry_run else "applied"
+        tail = " (dry-run, nothing written)" if args.dry_run else ""
+        print("{0}: {1} {2}, {3} skipped{4}".format(op, applied, verb, skipped, tail))
+    return 0
+
+
+def cmd_summary(manifest):
+    """Counts per state plus the completeness gate.
+
+    Silent omission = a unit whose recorded state is not one of the known
+    states (or is missing entirely and cannot even default). Every manifest
+    record must carry a recognized disposition; exit nonzero if any does not.
+    """
+    units = get_units(manifest)
+    # Surface a static-only manifest so a summary is never mistaken for a full
+    # inventory (GAP-1): runtime mode was requested but did not run.
+    if manifest.get("runtime_error"):
+        print("NOTE: manifest is STATIC-ONLY (runtime mode did not run: {0})".format(
+            manifest["runtime_error"]))
+    counts = {s: 0 for s in ALL_STATES}
+    unknown = []
+
+    for unit_id, unit in units.items():
+        state = unit_state(unit)
+        if state not in counts:
+            unknown.append((unit_id, state))
+        else:
+            counts[state] += 1
+
+    total = len(units)
+    print("units: {0}".format(total))
+    for state in ALL_STATES:
+        print("  {0:<14} {1}".format(state, counts[state]))
+
+    terminal = sum(counts[s] for s in TERMINAL)
+    in_flight = total - terminal - len(unknown)
+    print("dispositioned (complete or deferred): {0}/{1}".format(terminal, total))
+    print("in flight: {0}".format(in_flight))
+
+    if unknown:
+        print("SILENT OMISSION: {0} unit(s) with no recognized state".format(len(unknown)))
+        for unit_id, state in unknown:
+            print("  {0}  (state={1!r})".format(unit_id, state))
+        return 1
+    if in_flight:
+        # SKILL.md rule 2: every record ends complete or deferred; exit nonzero otherwise.
+        print("INCOMPLETE: {0} unit(s) not yet dispositioned".format(in_flight))
+        return 1
+    return 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Per-unit migration state machine.")
+    parser.add_argument("--manifest", default=DEFAULT_MANIFEST,
+                        help="inventory manifest JSON (default: " + DEFAULT_MANIFEST + ")")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def _add_filters(p):
+        # bulk selection, shared by advance/defer/reopen (unit_id optional)
+        p.add_argument("unit_id", nargs="?", default=None,
+                       help="single unit id; omit and use --where/--from-state for bulk")
+        p.add_argument("--where", action="append", default=[], metavar="KEY=VALUE",
+                       help="bulk filter on a record field (e.g. kind=op); repeatable, ANDed")
+        p.add_argument("--from-state", dest="from_state", default=None,
+                       help="bulk filter: only units currently in this state")
+        p.add_argument("--dry-run", action="store_true",
+                       help="print the matches and planned transitions without writing")
+
+    p_show = sub.add_parser("show", help="list units and their states")
+    p_show.add_argument("--by-state", action="store_true", help="group by state")
+
+    p_adv = sub.add_parser("advance", help="advance a unit (or a --where set) one step")
+    _add_filters(p_adv)
+    p_adv.add_argument("--evidence", required=True,
+                       help="path or command-output reference proving the gate passed")
+
+    p_def = sub.add_parser("defer", help="mark a unit (or a --where set) deferred with a reason")
+    _add_filters(p_def)
+    p_def.add_argument("--reason", required=True, help="why the unit(s) are deferred")
+
+    p_reopen = sub.add_parser("reopen", help="move complete/deferred unit(s) back to translate")
+    _add_filters(p_reopen)
+    p_reopen.add_argument("--reason", required=True, help="why the unit(s) are being reopened")
+
+    sub.add_parser("summary", help="counts per state and completeness check")
+
+    args = parser.parse_args(argv)
+    manifest = load_manifest(args.manifest)
+
+    if args.command == "show":
+        return cmd_show(manifest, args.by_state)
+    if args.command in ("advance", "defer", "reopen"):
+        return run_transition(manifest, args.manifest, args.command, args)
+    if args.command == "summary":
+        return cmd_summary(manifest)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/migrating-dagster-to-airflow/scripts/tests/conftest.py
+++ b/skills/migrating-dagster-to-airflow/scripts/tests/conftest.py
@@ -1,0 +1,163 @@
+"""Shared fixtures for the migration-scripts test suite.
+
+Self-contained: builds tiny synthetic Dagster projects under tmp_path so the
+suite has no dependency on the repo's test-projects/ or example-migrations/ (which stay behind when
+this skill subtree moves to astronomer/agents). The scripts are imported by
+adding the parent scripts/ directory to sys.path.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the scripts (one level up from tests/) importable as top-level modules.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+# A minimal Dagster project exercising the constructs the scanner must catch.
+# It is never imported or executed: the static scan only parses text, so the
+# `dagster` imports and decorators need not resolve.
+_ASSETS = '''\
+import dagster as dg
+from dagster import asset, multi_asset, AssetOut, AssetSpec, op
+
+
+@asset
+def raw_sales(context):
+    return 1
+
+
+@asset(io_manager_key="warehouse")
+def daily_sales(context, raw_sales):
+    # raw_sales is a signature-inferred upstream edge
+    return raw_sales
+
+
+@multi_asset(can_subset=True, outs={"out_a": AssetOut(), "out_b": AssetOut()})
+def multi_outs():
+    yield None
+
+
+@multi_asset(specs=[AssetSpec("spec_x", deps=["raw_sales"]), AssetSpec("spec_y")])
+def multi_specs():
+    yield None
+
+
+@op
+def legacy_op(x):
+    return x
+
+
+@solid
+def old_solid(x):
+    return x
+'''
+
+_RESOURCES = '''\
+import dagster as dg
+
+
+class BaseParquetIO(dg.ConfigurableIOManager):
+    def handle_output(self, context, obj):
+        pass
+
+    def load_input(self, context):
+        return None
+
+
+class DerivedParquetIO(BaseParquetIO):
+    prefix: str = "x"
+'''
+
+_FRESHNESS = '''\
+import dagster as dg
+
+NEW_FP = dg.FreshnessPolicy.cron(deadline_cron="0 9 * * *")
+LEGACY_FP = dg.LegacyFreshnessPolicy(maximum_lag_minutes=120)
+'''
+
+_CLOUD = '''\
+import os
+
+IS_BRANCH = os.environ.get("DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT", "")
+'''
+
+_DEFINITIONS = '''\
+import dagster as dg
+from dagster import Definitions, ScheduleDefinition, define_asset_job
+
+
+warehouse_job = define_asset_job("warehouse_job", selection="*")
+
+resources = {
+    "io_manager": DerivedParquetIO(),
+    "warehouse": dg.DuckDBPandasIOManager(database="x"),
+}
+
+defs = Definitions(
+    schedules=[ScheduleDefinition(job=warehouse_job, cron_schedule="@weekly")],
+    resources=resources,
+)
+'''
+
+_BRANCHED = '''\
+import os
+import dagster as dg
+from dagster import define_asset_job
+from dagster import sensor as sensor_decorator  # aliased import
+from dagster_dbt import dbt_cloud_assets          # integration package origin
+
+
+# name= kwarg / first-positional should win over the Python binding name
+named_job = define_asset_job(name="the_real_job_name", selection="*")
+
+
+# aliased decorator must still resolve to the dagster symbol `sensor`
+@sensor_decorator(name="the_real_sensor_name")
+def binding_sensor_name(context):
+    ...
+
+
+# import-time env branch selecting an alternate integration: BOTH branches must
+# produce records, each flagged with its condition.
+if os.getenv("ORCH_MODE") == "cloud":
+
+    @dbt_cloud_assets(workspace=None)
+    def cloud_models(context):
+        ...
+
+else:
+
+    @dg.asset
+    def local_only_asset():
+        return 1
+'''
+
+_DEFS_YAML = '''\
+type: my_lib.ComponentA
+attributes:
+  cron: "@daily"
+  key: alpha
+---
+type: my_lib.ComponentB
+attributes:
+  key: beta
+'''
+
+
+@pytest.fixture()
+def synth_project(tmp_path):
+    """Write the synthetic Dagster project and return its root path."""
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "assets.py").write_text(_ASSETS)
+    (pkg / "resources.py").write_text(_RESOURCES)
+    (pkg / "freshness.py").write_text(_FRESHNESS)
+    (pkg / "cloud.py").write_text(_CLOUD)
+    (pkg / "definitions.py").write_text(_DEFINITIONS)
+    (pkg / "branched.py").write_text(_BRANCHED)
+    comps = pkg / "components"
+    comps.mkdir()
+    (comps / "defs.yaml").write_text(_DEFS_YAML)
+    return tmp_path

--- a/skills/migrating-dagster-to-airflow/scripts/tests/conftest.py
+++ b/skills/migrating-dagster-to-airflow/scripts/tests/conftest.py
@@ -18,7 +18,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 # A minimal Dagster project exercising the constructs the scanner must catch.
 # It is never imported or executed: the static scan only parses text, so the
 # `dagster` imports and decorators need not resolve.
-_ASSETS = '''\
+_ASSETS = """\
 import dagster as dg
 from dagster import asset, multi_asset, AssetOut, AssetSpec, op
 
@@ -52,9 +52,9 @@ def legacy_op(x):
 @solid
 def old_solid(x):
     return x
-'''
+"""
 
-_RESOURCES = '''\
+_RESOURCES = """\
 import dagster as dg
 
 
@@ -68,22 +68,22 @@ class BaseParquetIO(dg.ConfigurableIOManager):
 
 class DerivedParquetIO(BaseParquetIO):
     prefix: str = "x"
-'''
+"""
 
-_FRESHNESS = '''\
+_FRESHNESS = """\
 import dagster as dg
 
 NEW_FP = dg.FreshnessPolicy.cron(deadline_cron="0 9 * * *")
 LEGACY_FP = dg.LegacyFreshnessPolicy(maximum_lag_minutes=120)
-'''
+"""
 
-_CLOUD = '''\
+_CLOUD = """\
 import os
 
 IS_BRANCH = os.environ.get("DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT", "")
-'''
+"""
 
-_DEFINITIONS = '''\
+_DEFINITIONS = """\
 import dagster as dg
 from dagster import Definitions, ScheduleDefinition, define_asset_job
 
@@ -99,9 +99,9 @@ defs = Definitions(
     schedules=[ScheduleDefinition(job=warehouse_job, cron_schedule="@weekly")],
     resources=resources,
 )
-'''
+"""
 
-_BRANCHED = '''\
+_BRANCHED = """\
 import os
 import dagster as dg
 from dagster import define_asset_job
@@ -132,9 +132,9 @@ else:
     @dg.asset
     def local_only_asset():
         return 1
-'''
+"""
 
-_DEFS_YAML = '''\
+_DEFS_YAML = """\
 type: my_lib.ComponentA
 attributes:
   cron: "@daily"
@@ -143,7 +143,7 @@ attributes:
 type: my_lib.ComponentB
 attributes:
   key: beta
-'''
+"""
 
 
 @pytest.fixture()

--- a/skills/migrating-dagster-to-airflow/scripts/tests/test_inventory.py
+++ b/skills/migrating-dagster-to-airflow/scripts/tests/test_inventory.py
@@ -24,7 +24,9 @@ def test_import_based_detection_kinds(synth_project):
     recs = list(m["units"].values())
     assert m["modes"] == ["static"]
     # kinds are the RAW dagster symbol names (no internal remapping)
-    assert {"daily_sales", "raw_sales", "local_only_asset"} <= set(_names(recs, "asset"))
+    assert {"daily_sales", "raw_sales", "local_only_asset"} <= set(
+        _names(recs, "asset")
+    )
     assert _names(recs, "multi_asset") == ["multi_outs", "multi_specs"]
     assert _by_kind(recs, "op") and _by_kind(recs, "define_asset_job")
     assert _by_kind(recs, "component_instance")
@@ -96,8 +98,10 @@ def test_resource_dict_key_naming(synth_project):
 
 def test_multi_asset_outputs_are_fields(synth_project):
     m = _scan(synth_project)
-    outs = {r["name"]: [o["name"] for o in r.get("outputs", [])]
-            for r in _by_kind(list(m["units"].values()), "multi_asset")}
+    outs = {
+        r["name"]: [o["name"] for o in r.get("outputs", [])]
+        for r in _by_kind(list(m["units"].values()), "multi_asset")
+    }
     assert outs["multi_outs"] == ["out_a", "out_b"]
     # output names are not minted as standalone asset units
     assert not ({"out_a", "out_b"} & set(_names(list(m["units"].values()), "asset")))
@@ -122,7 +126,10 @@ def test_both_conditional_branches_visible(synth_project):
 
 def test_multidoc_component_yaml(synth_project):
     m = _scan(synth_project)
-    assert _names(list(m["units"].values()), "component_instance") == ["my_lib.ComponentA", "my_lib.ComponentB"]
+    assert _names(list(m["units"].values()), "component_instance") == [
+        "my_lib.ComponentA",
+        "my_lib.ComponentB",
+    ]
 
 
 def test_dagster_cloud_ref_and_coupling_field(synth_project):
@@ -148,4 +155,6 @@ def test_helper_calls_not_recorded(synth_project):
 def test_units_shape_for_downstream_scripts(synth_project):
     m = _scan(synth_project)
     assert m["units"] and all(":" in uid for uid in m["units"])
-    assert all("source_edges" in rec and "edges" not in rec for rec in m["units"].values())
+    assert all(
+        "source_edges" in rec and "edges" not in rec for rec in m["units"].values()
+    )

--- a/skills/migrating-dagster-to-airflow/scripts/tests/test_inventory.py
+++ b/skills/migrating-dagster-to-airflow/scripts/tests/test_inventory.py
@@ -1,0 +1,151 @@
+"""Static-scan tests for the redesigned (import-based) inventory.py.
+
+The scanner no longer curates a symbol table: it records any decorator/call whose
+origin resolves to a dagster* module, kind = the raw dagster symbol name, and
+leaves classification = "pending" for the agent."""
+
+import inventory
+
+
+def _scan(root):
+    return inventory.build_manifest(root, use_runtime=False)
+
+
+def _by_kind(records, kind):
+    return [r for r in records if r["kind"] == kind]
+
+
+def _names(records, kind):
+    return sorted(r["name"] for r in records if r["kind"] == kind)
+
+
+def test_import_based_detection_kinds(synth_project):
+    m = _scan(synth_project)
+    recs = list(m["units"].values())
+    assert m["modes"] == ["static"]
+    # kinds are the RAW dagster symbol names (no internal remapping)
+    assert {"daily_sales", "raw_sales", "local_only_asset"} <= set(_names(recs, "asset"))
+    assert _names(recs, "multi_asset") == ["multi_outs", "multi_specs"]
+    assert _by_kind(recs, "op") and _by_kind(recs, "define_asset_job")
+    assert _by_kind(recs, "component_instance")
+
+
+def test_classification_is_pending_everywhere(synth_project):
+    # the scanner stops proposing MECH/JUDG/REDESIGN/NONE; the agent classifies
+    m = _scan(synth_project)
+    assert all(r["classification"] == "pending" for r in list(m["units"].values()))
+    assert set(m["legend"]) >= {"MECH", "JUDG", "REDESIGN", "NONE", "pending"}
+
+
+def test_counts_are_per_kind(synth_project):
+    m = _scan(synth_project)
+    assert m["counts"].get("asset", 0) >= 3
+    assert m["total"] == len(list(m["units"].values()))
+
+
+def test_bare_from_import_decorator(synth_project):
+    # `from dagster import asset` then `@asset` resolves to kind "asset"
+    m = _scan(synth_project)
+    assert "raw_sales" in _names(list(m["units"].values()), "asset")
+
+
+def test_module_alias_decorator(synth_project):
+    # `import dagster as dg` then `@dg.asset` resolves to kind "asset"
+    m = _scan(synth_project)
+    assert "local_only_asset" in _names(list(m["units"].values()), "asset")
+
+
+def test_aliased_decorator_import(synth_project):
+    # `from dagster import sensor as sensor_decorator` then `@sensor_decorator`
+    # must still resolve to the dagster symbol `sensor` (the old blind spot)
+    m = _scan(synth_project)
+    assert "the_real_sensor_name" in _names(list(m["units"].values()), "sensor")
+
+
+def test_integration_package_origin(synth_project):
+    # `from dagster_dbt import dbt_cloud_assets` resolves (dagster_* origin)
+    m = _scan(synth_project)
+    assert "cloud_models" in _names(list(m["units"].values()), "dbt_cloud_assets")
+
+
+def test_deprecated_spelling_flagged(synth_project):
+    # DEPRECATED_SYMBOLS (the stable past) still flags spelling + note
+    m = _scan(synth_project)
+    solids = _by_kind(list(m["units"].values()), "solid")
+    assert len(solids) == 1 and solids[0]["spelling"] == "deprecated"
+    assert solids[0]["note"]
+
+
+def test_declared_name_prefers_kwarg_over_binding(synth_project):
+    m = _scan(synth_project)
+    assert "the_real_job_name" in _names(list(m["units"].values()), "define_asset_job")
+    assert "the_real_sensor_name" in _names(list(m["units"].values()), "sensor")
+
+
+def test_custom_io_manager_subclass_chain(synth_project):
+    m = _scan(synth_project)
+    io = {r["name"] for r in _by_kind(list(m["units"].values()), "io_manager")}
+    assert {"BaseParquetIO", "DerivedParquetIO"} <= io
+
+
+def test_resource_dict_key_naming(synth_project):
+    # a dagster IO-manager constructed as a resources-dict value is named by key
+    m = _scan(synth_project)
+    assert "warehouse" in _names(list(m["units"].values()), "DuckDBPandasIOManager")
+
+
+def test_multi_asset_outputs_are_fields(synth_project):
+    m = _scan(synth_project)
+    outs = {r["name"]: [o["name"] for o in r.get("outputs", [])]
+            for r in _by_kind(list(m["units"].values()), "multi_asset")}
+    assert outs["multi_outs"] == ["out_a", "out_b"]
+    # output names are not minted as standalone asset units
+    assert not ({"out_a", "out_b"} & set(_names(list(m["units"].values()), "asset")))
+
+
+def test_signature_edges_and_producer_io_manager(synth_project):
+    m = _scan(synth_project)
+    daily = next(r for r in list(m["units"].values()) if r["name"] == "daily_sales")
+    e = daily["source_edges"][0]
+    assert e["upstream"] == "raw_sales" and e.get("from") == "signature"
+    assert e["io_manager"] == "io_manager" and e["io_manager_source"] == "producer"
+    assert e["consumer_io_manager"] == "warehouse"
+
+
+def test_both_conditional_branches_visible(synth_project):
+    m = _scan(synth_project)
+    by_name = {r["name"]: r for r in list(m["units"].values())}
+    assert "cloud_models" in by_name and "local_only_asset" in by_name
+    assert isinstance(by_name["cloud_models"].get("conditional"), str)
+    assert "not (" in by_name["local_only_asset"].get("conditional", "")
+
+
+def test_multidoc_component_yaml(synth_project):
+    m = _scan(synth_project)
+    assert _names(list(m["units"].values()), "component_instance") == ["my_lib.ComponentA", "my_lib.ComponentB"]
+
+
+def test_dagster_cloud_ref_and_coupling_field(synth_project):
+    m = _scan(synth_project)
+    assert _by_kind(list(m["units"].values()), "branch_env_ref")
+    assert m["dbt_manifest_coupling"] == []
+
+
+def test_freshness_policy_both_spellings(synth_project):
+    # import-based: kind is the raw symbol; the agent classifies legacy vs GA
+    m = _scan(synth_project)
+    kinds = {r["kind"] for r in list(m["units"].values())}
+    assert {"FreshnessPolicy", "LegacyFreshnessPolicy"} <= kinds
+
+
+def test_helper_calls_not_recorded(synth_project):
+    # AssetOut inside outs=, EnvVar defaults, etc. are not definition sites
+    m = _scan(synth_project)
+    kinds = {r["kind"] for r in list(m["units"].values())}
+    assert not (kinds & {"AssetOut", "AssetSpec", "AssetIn", "get_dagster_logger"})
+
+
+def test_units_shape_for_downstream_scripts(synth_project):
+    m = _scan(synth_project)
+    assert m["units"] and all(":" in uid for uid in m["units"])
+    assert all("source_edges" in rec and "edges" not in rec for rec in m["units"].values())

--- a/skills/migrating-dagster-to-airflow/scripts/tests/test_merge.py
+++ b/skills/migrating-dagster-to-airflow/scripts/tests/test_merge.py
@@ -1,0 +1,104 @@
+"""Runtime-first reconciliation tests for the redesigned inventory.py.
+
+Runtime records are the primary inventory; each is grafted with a matching
+static site's syntactic extras. Static-only sites are appended flagged
+`not_in_runtime`. Family matching is a stable structural heuristic, not a table."""
+
+import inventory
+
+
+def _rt(kind, name, **params):
+    return {"kind": kind, "name": name, "classification": "pending", "note": "",
+            "params": params, "source_edges": [], "status": "pending", "source": "runtime"}
+
+
+def _st(kind, name, **extra):
+    r = {"kind": kind, "name": name, "classification": "pending", "note": "",
+         "params": {}, "source_edges": [], "status": "pending"}
+    r.update(extra)
+    return r
+
+
+def test_runtime_primary_static_grafted():
+    runtime = [_rt("asset", "AssetKey(['users'])")]
+    static = [_st("asset", "users",
+                  source_edges=[{"upstream": "raw", "io_manager": None}], location="a.py:1")]
+    combined = inventory._merge_runtime_first(runtime, static)
+    assert len(combined) == 1
+    assert combined[0]["source"] == "runtime"          # runtime is primary
+    assert combined[0]["source_edges"]                 # static extras grafted on
+    assert combined[0]["static_location"] == "a.py:1"
+    assert not any(r.get("not_in_runtime") for r in combined)
+
+
+def test_static_only_site_is_supplemented():
+    # a static site the runtime enumeration does not surface (an op lives inside
+    # a job, not a top-level object) is kept, flagged not_in_runtime
+    runtime = [_rt("asset", "users")]
+    static = [_st("op", "my_op", location="o.py:1")]
+    combined = inventory._merge_runtime_first(runtime, static)
+    assert len(combined) == 2
+    only = [r for r in combined if r.get("not_in_runtime")]
+    assert len(only) == 1 and only[0]["kind"] == "op"
+
+
+def test_job_family_alignment():
+    # runtime kind `job` aligns with static `define_asset_job` via coarse family
+    runtime = [_rt("job", "weekly_job")]
+    static = [_st("define_asset_job", "weekly_job", location="d.py:1")]
+    combined = inventory._merge_runtime_first(runtime, static)
+    assert len(combined) == 1 and combined[0]["kind"] == "job"
+    assert not any(r.get("not_in_runtime") for r in combined)
+
+
+def test_check_does_not_align_with_asset():
+    # a check and an asset of the same name are different families
+    runtime = [_rt("asset_check", "row_check")]
+    static = [_st("asset", "row_check", location="a.py:1")]
+    combined = inventory._merge_runtime_first(runtime, static)
+    assert len(combined) == 2
+    assert any(r.get("not_in_runtime") and r["kind"] == "asset" for r in combined)
+
+
+def test_coarse_family_heuristic():
+    f = inventory._coarse_family
+    assert f("asset_check") == "check" and f("multi_asset_check") == "check"
+    assert f("asset_job") == "job" and f("define_asset_job") == "job"
+    assert f("ScheduleDefinition") == "schedule"
+    assert f("run_status_sensor") == "sensor"
+    assert f("multi_asset") == "asset" and f("dbt_assets") == "asset"
+    assert f("DuckDBPandasIOManager") == "resource" and f("DbtCloudWorkspace") == "resource"
+
+
+def test_runtime_check_pairs_extracts_check_name():
+    class _Key:
+        def __init__(self, name, asset):
+            self.name = name
+            self.asset_key = asset
+
+    class _ChecksDef:
+        def __init__(self, keys):
+            self.check_keys = keys
+
+    obj = _ChecksDef([_Key("row_count_positive", "AssetKey(['us_sector_etfs_raw'])")])
+    assert inventory._runtime_check_pairs(obj) == [("row_count_positive", "us_sector_etfs_raw")]
+
+
+def test_dagster_import_resolution():
+    # module alias, from-import, aliased from-import, builder form
+    mod = {"dg": "dagster", "ddbt": "dagster_dbt"}
+    sym = {"asset": ("dagster", "asset"), "a": ("dagster", "asset"),
+           "FreshnessPolicy": ("dagster", "FreshnessPolicy")}
+    import ast
+
+    def resolve(src):
+        node = ast.parse(src, mode="eval").body
+        return inventory._resolve_dagster_symbol(node, mod, sym)
+
+    assert resolve("dg.asset") == "asset"
+    assert resolve("dg.multi_asset()") == "multi_asset"
+    assert resolve("asset") == "asset"
+    assert resolve("a") == "asset"                       # aliased import
+    assert resolve("FreshnessPolicy.cron()") == "FreshnessPolicy"   # builder form
+    assert resolve("ddbt.dbt_assets") == "dbt_assets"    # integration package
+    assert resolve("pandas.DataFrame") is None           # non-dagster origin

--- a/skills/migrating-dagster-to-airflow/scripts/tests/test_merge.py
+++ b/skills/migrating-dagster-to-airflow/scripts/tests/test_merge.py
@@ -8,25 +8,46 @@ import inventory
 
 
 def _rt(kind, name, **params):
-    return {"kind": kind, "name": name, "classification": "pending", "note": "",
-            "params": params, "source_edges": [], "status": "pending", "source": "runtime"}
+    return {
+        "kind": kind,
+        "name": name,
+        "classification": "pending",
+        "note": "",
+        "params": params,
+        "source_edges": [],
+        "status": "pending",
+        "source": "runtime",
+    }
 
 
 def _st(kind, name, **extra):
-    r = {"kind": kind, "name": name, "classification": "pending", "note": "",
-         "params": {}, "source_edges": [], "status": "pending"}
+    r = {
+        "kind": kind,
+        "name": name,
+        "classification": "pending",
+        "note": "",
+        "params": {},
+        "source_edges": [],
+        "status": "pending",
+    }
     r.update(extra)
     return r
 
 
 def test_runtime_primary_static_grafted():
     runtime = [_rt("asset", "AssetKey(['users'])")]
-    static = [_st("asset", "users",
-                  source_edges=[{"upstream": "raw", "io_manager": None}], location="a.py:1")]
+    static = [
+        _st(
+            "asset",
+            "users",
+            source_edges=[{"upstream": "raw", "io_manager": None}],
+            location="a.py:1",
+        )
+    ]
     combined = inventory._merge_runtime_first(runtime, static)
     assert len(combined) == 1
-    assert combined[0]["source"] == "runtime"          # runtime is primary
-    assert combined[0]["source_edges"]                 # static extras grafted on
+    assert combined[0]["source"] == "runtime"  # runtime is primary
+    assert combined[0]["source_edges"]  # static extras grafted on
     assert combined[0]["static_location"] == "a.py:1"
     assert not any(r.get("not_in_runtime") for r in combined)
 
@@ -67,7 +88,10 @@ def test_coarse_family_heuristic():
     assert f("ScheduleDefinition") == "schedule"
     assert f("run_status_sensor") == "sensor"
     assert f("multi_asset") == "asset" and f("dbt_assets") == "asset"
-    assert f("DuckDBPandasIOManager") == "resource" and f("DbtCloudWorkspace") == "resource"
+    assert (
+        f("DuckDBPandasIOManager") == "resource"
+        and f("DbtCloudWorkspace") == "resource"
+    )
 
 
 def test_runtime_check_pairs_extracts_check_name():
@@ -81,14 +105,19 @@ def test_runtime_check_pairs_extracts_check_name():
             self.check_keys = keys
 
     obj = _ChecksDef([_Key("row_count_positive", "AssetKey(['us_sector_etfs_raw'])")])
-    assert inventory._runtime_check_pairs(obj) == [("row_count_positive", "us_sector_etfs_raw")]
+    assert inventory._runtime_check_pairs(obj) == [
+        ("row_count_positive", "us_sector_etfs_raw")
+    ]
 
 
 def test_dagster_import_resolution():
     # module alias, from-import, aliased from-import, builder form
     mod = {"dg": "dagster", "ddbt": "dagster_dbt"}
-    sym = {"asset": ("dagster", "asset"), "a": ("dagster", "asset"),
-           "FreshnessPolicy": ("dagster", "FreshnessPolicy")}
+    sym = {
+        "asset": ("dagster", "asset"),
+        "a": ("dagster", "asset"),
+        "FreshnessPolicy": ("dagster", "FreshnessPolicy"),
+    }
     import ast
 
     def resolve(src):
@@ -98,7 +127,7 @@ def test_dagster_import_resolution():
     assert resolve("dg.asset") == "asset"
     assert resolve("dg.multi_asset()") == "multi_asset"
     assert resolve("asset") == "asset"
-    assert resolve("a") == "asset"                       # aliased import
-    assert resolve("FreshnessPolicy.cron()") == "FreshnessPolicy"   # builder form
-    assert resolve("ddbt.dbt_assets") == "dbt_assets"    # integration package
-    assert resolve("pandas.DataFrame") is None           # non-dagster origin
+    assert resolve("a") == "asset"  # aliased import
+    assert resolve("FreshnessPolicy.cron()") == "FreshnessPolicy"  # builder form
+    assert resolve("ddbt.dbt_assets") == "dbt_assets"  # integration package
+    assert resolve("pandas.DataFrame") is None  # non-dagster origin

--- a/skills/migrating-dagster-to-airflow/scripts/tests/test_status.py
+++ b/skills/migrating-dagster-to-airflow/scripts/tests/test_status.py
@@ -1,0 +1,121 @@
+"""State-machine tests for status.py, driven through main(argv) on a temp manifest."""
+
+import json
+
+import pytest
+
+import status
+
+
+def _write(tmp_path, units):
+    p = tmp_path / "manifest.json"
+    p.write_text(json.dumps({"units": units}))
+    return str(p)
+
+
+def _state(path, unit_id):
+    units = json.loads(open(path).read())["units"]
+    return status.unit_state(units[unit_id])
+
+
+def _units():
+    return {
+        "asset:a": {"kind": "asset", "classification": "MECH", "status": "pending"},
+        "op:b": {"kind": "op", "classification": "MECH", "status": "pending"},
+        "op:c": {"kind": "op", "classification": "MECH", "status": "pending"},
+        "res:d": {"kind": "resource", "target": "none", "status": "pending"},
+    }
+
+
+def test_advance_single(tmp_path):
+    p = _write(tmp_path, _units())
+    assert status.main(["--manifest", p, "advance", "asset:a", "--evidence", "gate1.json"]) == 0
+    assert _state(p, "asset:a") == "translate"
+
+
+def test_advance_missing_unit(tmp_path):
+    p = _write(tmp_path, _units())
+    assert status.main(["--manifest", p, "advance", "nope:x", "--evidence", "e"]) == 2
+
+
+def test_advance_requires_evidence(tmp_path):
+    p = _write(tmp_path, _units())
+    with pytest.raises(SystemExit):  # argparse: --evidence is required
+        status.main(["--manifest", p, "advance", "asset:a"])
+
+
+def test_advance_already_complete_is_error(tmp_path):
+    units = _units()
+    units["asset:a"]["status"] = {"state": "complete"}
+    p = _write(tmp_path, units)
+    assert status.main(["--manifest", p, "advance", "asset:a", "--evidence", "e"]) == 1
+
+
+def test_target_none_advances_straight_to_complete(tmp_path):
+    p = _write(tmp_path, _units())
+    assert status.main(["--manifest", p, "advance", "res:d", "--evidence", "lowered to include/"]) == 0
+    assert _state(p, "res:d") == "complete"
+
+
+def test_defer_and_reason_required(tmp_path):
+    p = _write(tmp_path, _units())
+    with pytest.raises(SystemExit):
+        status.main(["--manifest", p, "defer", "op:b"])
+    assert status.main(["--manifest", p, "defer", "op:b", "--reason", "blocked"]) == 0
+    assert _state(p, "op:b") == "deferred"
+
+
+def test_reopen(tmp_path):
+    units = _units()
+    units["asset:a"]["status"] = {"state": "complete"}
+    p = _write(tmp_path, units)
+    assert status.main(["--manifest", p, "reopen", "asset:a", "--reason", "rework"]) == 0
+    assert _state(p, "asset:a") == "translate"
+
+
+def test_bulk_advance_where(tmp_path):
+    p = _write(tmp_path, _units())
+    rc = status.main(["--manifest", p, "advance", "--where", "kind=op",
+                      "--from-state", "pending", "--evidence", "batch"])
+    assert rc == 0
+    assert _state(p, "op:b") == "translate"
+    assert _state(p, "op:c") == "translate"
+    assert _state(p, "asset:a") == "pending"  # not matched
+
+
+def test_bulk_dry_run_writes_nothing(tmp_path):
+    p = _write(tmp_path, _units())
+    rc = status.main(["--manifest", p, "advance", "--where", "kind=op",
+                      "--evidence", "e", "--dry-run"])
+    assert rc == 0
+    assert _state(p, "op:b") == "pending"
+
+
+def test_bulk_and_single_are_mutually_exclusive(tmp_path):
+    p = _write(tmp_path, _units())
+    assert status.main(["--manifest", p, "advance", "op:b", "--where", "kind=op",
+                        "--evidence", "e"]) == 2
+
+
+def test_summary_exit_codes(tmp_path):
+    # all pending -> in flight -> nonzero
+    p = _write(tmp_path, _units())
+    assert status.main(["--manifest", p, "summary"]) == 1
+    # all dispositioned -> zero
+    done = {u: {"status": {"state": "complete"}} for u in _units()}
+    p2 = _write(tmp_path, done)
+    assert status.main(["--manifest", p2, "summary"]) == 0
+
+
+def test_summary_silent_omission_nonzero(tmp_path):
+    p = _write(tmp_path, {"weird:x": {"status": {"state": "banana"}}})
+    assert status.main(["--manifest", p, "summary"]) == 1
+
+
+def test_summary_surfaces_static_only_note(tmp_path, capsys):
+    manifest = {"units": {"asset:a": {"status": {"state": "complete"}}},
+                "runtime_error": "dagster not importable in this interpreter"}
+    rc = status.cmd_summary(manifest)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "STATIC-ONLY" in out

--- a/skills/migrating-dagster-to-airflow/scripts/tests/test_status.py
+++ b/skills/migrating-dagster-to-airflow/scripts/tests/test_status.py
@@ -29,7 +29,10 @@ def _units():
 
 def test_advance_single(tmp_path):
     p = _write(tmp_path, _units())
-    assert status.main(["--manifest", p, "advance", "asset:a", "--evidence", "gate1.json"]) == 0
+    assert (
+        status.main(["--manifest", p, "advance", "asset:a", "--evidence", "gate1.json"])
+        == 0
+    )
     assert _state(p, "asset:a") == "translate"
 
 
@@ -53,7 +56,12 @@ def test_advance_already_complete_is_error(tmp_path):
 
 def test_target_none_advances_straight_to_complete(tmp_path):
     p = _write(tmp_path, _units())
-    assert status.main(["--manifest", p, "advance", "res:d", "--evidence", "lowered to include/"]) == 0
+    assert (
+        status.main(
+            ["--manifest", p, "advance", "res:d", "--evidence", "lowered to include/"]
+        )
+        == 0
+    )
     assert _state(p, "res:d") == "complete"
 
 
@@ -69,14 +77,27 @@ def test_reopen(tmp_path):
     units = _units()
     units["asset:a"]["status"] = {"state": "complete"}
     p = _write(tmp_path, units)
-    assert status.main(["--manifest", p, "reopen", "asset:a", "--reason", "rework"]) == 0
+    assert (
+        status.main(["--manifest", p, "reopen", "asset:a", "--reason", "rework"]) == 0
+    )
     assert _state(p, "asset:a") == "translate"
 
 
 def test_bulk_advance_where(tmp_path):
     p = _write(tmp_path, _units())
-    rc = status.main(["--manifest", p, "advance", "--where", "kind=op",
-                      "--from-state", "pending", "--evidence", "batch"])
+    rc = status.main(
+        [
+            "--manifest",
+            p,
+            "advance",
+            "--where",
+            "kind=op",
+            "--from-state",
+            "pending",
+            "--evidence",
+            "batch",
+        ]
+    )
     assert rc == 0
     assert _state(p, "op:b") == "translate"
     assert _state(p, "op:c") == "translate"
@@ -85,16 +106,39 @@ def test_bulk_advance_where(tmp_path):
 
 def test_bulk_dry_run_writes_nothing(tmp_path):
     p = _write(tmp_path, _units())
-    rc = status.main(["--manifest", p, "advance", "--where", "kind=op",
-                      "--evidence", "e", "--dry-run"])
+    rc = status.main(
+        [
+            "--manifest",
+            p,
+            "advance",
+            "--where",
+            "kind=op",
+            "--evidence",
+            "e",
+            "--dry-run",
+        ]
+    )
     assert rc == 0
     assert _state(p, "op:b") == "pending"
 
 
 def test_bulk_and_single_are_mutually_exclusive(tmp_path):
     p = _write(tmp_path, _units())
-    assert status.main(["--manifest", p, "advance", "op:b", "--where", "kind=op",
-                        "--evidence", "e"]) == 2
+    assert (
+        status.main(
+            [
+                "--manifest",
+                p,
+                "advance",
+                "op:b",
+                "--where",
+                "kind=op",
+                "--evidence",
+                "e",
+            ]
+        )
+        == 2
+    )
 
 
 def test_summary_exit_codes(tmp_path):
@@ -113,8 +157,10 @@ def test_summary_silent_omission_nonzero(tmp_path):
 
 
 def test_summary_surfaces_static_only_note(tmp_path, capsys):
-    manifest = {"units": {"asset:a": {"status": {"state": "complete"}}},
-                "runtime_error": "dagster not importable in this interpreter"}
+    manifest = {
+        "units": {"asset:a": {"status": {"state": "complete"}}},
+        "runtime_error": "dagster not importable in this interpreter",
+    }
     rc = status.cmd_summary(manifest)
     out = capsys.readouterr().out
     assert rc == 0

--- a/skills/migrating-dagster-to-airflow/scripts/tests/test_validate_dag.py
+++ b/skills/migrating-dagster-to-airflow/scripts/tests/test_validate_dag.py
@@ -11,6 +11,7 @@ import validate_dag
 
 # --- Gate 1: python import + lint ------------------------------------------
 
+
 def _project(tmp_path, files):
     (tmp_path / "dags").mkdir()
     (tmp_path / "include").mkdir()
@@ -37,6 +38,7 @@ def test_gate1_no_files_fails(tmp_path):
 
 
 # --- Gate 3: structural asserts against a stubbed DagBag --------------------
+
 
 class _Asset:
     def __init__(self, uri):
@@ -65,22 +67,38 @@ class _DagBag:
 
 
 def _dag():
-    return _Dag([_Task("extract", ["load"]),
-                 _Task("load", outlets=[_Asset("s3://out")])])
+    return _Dag(
+        [_Task("extract", ["load"]), _Task("load", outlets=[_Asset("s3://out")])]
+    )
 
 
 def test_gate3_structure_pass():
-    manifest = {"units": {"asset:orders": {
-        "dag_id": "orders", "task_count": 2, "edges": [["extract", "load"]],
-        "schedule": "@daily", "asset_outlets": ["s3://out"]}}}
+    manifest = {
+        "units": {
+            "asset:orders": {
+                "dag_id": "orders",
+                "task_count": 2,
+                "edges": [["extract", "load"]],
+                "schedule": "@daily",
+                "asset_outlets": ["s3://out"],
+            }
+        }
+    }
     r = validate_dag.gate3_structure(_DagBag({"orders": _dag()}), manifest, None)
     assert r["status"] == "pass"
     assert r["details"]["runtime_attribute_probe"]["schedule_attr"] == "schedule"
 
 
 def test_gate3_structure_mismatch_fails():
-    manifest = {"units": {"asset:orders": {
-        "dag_id": "orders", "task_count": 99, "edges": [["a", "b"]]}}}
+    manifest = {
+        "units": {
+            "asset:orders": {
+                "dag_id": "orders",
+                "task_count": 99,
+                "edges": [["a", "b"]],
+            }
+        }
+    }
     r = validate_dag.gate3_structure(_DagBag({"orders": _dag()}), manifest, None)
     assert r["status"] == "fail"
 
@@ -107,15 +125,22 @@ def test_gate3_asset_schedule_and_timetable_type():
 
     dag = _Dag([_Task("a")], schedule="[Asset(uri='s3://raw')]")
     dag.timetable = CronPartitionTimetable()
-    manifest = {"units": {"asset:daily": {
-        "dag_id": "daily", "asset_schedule": ["s3://raw"],
-        "timetable_type": "CronPartitionTimetable"}}}
+    manifest = {
+        "units": {
+            "asset:daily": {
+                "dag_id": "daily",
+                "asset_schedule": ["s3://raw"],
+                "timetable_type": "CronPartitionTimetable",
+            }
+        }
+    }
     r = validate_dag.gate3_structure(_DagBag({"daily": dag}), manifest, None)
     checks = r["details"]["units"][0]["checks"]
     assert checks["asset_schedule"]["ok"] and checks["timetable_type"]["ok"]
 
 
 # --- Gate 2 / real DagBag: needs airflow, skip cleanly without it ----------
+
 
 def test_gate2_real_dagbag_requires_airflow(tmp_path):
     pytest.importorskip("airflow")

--- a/skills/migrating-dagster-to-airflow/scripts/tests/test_validate_dag.py
+++ b/skills/migrating-dagster-to-airflow/scripts/tests/test_validate_dag.py
@@ -1,0 +1,126 @@
+"""Gate 1 and Gate 3 tests for validate_dag.py.
+
+Gate 1 (ast.parse + optional ruff) and Gate 3 (structural asserts against a
+stubbed DagBag) need no airflow. The airflow-dependent path (Gate 2 / real
+DagBag) is import-guarded and skips cleanly when airflow is absent."""
+
+import pytest
+
+import validate_dag
+
+
+# --- Gate 1: python import + lint ------------------------------------------
+
+def _project(tmp_path, files):
+    (tmp_path / "dags").mkdir()
+    (tmp_path / "include").mkdir()
+    for rel, body in files.items():
+        (tmp_path / rel).write_text(body)
+    return str(tmp_path)
+
+
+def test_gate1_pass(tmp_path):
+    proj = _project(tmp_path, {"dags/good.py": "x = 1 + 1\n"})
+    assert validate_dag.gate1_import_lint(proj)["status"] == "pass"
+
+
+def test_gate1_syntax_error_fails(tmp_path):
+    proj = _project(tmp_path, {"dags/bad.py": "def broken(:\n"})
+    r = validate_dag.gate1_import_lint(proj)
+    assert r["status"] == "fail"
+    assert r["details"]["parse_errors"]
+
+
+def test_gate1_no_files_fails(tmp_path):
+    (tmp_path / "dags").mkdir()
+    assert validate_dag.gate1_import_lint(str(tmp_path))["status"] == "fail"
+
+
+# --- Gate 3: structural asserts against a stubbed DagBag --------------------
+
+class _Asset:
+    def __init__(self, uri):
+        self.uri = uri
+
+
+class _Task:
+    def __init__(self, task_id, downstream=(), outlets=()):
+        self.task_id = task_id
+        self.downstream_task_ids = set(downstream)
+        self.outlets = list(outlets)
+
+
+class _Dag:
+    def __init__(self, tasks, schedule="@daily"):
+        self.tasks = tasks
+        self.schedule = schedule
+
+
+class _DagBag:
+    def __init__(self, dags):
+        self._dags = dags
+
+    def get_dag(self, dag_id):
+        return self._dags.get(dag_id)
+
+
+def _dag():
+    return _Dag([_Task("extract", ["load"]),
+                 _Task("load", outlets=[_Asset("s3://out")])])
+
+
+def test_gate3_structure_pass():
+    manifest = {"units": {"asset:orders": {
+        "dag_id": "orders", "task_count": 2, "edges": [["extract", "load"]],
+        "schedule": "@daily", "asset_outlets": ["s3://out"]}}}
+    r = validate_dag.gate3_structure(_DagBag({"orders": _dag()}), manifest, None)
+    assert r["status"] == "pass"
+    assert r["details"]["runtime_attribute_probe"]["schedule_attr"] == "schedule"
+
+
+def test_gate3_structure_mismatch_fails():
+    manifest = {"units": {"asset:orders": {
+        "dag_id": "orders", "task_count": 99, "edges": [["a", "b"]]}}}
+    r = validate_dag.gate3_structure(_DagBag({"orders": _dag()}), manifest, None)
+    assert r["status"] == "fail"
+
+
+def test_gate3_all_missing_dag_id_is_loud_fail():
+    manifest = {"units": {"asset:a": {"dag_id": None}, "op:b": {"dag_id": None}}}
+    r = validate_dag.gate3_structure(_DagBag({}), manifest, None)
+    assert r["status"] == "fail"
+    assert r["details"]["skipped_no_dag_id_count"] == 2
+
+
+def test_gate3_target_none_skipped_silently():
+    manifest = {"units": {"io:x": {"target": "none"}}}
+    r = validate_dag.gate3_structure(_DagBag({}), manifest, None)
+    # a deliberately DAG-less unit is not counted as a planning gap
+    assert r["details"]["skipped_no_dag_id_count"] == 0
+    assert r["status"] == "skip"
+
+
+def test_gate3_asset_schedule_and_timetable_type():
+    class CronPartitionTimetable:  # class name is what timetable_type matches
+        def __repr__(self):
+            return "CronPartitionTimetable('15 * * * *')"
+
+    dag = _Dag([_Task("a")], schedule="[Asset(uri='s3://raw')]")
+    dag.timetable = CronPartitionTimetable()
+    manifest = {"units": {"asset:daily": {
+        "dag_id": "daily", "asset_schedule": ["s3://raw"],
+        "timetable_type": "CronPartitionTimetable"}}}
+    r = validate_dag.gate3_structure(_DagBag({"daily": dag}), manifest, None)
+    checks = r["details"]["units"][0]["checks"]
+    assert checks["asset_schedule"]["ok"] and checks["timetable_type"]["ok"]
+
+
+# --- Gate 2 / real DagBag: needs airflow, skip cleanly without it ----------
+
+def test_gate2_real_dagbag_requires_airflow(tmp_path):
+    pytest.importorskip("airflow")
+    (tmp_path / "dags").mkdir()
+    (tmp_path / "dags" / "d.py").write_text("x = 1\n")
+    dagbag, import_path, err = validate_dag.load_dagbag(str(tmp_path))
+    r = validate_dag.gate2_dagbag(str(tmp_path), dagbag, import_path, err)
+    assert r["gate"] == 2 and r["status"] in ("pass", "fail", "skip")

--- a/skills/migrating-dagster-to-airflow/scripts/uv.lock
+++ b/skills/migrating-dagster-to-airflow/scripts/uv.lock
@@ -1,0 +1,199 @@
+version = 1
+revision = 3
+requires-python = ">=3.9"
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version < '3.10'",
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "migrating-dagster-to-airflow-scripts"
+version = "0.0.0"
+source = { virtual = "." }
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pytest", marker = "extra == 'test'", specifier = ">=7" }]
+provides-extras = ["test"]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "packaging", marker = "python_full_version < '3.10'" },
+    { name = "pluggy", marker = "python_full_version < '3.10'" },
+    { name = "pygments", marker = "python_full_version < '3.10'" },
+    { name = "tomli", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "pluggy", marker = "python_full_version >= '3.10'" },
+    { name = "pygments", marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/skills/migrating-dagster-to-airflow/scripts/validate_dag.py
+++ b/skills/migrating-dagster-to-airflow/scripts/validate_dag.py
@@ -251,14 +251,16 @@ def gate3_structure(dagbag, manifest, dag_id_filter):
 
     if dagbag is None:
         result["status"] = "skip"
-        result["details"]["error"] = "gate 3 needs an in-process DagBag; airflow not importable"
+        result["details"]["error"] = (
+            "gate 3 needs an in-process DagBag; airflow not importable"
+        )
         return result
 
     units = manifest.get("units", {})
     unit_reports = []
     probe = {"schedule_attr": None, "downstream_attr": None}
     any_fail = False
-    considered = 0          # units not filtered out by --dag-id
+    considered = 0  # units not filtered out by --dag-id
     skipped_no_dag_id = []  # considered units with no planned dag_id yet
 
     for unit_id, spec in units.items():
@@ -306,7 +308,9 @@ def gate3_structure(dagbag, manifest, dag_id_filter):
         if expected_count is not None:
             ok = len(tasks) == expected_count
             ur["checks"]["task_count"] = {
-                "expected": expected_count, "actual": len(tasks), "ok": ok,
+                "expected": expected_count,
+                "actual": len(tasks),
+                "ok": ok,
             }
             ur["status"] = ur["status"] if ok else "fail"
 
@@ -337,8 +341,10 @@ def gate3_structure(dagbag, manifest, dag_id_filter):
             actual = str(value)
             ok = actual == str(expected_schedule)
             ur["checks"]["schedule"] = {
-                "expected": expected_schedule, "actual": actual,
-                "attribute": attr, "ok": ok,
+                "expected": expected_schedule,
+                "actual": actual,
+                "attribute": attr,
+                "ok": ok,
             }
             ur["status"] = ur["status"] if ok else "fail"
 
@@ -349,11 +355,14 @@ def gate3_structure(dagbag, manifest, dag_id_filter):
         expected_asset_sched = spec.get("asset_schedule")
         if expected_asset_sched is not None:
             sched_repr = "{0} {1}".format(
-                getattr(dag, "schedule", ""), getattr(dag, "timetable", ""))
+                getattr(dag, "schedule", ""), getattr(dag, "timetable", "")
+            )
             missing = [a for a in expected_asset_sched if str(a) not in sched_repr]
             ok = not missing
             ur["checks"]["asset_schedule"] = {
-                "ok": ok, "missing": missing, "schedule_repr": sched_repr[:300],
+                "ok": ok,
+                "missing": missing,
+                "schedule_repr": sched_repr[:300],
             }
             ur["status"] = ur["status"] if ok else "fail"
 
@@ -364,7 +373,9 @@ def gate3_structure(dagbag, manifest, dag_id_filter):
             tt_name = type(getattr(dag, "timetable", None)).__name__
             ok = expected_tt in tt_name
             ur["checks"]["timetable_type"] = {
-                "expected": expected_tt, "actual": tt_name, "ok": ok,
+                "expected": expected_tt,
+                "actual": tt_name,
+                "ok": ok,
             }
             ur["status"] = ur["status"] if ok else "fail"
 
@@ -401,7 +412,8 @@ def gate3_structure(dagbag, manifest, dag_id_filter):
         result["status"] = "fail"
         result["details"]["error"] = (
             "all {0} considered unit(s) skipped: no dag_id "
-            "(plan phase incomplete)".format(len(skipped_no_dag_id)))
+            "(plan phase incomplete)".format(len(skipped_no_dag_id))
+        )
     elif any_fail:
         result["status"] = "fail"
     return result
@@ -410,9 +422,15 @@ def gate3_structure(dagbag, manifest, dag_id_filter):
 def main(argv=None):
     parser = argparse.ArgumentParser(description="Run validation gates 1 to 3.")
     parser.add_argument("astro_project", help="path to the generated Astro project")
-    parser.add_argument("--manifest", help="inventory manifest JSON (required for gate 3)")
-    parser.add_argument("--gate", type=int, choices=[1, 2, 3],
-                        help="run only this gate (default: 1 through 3)")
+    parser.add_argument(
+        "--manifest", help="inventory manifest JSON (required for gate 3)"
+    )
+    parser.add_argument(
+        "--gate",
+        type=int,
+        choices=[1, 2, 3],
+        help="run only this gate (default: 1 through 3)",
+    )
     parser.add_argument("--dag-id", help="restrict gate 3 to a single dag_id")
     parser.add_argument("--out", help="write JSON report here instead of stdout")
     args = parser.parse_args(argv)
@@ -451,7 +469,11 @@ def main(argv=None):
         if gate == 3:
             n = r["details"].get("skipped_no_dag_id_count", 0)
             if n:
-                log("gate3: {0} unit(s) skipped (no dag_id; plan phase incomplete)".format(n))
+                log(
+                    "gate3: {0} unit(s) skipped (no dag_id; plan phase incomplete)".format(
+                        n
+                    )
+                )
         if r["status"] == "fail" and first_failed == 0:
             first_failed = gate
 

--- a/skills/migrating-dagster-to-airflow/scripts/validate_dag.py
+++ b/skills/migrating-dagster-to-airflow/scripts/validate_dag.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""Run validation gates 1 to 3 against a generated Astro project.
+
+Implements the cheap-to-expensive ladder from reference/validation.md:
+
+  Gate 1  python import + lint   ast.parse over dags/ and include/, then ruff
+  Gate 2  DagBag import check    load the project with airflow's DagBag, and/or
+                                 shell out to `astro dev parse`
+  Gate 3  structural asserts     compare each DAG against the inventory manifest
+                                 (task count, dependency edges, schedule string,
+                                 asset outlets)
+
+The manifest is the JSON produced by scripts/inventory.py. Expected shape:
+
+  {
+    "units": {
+      "<unit_id>": {
+        "dag_id": "orders_daily",
+        "task_count": 3,
+        "edges": [["extract", "transform"], ["transform", "load"]],
+        "schedule": "@daily",
+        "asset_schedule": ["s3://warehouse/raw_orders"],
+        "timetable_type": "CronPartitionTimetable",
+        "asset_outlets": ["s3://warehouse/orders"],
+        "target": "none",            # optional: lowers to include/ or platform
+        "source_edges": [ ... ],     # written by inventory.py, ignored here
+        "status": { ... }            # managed by status.py, ignored here
+      }
+    }
+  }
+
+Edge-key contract (G1): the SCANNER writes `source_edges` (dependency edges
+found in Dagster source). The PLANNER writes the DISTINCT `edges` key that
+Gate 3 asserts (target task edges). They never share a key. Every target
+expectation below is optional and only asserted when present:
+  edges           target task edges (upstream_task_id, downstream_task_id)
+  schedule        cron string, for cron DAGs
+  asset_schedule  asset uris/names that must appear in the DAG's asset condition
+  timetable_type  timetable class-name substring (e.g. CronPartitionTimetable)
+  asset_outlets   asset uris produced by the DAG's tasks
+A unit with target:"none" is skipped silently (not a planning gap).
+
+Two DAG attribute spellings are marked unverified in validation.md (whether the
+airflow.sdk DAG exposes `schedule_interval` vs `timetable` vs `schedule`, and
+whether task edges live on `downstream_task_ids`). Gate 3 probes both defensively
+and reports which spelling the runtime actually has, so the first real run settles
+the question.
+
+Usage:
+  validate_dag.py <astro_project> --manifest manifest.json [--gate N] [--dag-id X]
+                  [--out report.json]
+
+Exit code: 0 if every requested gate passed (or was cleanly skipped for a stated
+reason). Otherwise the number of the first gate that FAILED (1, 2, or 3).
+Machine-readable JSON goes to stdout (or --out); a human summary goes to stderr.
+"""
+
+import argparse
+import ast
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+
+def log(msg):
+    """Human-facing progress line, kept off stdout so JSON stays clean."""
+    print(msg, file=sys.stderr)
+
+
+def python_files(*dirs):
+    """Every .py file under the given directories, sorted for stable output."""
+    found = []
+    for d in dirs:
+        if not os.path.isdir(d):
+            continue
+        for root, _, files in os.walk(d):
+            for name in files:
+                if name.endswith(".py"):
+                    found.append(os.path.join(root, name))
+    return sorted(found)
+
+
+def gate1_import_lint(project):
+    """Gate 1: files parse as Python and pass ruff (ruff optional)."""
+    dags_dir = os.path.join(project, "dags")
+    include_dir = os.path.join(project, "include")
+    files = python_files(dags_dir, include_dir)
+
+    result = {"gate": 1, "name": "import+lint", "status": "pass", "details": {}}
+
+    if not files:
+        result["status"] = "fail"
+        result["details"]["error"] = "no python files found under dags/ or include/"
+        return result
+
+    # ast.parse: catches syntax errors without importing anything.
+    parse_errors = []
+    for path in files:
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                ast.parse(fh.read(), filename=path)
+        except SyntaxError as exc:
+            parse_errors.append({"file": path, "error": str(exc)})
+    result["details"]["files_checked"] = len(files)
+    result["details"]["parse_errors"] = parse_errors
+    if parse_errors:
+        result["status"] = "fail"
+        return result
+
+    # ruff: tolerate a missing binary rather than failing the gate on it.
+    if shutil.which("ruff") is None:
+        result["details"]["ruff"] = "skipped: ruff not on PATH"
+        return result
+
+    proc = subprocess.run(
+        ["ruff", "check", dags_dir, include_dir],
+        capture_output=True,
+        text=True,
+    )
+    result["details"]["ruff_returncode"] = proc.returncode
+    result["details"]["ruff_output"] = (proc.stdout + proc.stderr).strip()
+    if proc.returncode != 0:
+        result["status"] = "fail"
+    return result
+
+
+def load_dagbag(project):
+    """Load the project with airflow's DagBag, in this interpreter.
+
+    Returns (dagbag, import_path, error). `dagbag` is None when airflow is not
+    importable here, in which case the caller falls back to `astro dev parse`.
+    Run this script with the Astro project's own python so airflow is present.
+    """
+    dags_dir = os.path.join(project, "dags")
+
+    # Put the Astro project root on sys.path so DAGs doing `from include...`
+    # (the skill's own convention) import, matching what astro's container does.
+    # Without this the in-process DagBag disagrees with `astro dev parse` (found in testing).
+    project_root = os.path.abspath(project)
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
+
+    DagBag = None
+    import_path = None
+    # Airflow 3.x path is airflow.dag_processing.dagbag (verified). The 2.x
+    # airflow.models path is the compatibility fallback.
+    for candidate in (
+        "airflow.dag_processing.dagbag",
+        "airflow.models.dagbag",
+    ):
+        try:
+            module = __import__(candidate, fromlist=["DagBag"])
+            DagBag = getattr(module, "DagBag")
+            import_path = candidate
+            break
+        except Exception:
+            continue
+
+    if DagBag is None:
+        return None, None, "airflow DagBag not importable in this interpreter"
+
+    try:
+        dagbag = DagBag(dag_folder=dags_dir, include_examples=False)
+    except TypeError:
+        # Older/newer signatures may not accept include_examples.
+        dagbag = DagBag(dag_folder=dags_dir)
+    return dagbag, import_path, None
+
+
+def gate2_dagbag(project, dagbag, import_path, load_error):
+    """Gate 2: the project imports cleanly (DagBag and/or `astro dev parse`)."""
+    result = {"gate": 2, "name": "dagbag-import", "status": "pass", "details": {}}
+    checks_ran = 0
+
+    # In-process DagBag import.
+    if dagbag is not None:
+        checks_ran += 1
+        errors = dict(getattr(dagbag, "import_errors", {}) or {})
+        result["details"]["dagbag_import_path"] = import_path
+        result["details"]["dagbag_import_errors"] = errors
+        result["details"]["dag_ids"] = sorted(getattr(dagbag, "dag_ids", []) or [])
+        if errors:
+            result["status"] = "fail"
+    else:
+        result["details"]["dagbag"] = "skipped: " + (load_error or "unavailable")
+
+    # `astro dev parse`, if the CLI is installed.
+    if shutil.which("astro") is not None:
+        checks_ran += 1
+        proc = subprocess.run(
+            ["astro", "dev", "parse"],
+            cwd=project,
+            capture_output=True,
+            text=True,
+        )
+        result["details"]["astro_parse_returncode"] = proc.returncode
+        result["details"]["astro_parse_output"] = (proc.stdout + proc.stderr).strip()
+        if proc.returncode != 0:
+            result["status"] = "fail"
+    else:
+        result["details"]["astro_parse"] = "skipped: astro CLI not on PATH"
+
+    if checks_ran == 0:
+        result["status"] = "skip"
+        result["details"]["error"] = (
+            "neither in-process DagBag nor astro CLI available; "
+            "run with the Astro project python or install the astro CLI"
+        )
+    return result
+
+
+def probe_schedule(dag):
+    """Return (attribute_name, value) for whichever schedule spelling exists."""
+    # Probe order settled by testing (Airflow 3.3): `schedule` exists on sdk
+    # DAGs and returns the original string ("@daily"); `timetable` exists too but
+    # str() of it is a repr that never matches a manifest schedule. `summary` does
+    # not exist on airflow.sdk timetables.
+    for attr in ("schedule", "schedule_interval", "timetable"):
+        if hasattr(dag, attr):
+            return attr, getattr(dag, attr)
+    return None, None
+
+
+def probe_downstream(task):
+    """Return (attribute_name, set_of_ids) for the task's downstream edges."""
+    for attr in ("downstream_task_ids", "downstream_list"):
+        if hasattr(task, attr):
+            value = getattr(task, attr)
+            if attr == "downstream_list":
+                return attr, {t.task_id for t in value}
+            return attr, set(value)
+    return None, set()
+
+
+def probe_outlets(task):
+    """Return the set of outlet URIs for a task, tolerating missing outlets."""
+    outlets = getattr(task, "outlets", None) or []
+    uris = set()
+    for a in outlets:
+        uri = getattr(a, "uri", None)
+        if uri is not None:
+            uris.add(uri)
+    return uris
+
+
+def gate3_structure(dagbag, manifest, dag_id_filter):
+    """Gate 3: each DAG's shape matches its manifest record."""
+    result = {"gate": 3, "name": "structure", "status": "pass", "details": {}}
+
+    if dagbag is None:
+        result["status"] = "skip"
+        result["details"]["error"] = "gate 3 needs an in-process DagBag; airflow not importable"
+        return result
+
+    units = manifest.get("units", {})
+    unit_reports = []
+    probe = {"schedule_attr": None, "downstream_attr": None}
+    any_fail = False
+    considered = 0          # units not filtered out by --dag-id
+    skipped_no_dag_id = []  # considered units with no planned dag_id yet
+
+    for unit_id, spec in units.items():
+        dag_id = spec.get("dag_id")
+        if dag_id_filter and dag_id != dag_id_filter:
+            continue
+
+        # Deliberately DAG-less units (target:"none") lower into another unit or
+        # the platform layer (IO-manager helpers, external-asset decls, the
+        # Definitions object). They are dispositioned in status.py, not here, so
+        # skip them SILENTLY: they are not a planning gap and must not appear in
+        # the loud skip warning (G13).
+        if spec.get("target") == "none":
+            continue
+
+        considered += 1
+
+        # Units without a dag_id have not been planned into a target DAG yet.
+        # inventory.py documents them as skipped until planning fills them in;
+        # we skip but count them LOUDLY (G6): silently no-op'ing every unit let
+        # a run claim "gate 3 green" while gate 3 checked nothing.
+        if not dag_id:
+            skipped_no_dag_id.append(unit_id)
+            continue
+
+        ur = {"unit_id": unit_id, "dag_id": dag_id, "status": "pass", "checks": {}}
+        dags_map = getattr(dagbag, "dags", None) or {}
+        dag = dags_map.get(dag_id)
+        if dag is None:
+            try:
+                dag = dagbag.get_dag(dag_id)
+            except Exception:
+                dag = None
+        if dag is None:
+            ur["status"] = "fail"
+            ur["checks"]["dag_present"] = False
+            unit_reports.append(ur)
+            any_fail = True
+            continue
+
+        tasks = list(getattr(dag, "tasks", []))
+
+        # Task count.
+        expected_count = spec.get("task_count")
+        if expected_count is not None:
+            ok = len(tasks) == expected_count
+            ur["checks"]["task_count"] = {
+                "expected": expected_count, "actual": len(tasks), "ok": ok,
+            }
+            ur["status"] = ur["status"] if ok else "fail"
+
+        # Dependency edges.
+        expected_edges = spec.get("edges")
+        if expected_edges is not None:
+            actual_edges = set()
+            for t in tasks:
+                attr, downs = probe_downstream(t)
+                probe["downstream_attr"] = probe["downstream_attr"] or attr
+                for d in downs:
+                    actual_edges.add((t.task_id, d))
+            want = {tuple(e) for e in expected_edges}
+            ok = actual_edges == want
+            ur["checks"]["edges"] = {
+                "ok": ok,
+                "missing": sorted("->".join(e) for e in (want - actual_edges)),
+                "unexpected": sorted("->".join(e) for e in (actual_edges - want)),
+            }
+            ur["status"] = ur["status"] if ok else "fail"
+
+        # Schedule string, for CRON forms. The attribute spelling is unverified
+        # upstream, so we record which one the runtime exposed.
+        expected_schedule = spec.get("schedule")
+        if expected_schedule is not None:
+            attr, value = probe_schedule(dag)
+            probe["schedule_attr"] = probe["schedule_attr"] or attr
+            actual = str(value)
+            ok = actual == str(expected_schedule)
+            ur["checks"]["schedule"] = {
+                "expected": expected_schedule, "actual": actual,
+                "attribute": attr, "ok": ok,
+            }
+            ur["status"] = ur["status"] if ok else "fail"
+
+        # Asset-aware schedule (the flagship lowering). Asset lists and partition
+        # timetables render as Asset(...) / memory-address reprs that a plain
+        # string compare cannot assert (G4), so we check each expected asset
+        # uri/name is present in the rendered schedule + timetable repr.
+        expected_asset_sched = spec.get("asset_schedule")
+        if expected_asset_sched is not None:
+            sched_repr = "{0} {1}".format(
+                getattr(dag, "schedule", ""), getattr(dag, "timetable", ""))
+            missing = [a for a in expected_asset_sched if str(a) not in sched_repr]
+            ok = not missing
+            ur["checks"]["asset_schedule"] = {
+                "ok": ok, "missing": missing, "schedule_repr": sched_repr[:300],
+            }
+            ur["status"] = ur["status"] if ok else "fail"
+
+        # Timetable class (e.g. "CronPartitionTimetable"): substring match on the
+        # timetable type name, the assertable half of a partitioned schedule.
+        expected_tt = spec.get("timetable_type")
+        if expected_tt is not None:
+            tt_name = type(getattr(dag, "timetable", None)).__name__
+            ok = expected_tt in tt_name
+            ur["checks"]["timetable_type"] = {
+                "expected": expected_tt, "actual": tt_name, "ok": ok,
+            }
+            ur["status"] = ur["status"] if ok else "fail"
+
+        # Asset outlets across all tasks.
+        expected_outlets = spec.get("asset_outlets")
+        if expected_outlets is not None:
+            actual_outlets = set()
+            for t in tasks:
+                actual_outlets |= probe_outlets(t)
+            want = set(expected_outlets)
+            ok = actual_outlets == want
+            ur["checks"]["asset_outlets"] = {
+                "ok": ok,
+                "missing": sorted(want - actual_outlets),
+                "unexpected": sorted(actual_outlets - want),
+            }
+            ur["status"] = ur["status"] if ok else "fail"
+
+        if ur["status"] == "fail":
+            any_fail = True
+        unit_reports.append(ur)
+
+    result["details"]["units"] = unit_reports
+    result["details"]["runtime_attribute_probe"] = probe
+    result["details"]["skipped_no_dag_id"] = skipped_no_dag_id
+    result["details"]["skipped_no_dag_id_count"] = len(skipped_no_dag_id)
+    if considered == 0:
+        # Nothing matched the --dag-id filter (or the manifest has no units).
+        result["status"] = "skip"
+        result["details"]["error"] = "no matching units in manifest"
+    elif not unit_reports:
+        # Units exist but every one lacks a dag_id: gate 3 was requested yet
+        # verified nothing. That is a failure, not a silent pass (G6).
+        result["status"] = "fail"
+        result["details"]["error"] = (
+            "all {0} considered unit(s) skipped: no dag_id "
+            "(plan phase incomplete)".format(len(skipped_no_dag_id)))
+    elif any_fail:
+        result["status"] = "fail"
+    return result
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Run validation gates 1 to 3.")
+    parser.add_argument("astro_project", help="path to the generated Astro project")
+    parser.add_argument("--manifest", help="inventory manifest JSON (required for gate 3)")
+    parser.add_argument("--gate", type=int, choices=[1, 2, 3],
+                        help="run only this gate (default: 1 through 3)")
+    parser.add_argument("--dag-id", help="restrict gate 3 to a single dag_id")
+    parser.add_argument("--out", help="write JSON report here instead of stdout")
+    args = parser.parse_args(argv)
+
+    project = args.astro_project
+    if not os.path.isdir(project):
+        log("error: astro project not found: " + project)
+        return 2
+
+    gates_to_run = [args.gate] if args.gate else [1, 2, 3]
+    manifest = {}
+    if 3 in gates_to_run:
+        if not args.manifest:
+            log("error: gate 3 requires --manifest")
+            return 2
+        with open(args.manifest, "r", encoding="utf-8") as fh:
+            manifest = json.load(fh)
+
+    report = {"project": project, "gates": []}
+    first_failed = 0
+
+    # DagBag is loaded once and shared by gates 2 and 3.
+    dagbag = import_path = load_error = None
+    if any(g in gates_to_run for g in (2, 3)):
+        dagbag, import_path, load_error = load_dagbag(project)
+
+    for gate in gates_to_run:
+        if gate == 1:
+            r = gate1_import_lint(project)
+        elif gate == 2:
+            r = gate2_dagbag(project, dagbag, import_path, load_error)
+        else:
+            r = gate3_structure(dagbag, manifest, args.dag_id)
+        report["gates"].append(r)
+        log("gate {0} ({1}): {2}".format(r["gate"], r["name"], r["status"].upper()))
+        if gate == 3:
+            n = r["details"].get("skipped_no_dag_id_count", 0)
+            if n:
+                log("gate3: {0} unit(s) skipped (no dag_id; plan phase incomplete)".format(n))
+        if r["status"] == "fail" and first_failed == 0:
+            first_failed = gate
+
+    report["result"] = "fail" if first_failed else "pass"
+    text = json.dumps(report, indent=2, sort_keys=True)
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as fh:
+            fh.write(text + "\n")
+        log("wrote report to " + args.out)
+    else:
+        print(text)
+
+    return first_failed
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

A skill for migrating Dagster projects to Apache Airflow 3 on Astro. It includes:

- A concept map covering how every Dagster feature translates to Airflow 3: assets, partitions, schedules, sensors, automation, IO managers, resources, ops/jobs, dbt, Pipes, Components, and Dagster+ config
- Reference docs for the parts that are genuinely hard to translate
- A step-by-step workflow: scan the repo (read-only), plan, migrate piece by piece, check each piece (does it parse, does it run, does it produce the same data as before), then cut over gradually with rollback one step away
- Three small Python helpers: one lists everything in the Dagster repo so nothing gets missed, one checks the migrated DAGs, and one tracks progress so a migration can't be called done while anything is unaccounted for. They ship with their own tests, wired into CI in this PR.

## How it's been tested

Seven full migrations before this PR: Dagster's OSS examples, two community projects (253 and 296 definitions), Dagster Labs' own open-source data platform, a synthetic project that uses every Dagster feature, and one run against a real production Snowflake. Wherever a project could actually run, the migrated pipelines produced the same output data as the original, checked table by table (93/93, 16/16, 13/13, 5/5), and we rehearsed a live cutover and rollback. The docs were also checked against the official Airflow, Dagster, and Cosmos documentation and put through three review passes; the troubleshooting file lists 18 real failures we hit along the way and how to fix each one.

## Fit with this repo

- Named and laid out like the other skills (it sits next to `migrating-airflow-2-to-3`), with the same style of edit hook, easy to drop if you'd rather not have it
- Built not to go stale: the repo scanner asks Dagster itself what's in a project rather than keeping its own list of Dagster APIs, and anything version-dependent says which version it was checked on (Airflow 3.3 / Astro Runtime 3.3-2 / Cosmos 1.15 / Dagster 1.13)
- `scripts/` follows the `analyzing-data` pattern; the CI job added here is the only change outside the skill folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGYcYRpwF7vMhgSSG7v3F8