### PR TITLE
Detect Otto and GitHub Copilot as calling agents

### DIFF
--- a/astro-airflow-mcp/src/astro_airflow_mcp/telemetry.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/telemetry.py
@@ -96,11 +96,37 @@ def _detect_invocation_context() -> tuple[str, str | None, str | None]:
         "GEMINI_CLI": "gemini-cli",
         "OPENCODE": "opencode",
         "CODEX_API_KEY": "codex",
+        # GitHub Copilot. COPILOT_CLI is set by the Copilot CLI, which is also
+        # the harness behind the cloud coding agent and, as of 2026, Copilot for
+        # JetBrains; github's own gh keys on it (cli/cli internal/agents/
+        # detect.go). COPILOT_AGENT is set on terminals VS Code creates for
+        # agent mode (microsoft/vscode toolTerminalCreator.ts), where it is
+        # described as backward compatibility for exactly this kind of
+        # detection.
+        "COPILOT_CLI": "github-copilot",
+        "COPILOT_AGENT": "github-copilot",
     }
     for var, name in agent_env_vars.items():
         if os.environ.get(var):
             agent_name = name
             break
+
+    # AI_AGENT is a cross-vendor convention where the value names the agent
+    # rather than the variable: VS Code sets AI_AGENT=github_copilot_vscode_agent
+    # for agent sessions and the Copilot desktop app sets github_copilot_app_agent
+    # (microsoft/vscode aiAgentEnv.ts). gh reads it too.
+    #
+    # Checked after the list above so a specific marker still wins, and only
+    # prefixes we recognise are mapped. Values are not passed through: some
+    # vendors put a version in theirs (claude-code_2-1-156_agent), which would
+    # spray one agent across dozens of distinct values in the telemetry. A new
+    # vendor adopting the convention is a one-line addition here.
+    if agent_name is None:
+        ai_agent = os.environ.get("AI_AGENT", "").lower()
+        for prefix, name in {"github_copilot": "github-copilot"}.items():
+            if ai_agent.startswith(prefix):
+                agent_name = name
+                break
 
     # Check for CI/CD environments
     ci_env_vars = {

--- a/astro-airflow-mcp/src/astro_airflow_mcp/telemetry.py
+++ b/astro-airflow-mcp/src/astro_airflow_mcp/telemetry.py
@@ -80,8 +80,12 @@ def _detect_invocation_context() -> tuple[str, str | None, str | None]:
     agent_name: str | None = None
     ci_system: str | None = None
 
-    # Check for known AI agent environment variables
+    # Check for known AI agent environment variables. Order matters: the first
+    # match wins. Otto is first because it passes its own environment through to
+    # every command it runs, so an Otto session started from inside another
+    # agent still carries that agent's marker. Otto is the proximate caller.
     agent_env_vars = {
+        "OTTO": "otto",
         "CLAUDECODE": "claude-code",
         "CLAUDE_CODE_ENTRYPOINT": "claude-code",
         "CURSOR_TRACE_ID": "cursor",

--- a/astro-airflow-mcp/tests/test_telemetry.py
+++ b/astro-airflow-mcp/tests/test_telemetry.py
@@ -88,6 +88,7 @@ class TestDetectInvocationContext:
     def clean_env(self, monkeypatch):
         """Clear all agent/CI env vars so tests control the environment."""
         for var in (
+            "OTTO",
             "CLAUDECODE",
             "CLAUDE_CODE_ENTRYPOINT",
             "CURSOR_TRACE_ID",
@@ -119,6 +120,24 @@ class TestDetectInvocationContext:
         monkeypatch.setenv("CLAUDECODE", "1")
         _, agent, _ = telemetry._detect_invocation_context()
         assert agent == "claude-code"
+
+    def test_detects_otto(self, monkeypatch):
+        """Test detects Otto agent."""
+        monkeypatch.setenv("OTTO", "1")
+        _, agent, _ = telemetry._detect_invocation_context()
+        assert agent == "otto"
+
+    def test_otto_wins_over_inherited_marker(self, monkeypatch):
+        """Otto passes its environment through to every command it runs, so an
+        Otto session started from inside another agent still carries that
+        agent's marker. Otto is the proximate caller and must win."""
+        monkeypatch.setenv("CLAUDECODE", "1")
+        _, agent, _ = telemetry._detect_invocation_context()
+        assert agent == "claude-code"
+
+        monkeypatch.setenv("OTTO", "1")
+        _, agent, _ = telemetry._detect_invocation_context()
+        assert agent == "otto"
 
     def test_detects_cursor(self, monkeypatch):
         """Test detects Cursor agent."""

--- a/astro-airflow-mcp/tests/test_telemetry.py
+++ b/astro-airflow-mcp/tests/test_telemetry.py
@@ -99,6 +99,9 @@ class TestDetectInvocationContext:
             "GEMINI_CLI",
             "OPENCODE",
             "CODEX_API_KEY",
+            "COPILOT_CLI",
+            "COPILOT_AGENT",
+            "AI_AGENT",
             "GITHUB_ACTIONS",
             "GITLAB_CI",
             "JENKINS_URL",
@@ -134,6 +137,44 @@ class TestDetectInvocationContext:
         monkeypatch.setenv("CLAUDECODE", "1")
         _, agent, _ = telemetry._detect_invocation_context()
         assert agent == "claude-code"
+
+        monkeypatch.setenv("OTTO", "1")
+        _, agent, _ = telemetry._detect_invocation_context()
+        assert agent == "otto"
+
+    def test_detects_copilot_cli(self, monkeypatch):
+        """Test detects the GitHub Copilot CLI harness."""
+        monkeypatch.setenv("COPILOT_CLI", "1")
+        _, agent, _ = telemetry._detect_invocation_context()
+        assert agent == "github-copilot"
+
+    def test_detects_copilot_vscode_agent_mode(self, monkeypatch):
+        """Test detects Copilot agent mode terminals in VS Code."""
+        monkeypatch.setenv("COPILOT_AGENT", "1")
+        _, agent, _ = telemetry._detect_invocation_context()
+        assert agent == "github-copilot"
+
+    @pytest.mark.parametrize("value", ["github_copilot_vscode_agent", "github_copilot_app_agent"])
+    def test_detects_copilot_via_ai_agent_convention(self, monkeypatch, value):
+        """Test the cross-vendor AI_AGENT convention, where the value names the agent."""
+        monkeypatch.setenv("AI_AGENT", value)
+        _, agent, _ = telemetry._detect_invocation_context()
+        assert agent == "github-copilot"
+
+    def test_ignores_unrecognised_ai_agent_value(self, monkeypatch):
+        """Unknown AI_AGENT values are not passed through — some carry a version,
+        which would spray one agent across many distinct telemetry values."""
+        monkeypatch.setenv("AI_AGENT", "some_other_agent")
+        _, agent, _ = telemetry._detect_invocation_context()
+        assert agent is None
+
+    def test_specific_marker_beats_ai_agent(self, monkeypatch):
+        """AI_AGENT is the fallback, so a specific marker still decides. VS Code
+        sets both AI_AGENT and COPILOT_AGENT, and Otto inside a VS Code agent
+        terminal carries both plus its own."""
+        monkeypatch.setenv("AI_AGENT", "github_copilot_vscode_agent")
+        _, agent, _ = telemetry._detect_invocation_context()
+        assert agent == "github-copilot"
 
         monkeypatch.setenv("OTTO", "1")
         _, agent, _ = telemetry._detect_invocation_context()


### PR DESCRIPTION
`_detect_invocation_context` reads a fixed list of environment variables to work out which coding agent ran the command. Otto is not on it and sets no marker of its own, so every `af` command Otto runs arrives with no `agent` and looks like a person typing.

This matters more for `af` than for `astro`. Otto installs its own pinned `af` wrapper and puts it first on `PATH`, so in an Otto session essentially all `af` traffic is Otto-driven — and none of it is labelled.

There is a second effect. Otto hands its environment to child processes untouched, so a user who starts Otto from inside another coding agent passes that agent's variable straight through to `af`, and the commands get credited to it. Some share of the `claude-code` volume in `af` telemetry is really Otto.

## What this does

Adds `"OTTO": "otto"` to `agent_env_vars`, **first in the dict**. The loop breaks on the first match and dicts keep insertion order, so position is the fix for the second problem: with `OTTO` ahead of `CLAUDECODE`, an Otto session started inside Claude Code reports `otto`, the nearer caller.

Companion changes: `astronomer/otto#379` sets `OTTO=1`; `astronomer/astro-cli#2234` and `astronomer/astro-cli-internal#81` do the same for the `astro` CLI. Until the Otto change ships this is inert.

## Testing

`test_detects_otto` and `test_otto_wins_over_inherited_marker`, plus `OTTO` added to the `clean_env` fixture so it cannot leak in from the environment running the suite. 45 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKSW26NfBtfq8hVeeLdfLj
---

## Update: also adds GitHub Copilot detection

Second commit on this branch. Copilot was missing from the same list, so anything run from Copilot arrived unlabelled too.

| Variable | Surface | Source |
|---|---|---|
| `COPILOT_CLI` | Copilot CLI — also the harness behind the cloud coding agent and, since 2026, Copilot for JetBrains | github's own `gh` keys on it: [`cli/cli` `internal/agents/detect.go`](https://github.com/cli/cli/blob/trunk/internal/agents/detect.go) |
| `COPILOT_AGENT` | VS Code agent mode terminals | [`microsoft/vscode` `toolTerminalCreator.ts`](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/toolTerminalCreator.ts), where it is commented as backward compatibility for this kind of detection |
| `AI_AGENT` | VS Code agent mode (`github_copilot_vscode_agent`), Copilot desktop app (`github_copilot_app_agent`) | [`microsoft/vscode` `aiAgentEnv.ts`](https://github.com/microsoft/vscode/blob/main/src/vs/platform/chat/common/aiAgentEnv.ts), which calls it a wire contract |

`AI_AGENT` is a different shape from everything else in the list: the **value** names the agent, not the variable. It is read after the list so a specific marker still decides, and only prefixes we recognise are mapped.

Values are deliberately not passed through, which is where this differs from `gh`. `gh` returns any value matching `^[a-zA-Z0-9_-]+$`. Some vendors put a version in theirs — Claude Code's is `claude-code_2-1-156_agent` — so passing values through would spread one agent across a new telemetry value on every release and make the column useless for grouping. A new vendor adopting the convention is a one-line addition.

### Two candidates dropped after checking the sources

`COPILOT_AGENT_SESSION_ID` is widely cited but appears in no Copilot CLI changelog entry through `1.0.76`, and `gh` does not read it. `COPILOT_CLI` covers the same surface with a first-party source behind it.

`VSCODE_AGENT` is named in the [VS Code 1.121 release notes](https://code.visualstudio.com/updates/v1_121) but does not exist in the source — only `VSCODE_AGENT_ZSH_FIXUPS` and `VSCODE_AGENT_HOST_*`. The release note is wrong and at least one other library has copied the error.

Also avoided: `COPILOT_MODEL`, `COPILOT_ALLOW_ALL`, `COPILOT_GITHUB_TOKEN`. Some detectors key on these, but they are user config the CLI *reads*, so anyone with `export COPILOT_MODEL=…` in a shell profile would be misdetected forever.

### Worth a follow-up, not in this PR

`CODEX_API_KEY` in the existing list has that same flaw — it is a key the user sets, not a marker Codex exports. `CODEX_THREAD_ID` or `CODEX_SANDBOX` are what Codex actually sets per execution, and are what `gh` reads.