### PR TITLE
Fix the Type checking job, which now fails on every Python PR

### DIFF
--- a/skills/analyzing-data/scripts/cli.py
+++ b/skills/analyzing-data/scripts/cli.py
@@ -9,6 +9,13 @@
 #     "python-dotenv>=1.0.0",
 #     "cryptography>=41.0.0",
 # ]
+#
+# [tool.ty.rules]
+# # Same reason as ty.toml: ty does not install dependencies, so the imports
+# # above never resolve. ty 0.0.62 started reading rules from PEP 723 metadata,
+# # and for a script that carries its own metadata this block wins over ty.toml,
+# # so the suppression has to be repeated here.
+# unresolved-import = "ignore"
 # ///
 """CLI for the analyzing-data skill.
 

--- a/skills/analyzing-data/scripts/ty.toml
+++ b/skills/analyzing-data/scripts/ty.toml
@@ -1,5 +1,10 @@
 # ty type checker configuration
 # https://docs.astral.sh/ty/
+#
+# These rules do not reach scripts that carry PEP 723 inline metadata. Since
+# ty 0.0.62 such a script is configured by its own metadata block instead, so
+# cli.py repeats the unresolved-import suppression in its header. Any new
+# inline-metadata script in this directory needs the same.
 
 [rules]
 # Ignore unresolved imports for third-party libraries


### PR DESCRIPTION
`Type checking` fails on `main` as it stands. Any PR touching Python in this repo hits it — [#249](https://github.com/astronomer/agents/pull/249) is how I found it. I reproduced it by running the job's own command against an untouched checkout of `origin/main`:

```
error[unresolved-import]: Cannot resolve imported module `click`
  --> cli.py:26:8
```

`main` reads green only because its last CI run was 2026-07-20, before the ty release that changed this.

## What broke

The job at `.github/workflows/ci.yml:85-96` runs `uvx ty check`, unpinned, so every run picks up the latest ty.

ty `0.0.62` (2026-07-21) shipped this, under Configuration:

> Respect `rules` and `analysis` in PEP 723 script metadata configurations

`cli.py` carries a PEP 723 inline metadata block. As of that release the block configures the file, and `ty.toml` no longer reaches it. The `unresolved-import = "ignore"` rule stopped applying and the `click` import surfaced as an error.

Bisected:

| ty | result |
|---|---|
| `0.0.61` | passes |
| `0.0.62` | fails ← behaviour change |
| `0.0.65` (what CI pulls today) | fails |

## What this does

Repeats the suppression in the script's own metadata, which is where ty now reads it from, plus a note in `ty.toml` so the next person understands the duplication.

The dependency is not actually missing — `cli.py` declares `click>=8.0.0` in its PEP 723 header and runs via `uv run cli.py`. ty does not install dependencies, which is the reason `ty.toml` suppressed the rule in the first place. This keeps that decision, it just states it where ty will now look.

`cli.py` is the only PEP 723 script in the checked directory, so it is the only file affected.

## Testing

`uvx ty check` passes on ty `0.0.65` and on `0.0.61`, so it works either side of the change. `uv run cli.py --help` still works, confirming the added block does not disturb PEP 723 execution.

## One thing for the owners to decide

I did not pin ty, because that is a policy call rather than part of the fix. Worth considering though: an unpinned tool in CI means an upstream release can turn `main` red without anyone touching the repo, which is exactly what happened. A pin would make the job reproducible at the cost of someone bumping it. Happy to add it if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKSW26NfBtfq8hVeeLdfLj