### PR TITLE
Guard analyzing-data Stop hook against missing uv

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/skills/analyzing-data/scripts/cli.py stop"
+            "command": "${CLAUDE_PLUGIN_ROOT}/skills/analyzing-data/hooks/stop.sh"
           }
         ]
       }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -27,7 +27,7 @@
     "hooks": {
       "stop": [
         {
-          "command": "uv run ./skills/analyzing-data/scripts/cli.py stop"
+          "command": "./skills/analyzing-data/hooks/stop.sh"
         }
       ]
     }

--- a/skills/analyzing-data/hooks/stop.sh
+++ b/skills/analyzing-data/hooks/stop.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Hook: Stop - shut down the analyzing-data kernel if one is running.
+#
+# No-op if `uv` isn't on PATH. The kernel can only ever have been started
+# via `uv run` (see cli.py's own start/status commands), so if `uv` is
+# missing there is nothing to stop, and a hard failure here would just
+# surface a raw "uv: not found" shell error on every Stop hook run.
+
+if ! command -v uv > /dev/null 2>&1; then
+    exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+uv run "$script_dir/../scripts/cli.py" stop


### PR DESCRIPTION
## Problem

The `analyzing-data` skill's Stop hook is registered directly in `plugin.json`
as:

```json
"command": "uv run ${CLAUDE_PLUGIN_ROOT}/skills/analyzing-data/scripts/cli.py stop"
```

On a machine where `uv` isn't installed / isn't on `PATH`, the shell fails to
exec `uv` before `cli.py` ever starts — so `cli.py`'s own
`check_uv_installed()` helpful-error path never runs. Instead every Stop hook
invocation surfaces a raw, unhelpful error:

```
Stop hook error: Failed with non-blocking status code: /bin/sh: 1: uv: not found
```

This fires on every single turn for any user without `uv` on `PATH`, in both
Claude Code and Cursor (both plugin manifests have the same unguarded
command).

## Fix

Move the command into a small co-located `skills/analyzing-data/hooks/stop.sh`
script — the same pattern already used by
`skills/airflow/hooks/warm-uvx-cache.sh` elsewhere in this repo — that checks
for `uv` on `PATH` and no-ops (exit 0) if it's missing, since a kernel could
never have been started without `uv` in the first place, so there's nothing
to stop.

Both `.claude-plugin/plugin.json` and `.cursor-plugin/plugin.json` now point
at this script instead of embedding the raw `uv run` command inline.

## Testing

Ran the new script directly, both with `uv` present and with `PATH`
restricted to simulate `uv` missing:

```
$ ./skills/analyzing-data/hooks/stop.sh
...
Kernel not running
exit: 0

$ env PATH="/usr/bin:/bin" ./skills/analyzing-data/hooks/stop.sh
exit: 0
```

No error output in the missing-`uv` case, clean exit in both.